### PR TITLE
feat: LearnerProfile schema and persistence (SIR-033)

### DIFF
--- a/app/SayItRight/State/LearnerProfile/LearnerProfile.swift
+++ b/app/SayItRight/State/LearnerProfile/LearnerProfile.swift
@@ -1,0 +1,111 @@
+import Foundation
+
+/// The learner's structural thinking profile — drives Barbara's coaching behavior.
+struct LearnerProfile: Codable, Sendable {
+    var schemaVersion: Int = 1
+    var id: String
+    var displayName: String
+    var currentLevel: Int
+    var language: String
+    var structuralStrengths: [String]
+    var developmentAreas: [String]
+    var sessionCount: Int
+    var currentStreak: Int
+    var longestStreak: Int
+    var lastSessionDate: Date?
+    var levelHistory: [LevelTransition]
+    var dimensionScores: [String: [Int]]
+
+    struct LevelTransition: Codable, Sendable {
+        let fromLevel: Int
+        let toLevel: Int
+        let date: Date
+    }
+
+    /// Create a new default profile for first launch.
+    static func createDefault(displayName: String = "", language: String = "en") -> LearnerProfile {
+        LearnerProfile(
+            id: UUID().uuidString,
+            displayName: displayName,
+            currentLevel: 1,
+            language: language,
+            structuralStrengths: [],
+            developmentAreas: ["governing_thought", "lead_position", "clarity"],
+            sessionCount: 0,
+            currentStreak: 0,
+            longestStreak: 0,
+            lastSessionDate: nil,
+            levelHistory: [],
+            dimensionScores: [:]
+        )
+    }
+
+    /// Rolling average for a dimension (last 10 scores).
+    func rollingAverage(for dimension: String) -> Double? {
+        guard let scores = dimensionScores[dimension], !scores.isEmpty else { return nil }
+        let recent = scores.suffix(10)
+        return Double(recent.reduce(0, +)) / Double(recent.count)
+    }
+
+    /// Record a new score for a dimension (keeps last 10).
+    mutating func recordScore(_ score: Int, for dimension: String) {
+        var scores = dimensionScores[dimension] ?? []
+        scores.append(score)
+        if scores.count > 10 {
+            scores = Array(scores.suffix(10))
+        }
+        dimensionScores[dimension] = scores
+    }
+
+    /// Update streak based on current date.
+    mutating func updateStreak(now: Date = .now) {
+        let calendar = Calendar.current
+        if let lastDate = lastSessionDate {
+            let daysSince = calendar.dateComponents([.day], from: lastDate, to: now).day ?? 0
+            if daysSince <= 1 {
+                currentStreak += 1
+            } else {
+                currentStreak = 1
+            }
+        } else {
+            currentStreak = 1
+        }
+        longestStreak = max(longestStreak, currentStreak)
+        lastSessionDate = now
+    }
+
+    /// JSON representation for system prompt injection.
+    func toPromptJSON() -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        guard let data = try? encoder.encode(PromptProfile(from: self)),
+              let json = String(data: data, encoding: .utf8) else {
+            return "{}"
+        }
+        return json
+    }
+}
+
+/// Simplified profile for prompt injection (excludes internal tracking data).
+private struct PromptProfile: Codable {
+    let displayName: String
+    let currentLevel: Int
+    let strengths: [String]
+    let developmentAreas: [String]
+    let sessionsCompleted: Int
+    let streakDays: Int
+    let recentScores: [String: [Int]]
+    let notes: String
+
+    init(from profile: LearnerProfile) {
+        displayName = profile.displayName
+        currentLevel = profile.currentLevel
+        strengths = profile.structuralStrengths
+        developmentAreas = profile.developmentAreas
+        sessionsCompleted = profile.sessionCount
+        streakDays = profile.currentStreak
+        recentScores = profile.dimensionScores
+        notes = ""
+    }
+}

