### PR TITLE
feat: AnthropicService for streaming API communication (SIR-016)

### DIFF
--- a/app/SayItRight/Intelligence/ConversationManager/AnthropicService.swift
+++ b/app/SayItRight/Intelligence/ConversationManager/AnthropicService.swift
@@ -1,0 +1,317 @@
+import Foundation
+
+// MARK: - Data Types
+
+/// A single message in the Anthropic Messages API conversation format.
+struct ChatMessage: Codable, Sendable {
+    let role: String
+    let content: String
+}
+
+// MARK: - Errors
+
+/// Errors that can occur when communicating with the Anthropic API.
+enum AnthropicServiceError: Error, LocalizedError, Sendable {
+    case missingAPIKey
+    case invalidURL
+    case invalidAPIKey
+    case rateLimited(retryAfter: String?)
+    case serverError(statusCode: Int, message: String)
+    case networkTimeout
+    case unexpectedResponse(statusCode: Int)
+    case decodingError(String)
+    case streamingError(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .missingAPIKey:
+            "No API key configured. Add one in parent settings."
+        case .invalidURL:
+            "Invalid API endpoint URL."
+        case .invalidAPIKey:
+            "Invalid API key. Check your key in parent settings."
+        case .rateLimited(let retryAfter):
+            if let retry = retryAfter {
+                "Rate limited. Try again in \(retry) seconds."
+            } else {
+                "Rate limited. Please wait before trying again."
+            }
+        case .serverError(let code, let message):
+            "Server error (\(code)): \(message)"
+        case .networkTimeout:
+            "Network request timed out. Check your connection."
+        case .unexpectedResponse(let code):
+            "Unexpected response (HTTP \(code))."
+        case .decodingError(let detail):
+            "Failed to decode response: \(detail)"
+        case .streamingError(let detail):
+            "Streaming error: \(detail)"
+        }
+    }
+}
+
+// MARK: - SSE Event Types
+
+/// Parsed SSE event from the Anthropic streaming API.
+enum SSEEvent: Sendable {
+    case messageStart
+    case contentBlockStart
+    case contentBlockDelta(text: String)
+    case contentBlockStop
+    case messageStop
+    case messageDelta
+    case ping
+    case error(String)
+    case unknown(type: String)
+}
+
+// MARK: - SSE Parser
+
+/// Parses Server-Sent Events (SSE) lines into structured events.
+///
+/// The Anthropic streaming API sends events in SSE format:
+/// ```
+/// event: content_block_delta
+/// data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}
+/// ```
+struct SSEParser: Sendable {
+
+    /// Parse a single SSE data line (the JSON after `data: `).
+    ///
+    /// - Parameter dataLine: The raw JSON string from an SSE `data:` field.
+    /// - Returns: The parsed event, or nil if the line is empty or `[DONE]`.
+    func parse(dataLine: String) -> SSEEvent? {
+        let trimmed = dataLine.trimmingCharacters(in: .whitespaces)
+
+        if trimmed.isEmpty || trimmed == "[DONE]" {
+            return nil
+        }
+
+        guard let data = trimmed.data(using: .utf8) else {
+            return .error("Invalid UTF-8 in SSE data")
+        }
+
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let type = json["type"] as? String else {
+            return .error("Failed to parse SSE JSON")
+        }
+
+        switch type {
+        case "message_start":
+            return .messageStart
+        case "content_block_start":
+            return .contentBlockStart
+        case "content_block_delta":
+            if let delta = json["delta"] as? [String: Any],
+               let text = delta["text"] as? String {
+                return .contentBlockDelta(text: text)
+            }
+            return .contentBlockDelta(text: "")
+        case "content_block_stop":
+            return .contentBlockStop
+        case "message_stop":
+            return .messageStop
+        case "message_delta":
+            return .messageDelta
+        case "ping":
+            return .ping
+        case "error":
+            let errorMsg = (json["error"] as? [String: Any])?["message"] as? String
+                ?? "Unknown streaming error"
+            return .error(errorMsg)
+        default:
+            return .unknown(type: type)
+        }
+    }
+}
+
+// MARK: - AnthropicService
+
+/// Communicates with the Anthropic Messages API using streaming SSE responses.
+///
+/// Retrieves the API key from `KeychainService` (override) or `ConfigProvider`
+/// (bundled fallback). Sends conversation history with the assembled system
+/// prompt and returns an `AsyncThrowingStream` of text deltas for progressive
+/// display.
+actor AnthropicService {
+
+    static let shared = AnthropicService()
+
+    // MARK: - Configuration
+
+    private let apiEndpoint = "https://api.anthropic.com/v1/messages"
+    private let anthropicVersion = "2023-06-01"
+    private let maxTokens = 1024
+    private let requestTimeout: TimeInterval = 60
+
+    let sseParser = SSEParser()
+
+    // MARK: - Public API
+
+    /// Send a message to the Anthropic API and stream back the response.
+    ///
+    /// - Parameters:
+    ///   - systemPrompt: The assembled system prompt (from `SystemPromptAssembler`).
+    ///   - messages: The conversation history as an array of `ChatMessage`.
+    ///   - model: Optional model ID override. Defaults to `ModelCatalog.defaultModelID`.
+    /// - Returns: An `AsyncThrowingStream` yielding text chunks as they arrive.
+    func sendMessage(
+        systemPrompt: String,
+        messages: [ChatMessage],
+        model: String? = nil
+    ) -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { continuation in
+            let task = Task {
+                do {
+                    let apiKey = try await resolveAPIKey()
+                    let request = try buildRequest(
+                        apiKey: apiKey,
+                        systemPrompt: systemPrompt,
+                        messages: messages,
+                        model: model ?? ModelCatalog.defaultModelID
+                    )
+                    try await streamResponse(request: request, continuation: continuation)
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+            continuation.onTermination = { _ in
+                task.cancel()
+            }
+        }
+    }
+
+    // MARK: - Private: API Key Resolution
+
+    /// Resolve the API key: Keychain override first, then Config.plist fallback.
+    private func resolveAPIKey() async throws -> String {
+        // 1. Check Keychain override (set in parent settings)
+        if let keychainKey = await KeychainService.shared.retrieveAPIKey() {
+            return keychainKey
+        }
+
+        // 2. Fall back to bundled Config.plist
+        if let configKey = ConfigProvider.anthropicAPIKey {
+            return configKey
+        }
+
+        throw AnthropicServiceError.missingAPIKey
+    }
+
+    // MARK: - Private: Request Building
+
+    private func buildRequest(
+        apiKey: String,
+        systemPrompt: String,
+        messages: [ChatMessage],
+        model: String
+    ) throws -> URLRequest {
+        guard let url = URL(string: apiEndpoint) else {
+            throw AnthropicServiceError.invalidURL
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.timeoutInterval = requestTimeout
+
+        // Required headers per Anthropic API docs
+        request.setValue(apiKey, forHTTPHeaderField: "x-api-key")
+        request.setValue(anthropicVersion, forHTTPHeaderField: "anthropic-version")
+        request.setValue("application/json", forHTTPHeaderField: "content-type")
+
+        // Build request body
+        let body: [String: Any] = [
+            "model": model,
+            "max_tokens": maxTokens,
+            "stream": true,
+            "system": systemPrompt,
+            "messages": messages.map { ["role": $0.role, "content": $0.content] }
+        ]
+
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        return request
+    }
+
+    // MARK: - Private: Streaming
+
+    private func streamResponse(
+        request: URLRequest,
+        continuation: AsyncThrowingStream<String, Error>.Continuation
+    ) async throws {
+        let (bytes, response): (URLSession.AsyncBytes, URLResponse)
+        do {
+            (bytes, response) = try await URLSession.shared.bytes(for: request)
+        } catch let error as URLError where error.code == .timedOut {
+            throw AnthropicServiceError.networkTimeout
+        } catch let error as URLError where error.code == .notConnectedToInternet
+            || error.code == .networkConnectionLost {
+            throw AnthropicServiceError.networkTimeout
+        }
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw AnthropicServiceError.unexpectedResponse(statusCode: 0)
+        }
+
+        // Handle HTTP error status codes before reading the stream
+        try handleHTTPStatus(httpResponse, bytes: bytes)
+
+        // Parse SSE stream line by line
+        for try await line in bytes.lines {
+            if Task.isCancelled { break }
+
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+
+            // Skip SSE event-type lines and empty lines (event boundaries)
+            guard trimmed.hasPrefix("data:") else { continue }
+
+            let dataContent = String(trimmed.dropFirst(5)).trimmingCharacters(in: .whitespaces)
+
+            if let event = sseParser.parse(dataLine: dataContent) {
+                switch event {
+                case .contentBlockDelta(let text):
+                    if !text.isEmpty {
+                        continuation.yield(text)
+                    }
+                case .error(let message):
+                    continuation.finish(throwing: AnthropicServiceError.streamingError(message))
+                    return
+                case .messageStop:
+                    continuation.finish()
+                    return
+                case .messageStart, .contentBlockStart, .contentBlockStop,
+                     .messageDelta, .ping, .unknown:
+                    // These events don't produce text output
+                    break
+                }
+            }
+        }
+
+        // Stream ended without explicit message_stop
+        continuation.finish()
+    }
+
+    /// Check HTTP status and throw appropriate errors for non-200 responses.
+    private func handleHTTPStatus(
+        _ response: HTTPURLResponse,
+        bytes: URLSession.AsyncBytes
+    ) throws {
+        switch response.statusCode {
+        case 200:
+            return // Success — proceed to stream
+        case 401:
+            throw AnthropicServiceError.invalidAPIKey
+        case 429:
+            let retryAfter = response.value(forHTTPHeaderField: "retry-after")
+            throw AnthropicServiceError.rateLimited(retryAfter: retryAfter)
+        case 400...499:
+            throw AnthropicServiceError.unexpectedResponse(statusCode: response.statusCode)
+        case 500...599:
+            throw AnthropicServiceError.serverError(
+                statusCode: response.statusCode,
+                message: "Anthropic API server error"
+            )
+        default:
+            throw AnthropicServiceError.unexpectedResponse(statusCode: response.statusCode)
+        }
+    }
+}

--- a/app/SayItRight/Tests/AnthropicServiceTests.swift
+++ b/app/SayItRight/Tests/AnthropicServiceTests.swift
@@ -1,0 +1,281 @@
+import XCTest
+@testable import SayItRight
+
+final class AnthropicServiceTests: XCTestCase {
+
+    private let parser = SSEParser()
+
+    // MARK: - SSE Parser: content_block_delta
+
+    func testParseContentBlockDelta() {
+        let json = """
+        {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}
+        """
+        let event = parser.parse(dataLine: json)
+        guard case .contentBlockDelta(let text) = event else {
+            XCTFail("Expected contentBlockDelta, got \(String(describing: event))")
+            return
+        }
+        XCTAssertEqual(text, "Hello")
+    }
+
+    func testParseContentBlockDeltaWithSpecialCharacters() {
+        let json = """
+        {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Grüße! Das ist \\"gut\\"."}}
+        """
+        let event = parser.parse(dataLine: json)
+        guard case .contentBlockDelta(let text) = event else {
+            XCTFail("Expected contentBlockDelta, got \(String(describing: event))")
+            return
+        }
+        XCTAssertEqual(text, "Grüße! Das ist \"gut\".")
+    }
+
+    func testParseContentBlockDeltaEmptyText() {
+        let json = """
+        {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":""}}
+        """
+        let event = parser.parse(dataLine: json)
+        guard case .contentBlockDelta(let text) = event else {
+            XCTFail("Expected contentBlockDelta, got \(String(describing: event))")
+            return
+        }
+        XCTAssertEqual(text, "")
+    }
+
+    // MARK: - SSE Parser: message_start
+
+    func testParseMessageStart() {
+        let json = """
+        {"type":"message_start","message":{"id":"msg_123","type":"message","role":"assistant","content":[],"model":"claude-sonnet-4-5-20250514","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":25,"output_tokens":1}}}
+        """
+        let event = parser.parse(dataLine: json)
+        guard case .messageStart = event else {
+            XCTFail("Expected messageStart, got \(String(describing: event))")
+            return
+        }
+    }
+
+    // MARK: - SSE Parser: content_block_start
+
+    func testParseContentBlockStart() {
+        let json = """
+        {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+        """
+        let event = parser.parse(dataLine: json)
+        guard case .contentBlockStart = event else {
+            XCTFail("Expected contentBlockStart, got \(String(describing: event))")
+            return
+        }
+    }
+
+    // MARK: - SSE Parser: content_block_stop
+
+    func testParseContentBlockStop() {
+        let json = """
+        {"type":"content_block_stop","index":0}
+        """
+        let event = parser.parse(dataLine: json)
+        guard case .contentBlockStop = event else {
+            XCTFail("Expected contentBlockStop, got \(String(describing: event))")
+            return
+        }
+    }
+
+    // MARK: - SSE Parser: message_stop
+
+    func testParseMessageStop() {
+        let json = """
+        {"type":"message_stop"}
+        """
+        let event = parser.parse(dataLine: json)
+        guard case .messageStop = event else {
+            XCTFail("Expected messageStop, got \(String(describing: event))")
+            return
+        }
+    }
+
+    // MARK: - SSE Parser: message_delta
+
+    func testParseMessageDelta() {
+        let json = """
+        {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":15}}
+        """
+        let event = parser.parse(dataLine: json)
+        guard case .messageDelta = event else {
+            XCTFail("Expected messageDelta, got \(String(describing: event))")
+            return
+        }
+    }
+
+    // MARK: - SSE Parser: ping
+
+    func testParsePing() {
+        let json = """
+        {"type":"ping"}
+        """
+        let event = parser.parse(dataLine: json)
+        guard case .ping = event else {
+            XCTFail("Expected ping, got \(String(describing: event))")
+            return
+        }
+    }
+
+    // MARK: - SSE Parser: error event
+
+    func testParseErrorEvent() {
+        let json = """
+        {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}
+        """
+        let event = parser.parse(dataLine: json)
+        guard case .error(let message) = event else {
+            XCTFail("Expected error, got \(String(describing: event))")
+            return
+        }
+        XCTAssertEqual(message, "Overloaded")
+    }
+
+    func testParseErrorEventWithoutMessage() {
+        let json = """
+        {"type":"error","error":{"type":"overloaded_error"}}
+        """
+        let event = parser.parse(dataLine: json)
+        guard case .error(let message) = event else {
+            XCTFail("Expected error, got \(String(describing: event))")
+            return
+        }
+        XCTAssertEqual(message, "Unknown streaming error")
+    }
+
+    // MARK: - SSE Parser: unknown event type
+
+    func testParseUnknownEventType() {
+        let json = """
+        {"type":"some_future_event","data":{}}
+        """
+        let event = parser.parse(dataLine: json)
+        guard case .unknown(let type) = event else {
+            XCTFail("Expected unknown, got \(String(describing: event))")
+            return
+        }
+        XCTAssertEqual(type, "some_future_event")
+    }
+
+    // MARK: - SSE Parser: edge cases
+
+    func testParseEmptyLine() {
+        let event = parser.parse(dataLine: "")
+        XCTAssertNil(event)
+    }
+
+    func testParseDoneSentinel() {
+        let event = parser.parse(dataLine: "[DONE]")
+        XCTAssertNil(event)
+    }
+
+    func testParseInvalidJSON() {
+        let event = parser.parse(dataLine: "not json at all")
+        guard case .error = event else {
+            XCTFail("Expected error for invalid JSON, got \(String(describing: event))")
+            return
+        }
+    }
+
+    func testParseMissingTypeField() {
+        let json = """
+        {"data":"no type field"}
+        """
+        let event = parser.parse(dataLine: json)
+        guard case .error = event else {
+            XCTFail("Expected error for missing type, got \(String(describing: event))")
+            return
+        }
+    }
+
+    func testParseWhitespaceAroundData() {
+        let json = """
+          {"type":"message_stop"}
+        """
+        let event = parser.parse(dataLine: json)
+        guard case .messageStop = event else {
+            XCTFail("Expected messageStop, got \(String(describing: event))")
+            return
+        }
+    }
+
+    // MARK: - SSE Parser: full stream simulation
+
+    func testParseFullStreamSequence() {
+        // Simulate a realistic sequence of SSE data lines
+        let lines = [
+            """
+            {"type":"message_start","message":{"id":"msg_01","type":"message","role":"assistant","content":[],"model":"claude-sonnet-4-5-20250514","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":10,"output_tokens":1}}}
+            """,
+            """
+            {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+            """,
+            """
+            {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Das "}}
+            """,
+            """
+            {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ist "}}
+            """,
+            """
+            {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"klar."}}
+            """,
+            """
+            {"type":"content_block_stop","index":0}
+            """,
+            """
+            {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":5}}
+            """,
+            """
+            {"type":"message_stop"}
+            """
+        ]
+
+        var assembledText = ""
+        var eventCount = 0
+
+        for line in lines {
+            if let event = parser.parse(dataLine: line) {
+                eventCount += 1
+                if case .contentBlockDelta(let text) = event {
+                    assembledText += text
+                }
+            }
+        }
+
+        XCTAssertEqual(assembledText, "Das ist klar.")
+        XCTAssertEqual(eventCount, 8) // All events parsed
+    }
+
+    // MARK: - ChatMessage
+
+    func testChatMessageEncoding() throws {
+        let message = ChatMessage(role: "user", content: "Hello Barbara")
+        let data = try JSONEncoder().encode(message)
+        let decoded = try JSONDecoder().decode(ChatMessage.self, from: data)
+        XCTAssertEqual(decoded.role, "user")
+        XCTAssertEqual(decoded.content, "Hello Barbara")
+    }
+
+    // MARK: - AnthropicServiceError descriptions
+
+    func testErrorDescriptions() {
+        XCTAssertNotNil(AnthropicServiceError.missingAPIKey.errorDescription)
+        XCTAssertNotNil(AnthropicServiceError.invalidAPIKey.errorDescription)
+        XCTAssertNotNil(AnthropicServiceError.invalidURL.errorDescription)
+        XCTAssertNotNil(AnthropicServiceError.networkTimeout.errorDescription)
+        XCTAssertNotNil(AnthropicServiceError.rateLimited(retryAfter: "30").errorDescription)
+        XCTAssertNotNil(AnthropicServiceError.rateLimited(retryAfter: nil).errorDescription)
+        XCTAssertNotNil(AnthropicServiceError.serverError(statusCode: 500, message: "err").errorDescription)
+        XCTAssertNotNil(AnthropicServiceError.unexpectedResponse(statusCode: 418).errorDescription)
+        XCTAssertNotNil(AnthropicServiceError.decodingError("bad").errorDescription)
+        XCTAssertNotNil(AnthropicServiceError.streamingError("oops").errorDescription)
+
+        // Verify rate limit includes retry-after value
+        let rateLimitMsg = AnthropicServiceError.rateLimited(retryAfter: "30").errorDescription!
+        XCTAssertTrue(rateLimitMsg.contains("30"))
+    }
+}


### PR DESCRIPTION
## Summary
- Add `AnthropicService` actor with `sendMessage(systemPrompt:messages:) -> AsyncThrowingStream<String, Error>`
- SSE streaming parser handles all Anthropic event types (`message_start`, `content_block_delta`, `message_stop`, etc.)
- API key resolved from KeychainService override, then ConfigProvider fallback
- Structured error handling: invalid API key (401), rate limiting (429), network timeout, server errors
- 20 unit tests covering SSE parsing, edge cases, error descriptions, and full stream simulation

Closes #16

## Test plan
- [x] All 20 AnthropicServiceTests pass (SSE parsing, error handling, ChatMessage encoding)
- [x] Full stream simulation test verifies correct text assembly from realistic event sequence
- [x] Existing tests unaffected (28 XCTest + 18 Swift Testing all green)
- [x] macOS build succeeds with no warnings in new code