### PR TITLE
feat: language settings UI (SIR-021)

### DIFF
--- a/app/SayItRight/Presentation/Session/SettingsView.swift
+++ b/app/SayItRight/Presentation/Session/SettingsView.swift
@@ -1,0 +1,48 @@
+import SwiftUI
+
+struct SettingsView: View {
+    @Environment(AppSettings.self) private var settings
+
+    var body: some View {
+        @Bindable var settings = settings
+
+        NavigationStack {
+            Form {
+                Section("Language / Sprache") {
+                    Picker("Content Language", selection: $settings.language) {
+                        ForEach(AppLanguage.allCases, id: \.rawValue) { lang in
+                            Text("\(lang.flag) \(lang.displayName)")
+                                .tag(lang.rawValue)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+
+                    Text(settings.language == "de"
+                         ? "Barbara spricht Deutsch mit dir."
+                         : "Barbara speaks English with you.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Section("Display Name") {
+                    TextField("Your name", text: $settings.displayName)
+                }
+            }
+            .navigationTitle("Settings")
+        }
+    }
+}
+
+#Preview("English") {
+    let settings = AppSettings.shared
+    SettingsView()
+        .environment(settings)
+        .onAppear { settings.language = "en" }
+}
+
+#Preview("German") {
+    let settings = AppSettings.shared
+    SettingsView()
+        .environment(settings)
+        .onAppear { settings.language = "de" }
+}

--- a/app/SayItRight/State/Settings/AppLanguage.swift
+++ b/app/SayItRight/State/Settings/AppLanguage.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// Content language for Barbara's coaching sessions.
+///
+/// This controls which prompt blocks, practice texts, and topics are loaded.
+/// It is NOT iOS localization — the app chrome stays in English.
+enum AppLanguage: String, CaseIterable, Sendable {
+    case en
+    case de
+
+    var displayName: String {
+        switch self {
+        case .en: "English"
+        case .de: "Deutsch"
+        }
+    }
+
+    var flag: String {
+        switch self {
+        case .en: "🇬🇧"
+        case .de: "🇩🇪"
+        }
+    }
+
+    /// Default language based on device locale.
+    static var deviceDefault: AppLanguage {
+        let preferred = Locale.preferredLanguages.first ?? "en"
+        return preferred.hasPrefix("de") ? .de : .en
+    }
+}


### PR DESCRIPTION
## Summary
- `AppLanguage` enum with en/de, display names, device default detection
- `SettingsView` with segmented language picker
- SwiftUI previews for both languages

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)