### PR TITLE
feat: add SpeechRecognitionService with protocol and mock (SIR-053)

### DIFF
--- a/app/SayItRight/App/SpeechRecognition/MockSpeechRecognitionService.swift
+++ b/app/SayItRight/App/SpeechRecognition/MockSpeechRecognitionService.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+/// Mock implementation of SpeechRecognitionServiceProtocol for testing and SwiftUI previews.
+///
+/// Configure the mock's behavior by setting properties before use:
+/// ```
+/// let mock = MockSpeechRecognitionService()
+/// mock.stubbedAuthorizationStatus = .denied
+/// // Now calls to startRecognition() will throw .permissionDenied
+/// ```
+final class MockSpeechRecognitionService: SpeechRecognitionServiceProtocol, @unchecked Sendable {
+
+    // MARK: - Stubbed values
+
+    var stubbedAuthorizationStatus: SpeechAuthorizationStatus = .authorized
+    var stubbedIsAvailable: Bool = true
+    var stubbedTranscriptions: [SpeechTranscription] = []
+    var stubbedError: SpeechRecognitionError?
+
+    // MARK: - Call tracking
+
+    private(set) var requestAuthorizationCallCount = 0
+    private(set) var startRecognitionCallCount = 0
+    private(set) var stopRecognitionCallCount = 0
+    private(set) var setLocaleCallCount = 0
+    private(set) var lastSetLocale: SpeechLocale?
+
+    // MARK: - Protocol
+
+    var authorizationStatus: SpeechAuthorizationStatus {
+        stubbedAuthorizationStatus
+    }
+
+    func requestAuthorization() async -> SpeechAuthorizationStatus {
+        requestAuthorizationCallCount += 1
+        return stubbedAuthorizationStatus
+    }
+
+    var isAvailable: Bool {
+        stubbedIsAvailable
+    }
+
+    func startRecognition() async throws -> AsyncStream<SpeechTranscription> {
+        startRecognitionCallCount += 1
+
+        if let error = stubbedError {
+            throw error
+        }
+
+        if stubbedAuthorizationStatus != .authorized {
+            throw SpeechRecognitionError.permissionDenied
+        }
+
+        if !stubbedIsAvailable {
+            throw SpeechRecognitionError.recognizerUnavailable
+        }
+
+        let transcriptions = stubbedTranscriptions
+        return AsyncStream { continuation in
+            for transcription in transcriptions {
+                continuation.yield(transcription)
+            }
+            continuation.finish()
+        }
+    }
+
+    func stopRecognition() {
+        stopRecognitionCallCount += 1
+    }
+
+    func setLocale(_ locale: SpeechLocale) {
+        setLocaleCallCount += 1
+        lastSetLocale = locale
+    }
+}

