### PR TITLE
feat: ResponseParser for hidden metadata (SIR-018)

### DIFF
--- a/app/SayItRight/Intelligence/ResponseParser/ResponseParser.swift
+++ b/app/SayItRight/Intelligence/ResponseParser/ResponseParser.swift
@@ -1,0 +1,115 @@
+import Foundation
+
+/// Parsed result from Barbara's response.
+struct ParsedResponse {
+    let visibleText: String
+    let metadata: BarbaraMetadata?
+}
+
+/// Hidden metadata appended to every Barbara response.
+///
+/// Barbara's system prompt instructs her to end each reply with
+/// `<!-- BARBARA_META: { … } -->`. This struct captures that JSON payload.
+struct BarbaraMetadata: Codable, Sendable {
+    let scores: [String: Int]
+    let totalScore: Int
+    let mood: BarbaraMood
+    let progressionSignal: ProgressionSignal
+    let revisionRound: Int
+    let sessionPhase: SessionPhase
+    let feedbackFocus: String
+    let language: String
+}
+
+// MARK: - Supporting Enums
+
+/// Signal indicating the learner's trajectory within the current level.
+enum ProgressionSignal: String, Codable, Sendable {
+    case none
+    case improving
+    case struggling
+    case readyForLevelUp = "ready_for_level_up"
+    case regression
+}
+
+/// Phase of a coaching session, used to adapt Barbara's behaviour.
+enum SessionPhase: String, Codable, Sendable {
+    case greeting
+    case topicPresentation = "topic_presentation"
+    case evaluation
+    case revision
+    case summary
+    case closing
+}
+
+// NOTE: `BarbaraMood` is defined in Presentation/Chat/BarbaraMood.swift
+// and shared across the single app target. It provides the 8 mood cases:
+// attentive, skeptical, approving, waiting, proud, evaluating, teaching, disappointed.
+
+// MARK: - ResponseParser
+
+/// Parses Barbara's response into visible text and hidden metadata.
+///
+/// Barbara ends every reply with an HTML comment containing structured
+/// evaluation data:
+/// ```
+/// <!-- BARBARA_META: {"scores":{"clarity":3}, …} -->
+/// ```
+/// `ResponseParser` strips that block from the user-visible text and
+/// decodes its JSON payload into a `BarbaraMetadata` value.
+struct ResponseParser {
+
+    /// Parse a complete response from Barbara.
+    ///
+    /// - Parameter fullResponse: The raw text returned by the LLM,
+    ///   potentially containing one or more `BARBARA_META` blocks.
+    /// - Returns: A `ParsedResponse` with clean visible text and,
+    ///   if present and valid, the decoded metadata from the *last* block.
+    func parse(fullResponse: String) -> ParsedResponse {
+        // Pattern: <!-- BARBARA_META: {...} -->
+        let pattern = #"<!--\s*BARBARA_META:\s*(.*?)\s*-->"#
+
+        guard let regex = try? NSRegularExpression(
+            pattern: pattern,
+            options: [.dotMatchesLineSeparators]
+        ) else {
+            return ParsedResponse(visibleText: fullResponse, metadata: nil)
+        }
+
+        let nsString = fullResponse as NSString
+        let matches = regex.matches(
+            in: fullResponse,
+            range: NSRange(location: 0, length: nsString.length)
+        )
+
+        guard let lastMatch = matches.last else {
+            return ParsedResponse(
+                visibleText: fullResponse.trimmingCharacters(in: .whitespacesAndNewlines),
+                metadata: nil
+            )
+        }
+
+        // Extract JSON from the last metadata block.
+        let jsonRange = lastMatch.range(at: 1)
+        let jsonString = nsString.substring(with: jsonRange)
+
+        // Remove all metadata blocks from visible text.
+        var visibleText = fullResponse
+        for match in matches.reversed() {
+            let fullRange = Range(match.range, in: fullResponse)!
+            visibleText.removeSubrange(fullRange)
+        }
+        visibleText = visibleText.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        // Decode JSON payload.
+        let metadata: BarbaraMetadata?
+        if let data = jsonString.data(using: .utf8) {
+            let decoder = JSONDecoder()
+            metadata = try? decoder.decode(BarbaraMetadata.self, from: data)
+        } else {
+            metadata = nil
+        }
+
+        return ParsedResponse(visibleText: visibleText, metadata: metadata)
+    }
+}

