### PR TITLE
feat: Xcode project scaffold with app entry point (SIR-014)

### DIFF
--- a/app/SayItRight/App/ConfigProvider.swift
+++ b/app/SayItRight/App/ConfigProvider.swift
@@ -7,7 +7,7 @@ import Foundation
 /// can override the bundled API key at runtime (stored in Keychain).
 enum ConfigProvider {
 
-    private static let values: [String: Any] = {
+    nonisolated(unsafe) private static let values: [String: Any] = {
         guard let url = Bundle.main.url(forResource: "Config", withExtension: "plist"),
               let data = try? Data(contentsOf: url),
               let dict = try? PropertyListSerialization.propertyList(

--- a/app/SayItRight/App/SayItRightApp.swift
+++ b/app/SayItRight/App/SayItRightApp.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+
+@main
+struct SayItRightApp: App {
+    @State private var settings = AppSettings.shared
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .environment(settings)
+        }
+    }
+}
+
+struct ContentView: View {
+    @Environment(AppSettings.self) private var settings
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 24) {
+                Image("barbara-attentive")
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 120, height: 120)
+                    .clipShape(Circle())
+
+                Text("Hello, Barbara")
+                    .font(.largeTitle)
+                    .fontWeight(.bold)
+
+                Text("Say it right! / Sag's richtig!")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+            .padding()
+        }
+    }
+}
+
+#Preview {
+    ContentView()
+        .environment(AppSettings.shared)
+}

--- a/app/SayItRight/Presentation/Session/OnboardingView.swift
+++ b/app/SayItRight/Presentation/Session/OnboardingView.swift
@@ -49,7 +49,7 @@ struct OnboardingView: View {
         .padding()
         .background(
             LinearGradient(
-                colors: [Color(.systemBackground), Color.blue.opacity(0.05)],
+                colors: [Color.clear, Color.blue.opacity(0.05)],
                 startPoint: .top,
                 endPoint: .bottom
             )

--- a/app/SayItRight/Presentation/Session/PINEntryView.swift
+++ b/app/SayItRight/Presentation/Session/PINEntryView.swift
@@ -33,7 +33,9 @@ struct PINEntryView: View {
 
             // Hidden text field to capture keyboard input
             TextField("", text: $pin)
+                #if os(iOS)
                 .keyboardType(.numberPad)
+                #endif
                 .focused($isFocused)
                 .frame(width: 0, height: 0)
                 .opacity(0)

--- a/app/SayItRight/Presentation/Session/ParentSettingsView.swift
+++ b/app/SayItRight/Presentation/Session/ParentSettingsView.swift
@@ -257,11 +257,15 @@ struct ParentSettingsView: View {
             Form {
                 Section("New PIN") {
                     SecureField("4-digit PIN", text: $newPIN)
+                        #if os(iOS)
                         .keyboardType(.numberPad)
+                        #endif
                 }
                 Section("Confirm PIN") {
                     SecureField("Repeat PIN", text: $confirmPIN)
+                        #if os(iOS)
                         .keyboardType(.numberPad)
+                        #endif
                 }
                 if pinMismatch {
                     Text("PINs don't match")

--- a/app/SayItRight/State/Settings/ParentGate.swift
+++ b/app/SayItRight/State/Settings/ParentGate.swift
@@ -6,6 +6,7 @@ import SwiftUI
 /// Parent settings (API key, model, debug mode) are behind this gate.
 /// The gate is unlocked for the duration of the settings session;
 /// navigating away re-locks it.
+@MainActor
 @Observable
 final class ParentGate {
 


### PR DESCRIPTION
## Summary
- Add `@main` SwiftUI app entry point (`SayItRightApp.swift`)
- Fix Swift 6 strict concurrency issues across existing files
- Fix cross-platform compatibility (iOS + macOS both build)
- XcodeGen project.yml already existed with full 4-layer folder structure

Closes #14

## Test plan
- [x] `xcodegen generate` succeeds
- [x] iOS build succeeds (iPhone 17 Simulator)
- [x] macOS build succeeds
- [x] App shows "Hello, Barbara" placeholder with avatar

🤖 Generated with [Claude Code](https://claude.com/claude-code)