--- a/app/SayItRight/App/SpeechRecognition/SpeechRecognitionService.swift
+++ b/app/SayItRight/App/SpeechRecognition/SpeechRecognitionService.swift
@@ -1,0 +1,286 @@
+import Foundation
+#if canImport(Speech)
+import Speech
+#endif
+
+// MARK: - Protocol
+
+/// Errors that can occur during speech recognition.
+enum SpeechRecognitionError: Error, Sendable, Equatable {
+    case permissionDenied
+    case recognizerUnavailable
+    case noSpeechDetected
+    case recognitionFailed(String)
+    case audioEngineError(String)
+}
+
+/// Authorization status for speech recognition.
+enum SpeechAuthorizationStatus: Sendable {
+    case notDetermined
+    case denied
+    case restricted
+    case authorized
+}
+
+/// A partial transcription result from the recognizer.
+struct SpeechTranscription: Sendable {
+    /// The current best transcription text.
+    let text: String
+    /// Whether the recognizer considers this result final.
+    let isFinal: Bool
+    /// Confidence score (0.0-1.0), if available.
+    let confidence: Float?
+}
+
+/// Protocol for speech recognition, enabling testability via mock implementations.
+protocol SpeechRecognitionServiceProtocol: Sendable {
+    /// Current authorization status.
+    var authorizationStatus: SpeechAuthorizationStatus { get }
+
+    /// Request speech recognition authorization from the user.
+    /// Returns the resulting authorization status.
+    func requestAuthorization() async -> SpeechAuthorizationStatus
+
+    /// Whether the recognizer is currently available for the configured locale.
+    var isAvailable: Bool { get }
+
+    /// Start recognition and return an AsyncStream of partial results.
+    /// Throws if permissions are denied or the recognizer is unavailable.
+    func startRecognition() async throws -> AsyncStream<SpeechTranscription>
+
+    /// Stop the current recognition session.
+    func stopRecognition()
+
+    /// Update the recognition locale (e.g. when the learner switches language).
+    func setLocale(_ locale: SpeechLocale)
+}
+
+/// Supported speech recognition locales.
+enum SpeechLocale: String, Sendable {
+    case german = "de-DE"
+    case english = "en-US"
+
+    init(appLanguage: String) {
+        self = appLanguage == "de" ? .german : .english
+    }
+
+    var locale: Locale {
+        Locale(identifier: rawValue)
+    }
+}
+
+// MARK: - Live Implementation
+
+#if canImport(Speech)
+
+/// Live speech recognition service using SFSpeechRecognizer.
+///
+/// Placed in the App layer as a service object for dependency injection.
+/// Not owned by any view — injected via the DI container.
+///
+/// Thread safety is achieved via `os_unfair_lock` (through `NSLock`) for
+/// synchronous property access, while the async `startRecognition` method
+/// delegates to a nonisolated helper that sets up the recognition pipeline.
+final class LiveSpeechRecognitionService: SpeechRecognitionServiceProtocol, @unchecked Sendable {
+
+    // MARK: - State
+
+    /// Internal mutable state protected by the Mutex-like pattern below.
+    /// All reads/writes go through `withState`.
+    private struct State {
+        var locale: SpeechLocale
+        var recognizer: SFSpeechRecognizer?
+        var recognitionRequest: SFSpeechAudioBufferRecognitionRequest?
+        var recognitionTask: SFSpeechRecognitionTask?
+        var audioEngine: AVAudioEngine?
+        var isRecognizing: Bool = false
+    }
+
+    private let stateLock = NSLock()
+    private var state: State
+
+    // MARK: - Init
+
+    init(locale: SpeechLocale = .english) {
+        let recognizer = SFSpeechRecognizer(locale: locale.locale)
+        recognizer?.defaultTaskHint = .dictation
+        self.state = State(locale: locale, recognizer: recognizer)
+    }
+
+    // MARK: - Synchronized state access (non-async only)
+
+    private func withState<T>(_ body: (inout State) -> T) -> T {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return body(&state)
+    }
+
+    private func withStateThrowing<T>(_ body: (inout State) throws -> T) throws -> T {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return try body(&state)
+    }
+
+    // MARK: - Protocol
+
+    var authorizationStatus: SpeechAuthorizationStatus {
+        Self.mapStatus(SFSpeechRecognizer.authorizationStatus())
+    }
+
+    func requestAuthorization() async -> SpeechAuthorizationStatus {
+        await withCheckedContinuation { continuation in
+            SFSpeechRecognizer.requestAuthorization { status in
+                continuation.resume(returning: Self.mapStatus(status))
+            }
+        }
+    }
+
+    var isAvailable: Bool {
+        withState { $0.recognizer?.isAvailable ?? false }
+    }
+
+    func startRecognition() async throws -> AsyncStream<SpeechTranscription> {
+        // Pre-check authorization (this property access is synchronous)
+        let status = authorizationStatus
+        guard status == .authorized else {
+            throw SpeechRecognitionError.permissionDenied
+        }
+
+        // Prepare synchronously under the lock
+        let recognizer: SFSpeechRecognizer = try withStateThrowing { state in
+            guard let rec = state.recognizer, rec.isAvailable else {
+                throw SpeechRecognitionError.recognizerUnavailable
+            }
+            // Clean up any existing session
+            Self.cleanupState(&state)
+            return rec
+        }
+
+        let request = SFSpeechAudioBufferRecognitionRequest()
+        request.shouldReportPartialResults = true
+
+        if recognizer.supportsOnDeviceRecognition {
+            request.requiresOnDeviceRecognition = true
+        }
+
+        // Set up audio engine
+        let audioEngine = AVAudioEngine()
+        let inputNode = audioEngine.inputNode
+        let recordingFormat = inputNode.outputFormat(forBus: 0)
+
+        inputNode.installTap(onBus: 0, bufferSize: 1024, format: recordingFormat) { buffer, _ in
+            request.append(buffer)
+        }
+
+        do {
+            audioEngine.prepare()
+            try audioEngine.start()
+        } catch {
+            throw SpeechRecognitionError.audioEngineError(error.localizedDescription)
+        }
+
+        // Store references synchronously
+        withState { state in
+            state.recognitionRequest = request
+            state.audioEngine = audioEngine
+            state.isRecognizing = true
+        }
+
+        // Build and return the stream
+        return buildStream(recognizer: recognizer, request: request)
+    }
+
+    func stopRecognition() {
+        withState { state in
+            Self.cleanupState(&state)
+        }
+    }
+
+    func setLocale(_ locale: SpeechLocale) {
+        withState { state in
+            Self.cleanupState(&state)
+            state.locale = locale
+            let recognizer = SFSpeechRecognizer(locale: locale.locale)
+            recognizer?.defaultTaskHint = .dictation
+            state.recognizer = recognizer
+        }
+    }
+
+    // MARK: - Private
+
+    /// Build the AsyncStream that drives partial results to the caller.
+    /// This is nonisolated and synchronous — safe to call from async context.
+    private nonisolated func buildStream(
+        recognizer: SFSpeechRecognizer,
+        request: SFSpeechAudioBufferRecognitionRequest
+    ) -> AsyncStream<SpeechTranscription> {
+        AsyncStream { [weak self] continuation in
+            let task = recognizer.recognitionTask(with: request) { result, error in
+                if let result {
+                    let transcription = SpeechTranscription(
+                        text: result.bestTranscription.formattedString,
+                        isFinal: result.isFinal,
+                        confidence: result.bestTranscription.segments.last
+                            .map { Float($0.confidence) }
+                    )
+                    continuation.yield(transcription)
+
+                    if result.isFinal {
+                        self?.stopRecognition()
+                        continuation.finish()
+                    }
+                }
+
+                if let error {
+                    #if DEBUG
+                    let nsError = error as NSError
+                    print("[SpeechRecognition] Error: \(nsError.domain) \(nsError.code)")
+                    #endif
+                    self?.stopRecognition()
+                    continuation.finish()
+                }
+            }
+
+            self?.withState { state in
+                state.recognitionTask = task
+            }
+
+            let service = self
+            continuation.onTermination = { @Sendable _ in
+                service?.stopRecognition()
+            }
+        }
+    }
+
+    /// Clean up all recognition resources. Must be called while holding the lock
+    /// (i.e. inside `withState`).
+    private static func cleanupState(_ state: inout State) {
+        state.recognitionTask?.cancel()
+        state.recognitionTask = nil
+
+        state.recognitionRequest?.endAudio()
+        state.recognitionRequest = nil
+
+        if let engine = state.audioEngine, engine.isRunning {
+            engine.stop()
+            engine.inputNode.removeTap(onBus: 0)
+        }
+        state.audioEngine = nil
+
+        state.isRecognizing = false
+    }
+
+    private static func mapStatus(
+        _ status: SFSpeechRecognizerAuthorizationStatus
+    ) -> SpeechAuthorizationStatus {
+        switch status {
+        case .notDetermined: .notDetermined
+        case .denied: .denied
+        case .restricted: .restricted
+        case .authorized: .authorized
+        @unknown default: .denied
+        }
+    }
+}
+
+#endif