--- a/app/SayItRight/Tests/ResponseParserTests.swift
+++ b/app/SayItRight/Tests/ResponseParserTests.swift
@@ -1,0 +1,126 @@
+import XCTest
+@testable import SayItRight
+
+final class ResponseParserTests: XCTestCase {
+
+    private let parser = ResponseParser()
+
+    // MARK: - Helpers
+
+    /// Builds a valid BARBARA_META comment block from individual fields.
+    private func metaBlock(
+        scores: [String: Int] = ["clarity": 3, "structure": 4],
+        totalScore: Int = 7,
+        mood: String = "approving",
+        progressionSignal: String = "improving",
+        revisionRound: Int = 1,
+        sessionPhase: String = "evaluation",
+        feedbackFocus: String = "Lead with your conclusion.",
+        language: String = "en"
+    ) -> String {
+        """
+        <!-- BARBARA_META: {"scores":{"clarity":\(scores["clarity"]!),"structure":\(scores["structure"]!)},"totalScore":\(totalScore),"mood":"\(mood)","progressionSignal":"\(progressionSignal)","revisionRound":\(revisionRound),"sessionPhase":"\(sessionPhase)","feedbackFocus":"\(feedbackFocus)","language":"\(language)"} -->
+        """
+    }
+
+    // MARK: - 1. Clean extraction of visible text and valid metadata
+
+    func testCleanExtraction() {
+        let visiblePart = "Good structure! Your conclusion leads clearly."
+        let fullResponse = "\(visiblePart)\n\n\(metaBlock())"
+
+        let result = parser.parse(fullResponse: fullResponse)
+
+        XCTAssertEqual(result.visibleText, visiblePart)
+        XCTAssertNotNil(result.metadata)
+
+        let meta = result.metadata!
+        XCTAssertEqual(meta.scores["clarity"], 3)
+        XCTAssertEqual(meta.scores["structure"], 4)
+        XCTAssertEqual(meta.totalScore, 7)
+        XCTAssertEqual(meta.mood, .approving)
+        XCTAssertEqual(meta.progressionSignal, .improving)
+        XCTAssertEqual(meta.revisionRound, 1)
+        XCTAssertEqual(meta.sessionPhase, .evaluation)
+        XCTAssertEqual(meta.feedbackFocus, "Lead with your conclusion.")
+        XCTAssertEqual(meta.language, "en")
+    }
+
+    // MARK: - 2. Missing metadata block
+
+    func testMissingMetadataBlock() {
+        let plainText = "That's not a conclusion, that's a preamble. Start over."
+
+        let result = parser.parse(fullResponse: plainText)
+
+        XCTAssertEqual(result.visibleText, plainText)
+        XCTAssertNil(result.metadata)
+    }
+
+    // MARK: - 3. Malformed JSON
+
+    func testMalformedJSON() {
+        let fullResponse = "Nice try.\n\n<!-- BARBARA_META: {not valid json} -->"
+
+        let result = parser.parse(fullResponse: fullResponse)
+
+        XCTAssertEqual(result.visibleText, "Nice try.")
+        XCTAssertNil(result.metadata)
+    }
+
+    // MARK: - 4. Multiple metadata blocks (uses last one)
+
+    func testMultipleMetadataBlocksUsesLast() {
+        let firstBlock = metaBlock(totalScore: 3, mood: "skeptical")
+        let secondBlock = metaBlock(totalScore: 8, mood: "proud")
+        let fullResponse = "First reply.\n\n\(firstBlock)\n\nSecond reply.\n\n\(secondBlock)"
+
+        let result = parser.parse(fullResponse: fullResponse)
+
+        // Both blocks stripped from visible text
+        XCTAssertFalse(result.visibleText.contains("BARBARA_META"))
+        XCTAssertTrue(result.visibleText.contains("First reply."))
+        XCTAssertTrue(result.visibleText.contains("Second reply."))
+
+        // Metadata comes from the last block
+        XCTAssertNotNil(result.metadata)
+        XCTAssertEqual(result.metadata!.totalScore, 8)
+        XCTAssertEqual(result.metadata!.mood, .proud)
+    }
+
+    // MARK: - 5. Metadata in middle of text
+
+    func testMetadataInMiddleOfText() {
+        let fullResponse = "Before the block.\n\n\(metaBlock())\n\nAfter the block."
+
+        let result = parser.parse(fullResponse: fullResponse)
+
+        XCTAssertFalse(result.visibleText.contains("BARBARA_META"))
+        XCTAssertTrue(result.visibleText.contains("Before the block."))
+        XCTAssertTrue(result.visibleText.contains("After the block."))
+        XCTAssertNotNil(result.metadata)
+        XCTAssertEqual(result.metadata!.mood, .approving)
+    }
+
+    // MARK: - Edge cases
+
+    func testEmptyInput() {
+        let result = parser.parse(fullResponse: "")
+        XCTAssertEqual(result.visibleText, "")
+        XCTAssertNil(result.metadata)
+    }
+
+    func testWhitespaceOnlyInput() {
+        let result = parser.parse(fullResponse: "   \n\n  ")
+        XCTAssertEqual(result.visibleText, "")
+        XCTAssertNil(result.metadata)
+    }
+
+    func testMetadataBlockOnly() {
+        let fullResponse = metaBlock()
+        let result = parser.parse(fullResponse: fullResponse)
+
+        XCTAssertEqual(result.visibleText, "")
+        XCTAssertNotNil(result.metadata)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `ResponseParser` struct that extracts visible text and hidden `BarbaraMetadata` from LLM responses containing `<!-- BARBARA_META: {...} -->` blocks
- Defines `BarbaraMetadata`, `ProgressionSignal`, and `SessionPhase` types; reuses existing `BarbaraMood` enum from Presentation layer
- Adds unit tests covering clean extraction, missing metadata, malformed JSON, multiple blocks, and mid-text metadata

## Test plan
- [ ] `ResponseParserTests` — 8 test cases covering all specified scenarios plus edge cases
- [ ] Verify `BarbaraMood` cases align with existing `Presentation/Chat/BarbaraMood.swift`
- [ ] Confirm no circular dependency between Intelligence and Presentation layers

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)