--- a/app/SayItRight/State/LearnerProfile/LearnerProfileStore.swift
+++ b/app/SayItRight/State/LearnerProfile/LearnerProfileStore.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// Thread-safe persistence layer for the learner profile.
+actor LearnerProfileStore {
+    private let fileURL: URL
+    private var profile: LearnerProfile
+
+    init(directory: URL? = nil) async {
+        let dir = directory ?? FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+        self.fileURL = dir.appendingPathComponent("learner-profile.json")
+
+        if let data = try? Data(contentsOf: fileURL),
+           let loaded = try? JSONDecoder.iso8601.decode(LearnerProfile.self, from: data) {
+            self.profile = loaded
+        } else {
+            self.profile = LearnerProfile.createDefault()
+        }
+    }
+
+    var current: LearnerProfile { profile }
+
+    func update(_ transform: (inout LearnerProfile) -> Void) async throws {
+        transform(&profile)
+        try await save()
+    }
+
+    func save() async throws {
+        let data = try JSONEncoder.iso8601.encode(profile)
+        let tempURL = fileURL.deletingLastPathComponent()
+            .appendingPathComponent(UUID().uuidString + ".tmp")
+        try data.write(to: tempURL, options: .atomic)
+        _ = try FileManager.default.replaceItemAt(fileURL, withItemAt: tempURL)
+    }
+
+    func reset() async throws {
+        profile = LearnerProfile.createDefault()
+        try await save()
+    }
+}
+
+private extension JSONEncoder {
+    static let iso8601: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        return encoder
+    }()
+}
+
+private extension JSONDecoder {
+    static let iso8601: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }()
+}