--- a/app/SayItRight/Tests/SpeechRecognitionServiceTests.swift
+++ b/app/SayItRight/Tests/SpeechRecognitionServiceTests.swift
@@ -1,0 +1,191 @@
+import Foundation
+import Testing
+
+@testable import SayItRight
+
+// MARK: - SpeechLocale Tests
+
+@Suite("SpeechLocale")
+struct SpeechLocaleTests {
+
+    @Test("German language maps to de-DE locale")
+    func germanLocale() {
+        let locale = SpeechLocale(appLanguage: "de")
+        #expect(locale == .german)
+        #expect(locale.rawValue == "de-DE")
+        #expect(locale.locale.identifier == "de-DE")
+    }
+
+    @Test("English language maps to en-US locale")
+    func englishLocale() {
+        let locale = SpeechLocale(appLanguage: "en")
+        #expect(locale == .english)
+        #expect(locale.rawValue == "en-US")
+        #expect(locale.locale.identifier == "en-US")
+    }
+
+    @Test("Unknown language defaults to English")
+    func unknownLanguageDefaultsToEnglish() {
+        let locale = SpeechLocale(appLanguage: "fr")
+        #expect(locale == .english)
+    }
+}
+
+// MARK: - Mock Service Tests
+
+@Suite("MockSpeechRecognitionService")
+struct MockSpeechRecognitionServiceTests {
+
+    @Test("Default mock is authorized and available")
+    func defaultState() {
+        let mock = MockSpeechRecognitionService()
+        #expect(mock.authorizationStatus == .authorized)
+        #expect(mock.isAvailable)
+    }
+
+    @Test("Request authorization increments call count")
+    func requestAuthorizationTracking() async {
+        let mock = MockSpeechRecognitionService()
+        let status = await mock.requestAuthorization()
+        #expect(status == .authorized)
+        #expect(mock.requestAuthorizationCallCount == 1)
+    }
+
+    @Test("Start recognition throws when permission denied")
+    func startRecognitionPermissionDenied() async {
+        let mock = MockSpeechRecognitionService()
+        mock.stubbedAuthorizationStatus = .denied
+
+        do {
+            _ = try await mock.startRecognition()
+            Issue.record("Expected permissionDenied error")
+        } catch let error as SpeechRecognitionError {
+            #expect(error == .permissionDenied)
+        } catch {
+            Issue.record("Unexpected error type: \(error)")
+        }
+    }
+
+    @Test("Start recognition throws when recognizer unavailable")
+    func startRecognitionUnavailable() async {
+        let mock = MockSpeechRecognitionService()
+        mock.stubbedIsAvailable = false
+
+        do {
+            _ = try await mock.startRecognition()
+            Issue.record("Expected recognizerUnavailable error")
+        } catch let error as SpeechRecognitionError {
+            #expect(error == .recognizerUnavailable)
+        } catch {
+            Issue.record("Unexpected error type: \(error)")
+        }
+    }
+
+    @Test("Start recognition throws stubbed error")
+    func startRecognitionStubbedError() async {
+        let mock = MockSpeechRecognitionService()
+        mock.stubbedError = .noSpeechDetected
+
+        do {
+            _ = try await mock.startRecognition()
+            Issue.record("Expected noSpeechDetected error")
+        } catch let error as SpeechRecognitionError {
+            #expect(error == .noSpeechDetected)
+        } catch {
+            Issue.record("Unexpected error type: \(error)")
+        }
+    }
+
+    @Test("Start recognition streams stubbed transcriptions")
+    func startRecognitionStreamsResults() async throws {
+        let mock = MockSpeechRecognitionService()
+        mock.stubbedTranscriptions = [
+            SpeechTranscription(text: "Hello", isFinal: false, confidence: 0.5),
+            SpeechTranscription(text: "Hello world", isFinal: true, confidence: 0.9),
+        ]
+
+        let stream = try await mock.startRecognition()
+        var results: [SpeechTranscription] = []
+        for await transcription in stream {
+            results.append(transcription)
+        }
+
+        #expect(results.count == 2)
+        #expect(results[0].text == "Hello")
+        #expect(results[0].isFinal == false)
+        #expect(results[1].text == "Hello world")
+        #expect(results[1].isFinal == true)
+        #expect(mock.startRecognitionCallCount == 1)
+    }
+
+    @Test("Stop recognition increments call count")
+    func stopRecognitionTracking() {
+        let mock = MockSpeechRecognitionService()
+        mock.stopRecognition()
+        mock.stopRecognition()
+        #expect(mock.stopRecognitionCallCount == 2)
+    }
+
+    @Test("Set locale updates tracked locale")
+    func setLocaleTracking() {
+        let mock = MockSpeechRecognitionService()
+        mock.setLocale(.german)
+        #expect(mock.setLocaleCallCount == 1)
+        #expect(mock.lastSetLocale == .german)
+
+        mock.setLocale(.english)
+        #expect(mock.setLocaleCallCount == 2)
+        #expect(mock.lastSetLocale == .english)
+    }
+
+    @Test("Language switching from app language string")
+    func languageSwitching() {
+        let mock = MockSpeechRecognitionService()
+
+        // Simulate what happens when learner profile language changes
+        let germanLanguage = "de"
+        mock.setLocale(SpeechLocale(appLanguage: germanLanguage))
+        #expect(mock.lastSetLocale == .german)
+
+        let englishLanguage = "en"
+        mock.setLocale(SpeechLocale(appLanguage: englishLanguage))
+        #expect(mock.lastSetLocale == .english)
+    }
+}
+
+// MARK: - SpeechRecognitionError Tests
+
+@Suite("SpeechRecognitionError")
+struct SpeechRecognitionErrorTests {
+
+    @Test("Errors are equatable")
+    func errorsAreEquatable() {
+        #expect(SpeechRecognitionError.permissionDenied == .permissionDenied)
+        #expect(SpeechRecognitionError.recognizerUnavailable == .recognizerUnavailable)
+        #expect(SpeechRecognitionError.noSpeechDetected == .noSpeechDetected)
+        #expect(SpeechRecognitionError.recognitionFailed("x") == .recognitionFailed("x"))
+        #expect(SpeechRecognitionError.recognitionFailed("x") != .recognitionFailed("y"))
+        #expect(SpeechRecognitionError.audioEngineError("e") == .audioEngineError("e"))
+        #expect(SpeechRecognitionError.permissionDenied != .noSpeechDetected)
+    }
+}
+
+// MARK: - SpeechTranscription Tests
+
+@Suite("SpeechTranscription")
+struct SpeechTranscriptionTests {
+
+    @Test("Transcription stores all fields")
+    func transcriptionFields() {
+        let t = SpeechTranscription(text: "Test", isFinal: true, confidence: 0.95)
+        #expect(t.text == "Test")
+        #expect(t.isFinal == true)
+        #expect(t.confidence == 0.95)
+    }
+
+    @Test("Transcription with nil confidence")
+    func nilConfidence() {
+        let t = SpeechTranscription(text: "Partial", isFinal: false, confidence: nil)
+        #expect(t.confidence == nil)
+    }
+}


### PR DESCRIPTION
## Summary
- `SpeechRecognitionServiceProtocol` for testability and DI
- `LiveSpeechRecognitionService` using `SFSpeechRecognizer` + `SFSpeechAudioBufferRecognitionRequest` for streaming partial results
- On-device recognition preferred with automatic server fallback
- `SpeechLocale` enum maps `AppLanguage` (de/en) to de-DE/en-US
- `MockSpeechRecognitionService` with call tracking and stubbed responses
- 15 unit tests covering locale mapping, error paths, streaming, and mock behavior
- Graceful error handling for permission denied, recognizer unavailable, no speech detected, audio engine errors

## Test plan
- [x] All 33 tests pass (15 new + 18 existing)
- [x] macOS build succeeds
- [ ] Manual: verify speech recognition authorization prompt on iOS device
- [ ] Manual: verify on-device recognition works in both DE and EN

Closes #53