--- a/app/SayItRight/Tests/LearnerProfileTests.swift
+++ b/app/SayItRight/Tests/LearnerProfileTests.swift
@@ -1,0 +1,146 @@
+import Testing
+import Foundation
+@testable import SayItRight
+
+@Suite("LearnerProfile")
+struct LearnerProfileTests {
+
+    @Test func createDefault() {
+        let profile = LearnerProfile.createDefault(displayName: "Test", language: "de")
+        #expect(profile.currentLevel == 1)
+        #expect(profile.displayName == "Test")
+        #expect(profile.language == "de")
+        #expect(profile.sessionCount == 0)
+        #expect(profile.currentStreak == 0)
+        #expect(profile.developmentAreas.contains("governing_thought"))
+        #expect(profile.structuralStrengths.isEmpty)
+        #expect(profile.dimensionScores.isEmpty)
+    }
+
+    @Test func recordScoreKeepsLast10() {
+        var profile = LearnerProfile.createDefault()
+        for i in 1...15 {
+            profile.recordScore(i, for: "clarity")
+        }
+        let scores = profile.dimensionScores["clarity"]!
+        #expect(scores.count == 10)
+        #expect(scores.first == 6)
+        #expect(scores.last == 15)
+    }
+
+    @Test func rollingAverage() {
+        var profile = LearnerProfile.createDefault()
+        profile.recordScore(4, for: "grouping_mece")
+        profile.recordScore(6, for: "grouping_mece")
+        let avg = profile.rollingAverage(for: "grouping_mece")
+        #expect(avg == 5.0)
+    }
+
+    @Test func rollingAverageNilForMissing() {
+        let profile = LearnerProfile.createDefault()
+        #expect(profile.rollingAverage(for: "nonexistent") == nil)
+    }
+
+    @Test func updateStreakFirstSession() {
+        var profile = LearnerProfile.createDefault()
+        profile.updateStreak()
+        #expect(profile.currentStreak == 1)
+        #expect(profile.longestStreak == 1)
+        #expect(profile.lastSessionDate != nil)
+    }
+
+    @Test func updateStreakConsecutiveDays() {
+        var profile = LearnerProfile.createDefault()
+        let yesterday = Calendar.current.date(byAdding: .hour, value: -20, to: .now)!
+        profile.updateStreak(now: yesterday)
+        #expect(profile.currentStreak == 1)
+        profile.updateStreak(now: .now)
+        #expect(profile.currentStreak == 2)
+        #expect(profile.longestStreak == 2)
+    }
+
+    @Test func updateStreakResetsAfterGap() {
+        var profile = LearnerProfile.createDefault()
+        let threeDaysAgo = Calendar.current.date(byAdding: .day, value: -3, to: .now)!
+        profile.updateStreak(now: threeDaysAgo)
+        #expect(profile.currentStreak == 1)
+        profile.updateStreak(now: .now)
+        #expect(profile.currentStreak == 1)
+        #expect(profile.longestStreak == 1)
+    }
+
+    @Test func toPromptJSONExcludesInternalFields() throws {
+        let profile = LearnerProfile.createDefault(displayName: "Alice", language: "en")
+        let json = profile.toPromptJSON()
+        #expect(json.contains("Alice"))
+        #expect(json.contains("currentLevel"))
+        #expect(!json.contains("schemaVersion"))
+        #expect(!json.contains("levelHistory"))
+    }
+
+    @Test func codableRoundTrip() throws {
+        var profile = LearnerProfile.createDefault(displayName: "Bob", language: "de")
+        profile.recordScore(7, for: "lead_position")
+        profile.updateStreak()
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(profile)
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(LearnerProfile.self, from: data)
+
+        #expect(decoded.displayName == "Bob")
+        #expect(decoded.language == "de")
+        #expect(decoded.dimensionScores["lead_position"] == [7])
+        #expect(decoded.currentStreak == 1)
+    }
+}
+
+@Suite("LearnerProfileStore")
+struct LearnerProfileStoreTests {
+
+    @Test func createAndLoad() async throws {
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let store = await LearnerProfileStore(directory: tmpDir)
+        let profile = await store.current
+        #expect(profile.currentLevel == 1)
+        #expect(profile.sessionCount == 0)
+    }
+
+    @Test func saveAndReload() async throws {
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let store1 = await LearnerProfileStore(directory: tmpDir)
+        try await store1.update { profile in
+            profile.displayName = "Saved"
+            profile.recordScore(8, for: "clarity")
+        }
+
+        let store2 = await LearnerProfileStore(directory: tmpDir)
+        let reloaded = await store2.current
+        #expect(reloaded.displayName == "Saved")
+        #expect(reloaded.dimensionScores["clarity"] == [8])
+    }
+
+    @Test func reset() async throws {
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let store = await LearnerProfileStore(directory: tmpDir)
+        try await store.update { $0.displayName = "Modified" }
+        try await store.reset()
+        let profile = await store.current
+        #expect(profile.displayName == "")
+    }
+}

--- a/app/SayItRight/project.yml
+++ b/app/SayItRight/project.yml
@@ -18,6 +18,7 @@ targets:
           - project.yml
           - ExportOptions.plist
           - build/
+          - Tests/
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: io.mattern.say-it-right
@@ -40,3 +41,17 @@ targets:
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         ENABLE_PREVIEWS: true
         SUPPORTS_MACCATALYST: false
+
+  SayItRightTests:
+    type: bundle.unit-test
+    platform: [iOS, macOS]
+    sources:
+      - path: Tests
+        excludes:
+          - "**/.DS_Store"
+    dependencies:
+      - target: SayItRight_${platform}
+    settings:
+      base:
+        SWIFT_VERSION: "6.0"
+        GENERATE_INFOPLIST_FILE: true


### PR DESCRIPTION
## Summary
- LearnerProfile Codable struct with schema versioning, rolling dimension scores, streak tracking
- LearnerProfileStore actor for atomic JSON persistence to Documents directory
- 12 unit tests covering all CRUD operations, streak logic, and codable round-trips
- Test target added to XcodeGen project.yml

Closes #33