### PR TITLE
feat: practice text generation pipeline (SIR-041)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Xcode
 DerivedData/
 build/
+*.xcodeproj
 *.xcuserdata
 *.xcworkspace
 !*.xcworkspace/contents.xcworkspacedata
@@ -26,6 +27,9 @@ backend/src/generated/
 .claude/MEMORY.md
 .claude/settings.json
 logs/
+
+# Generated practice texts staging (review before committing)
+content/practice-texts/staging/*.json
 
 # OS
 .DS_Store

--- a/app/SayItRight/Content/PracticeTexts/PracticeText.swift
+++ b/app/SayItRight/Content/PracticeTexts/PracticeText.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+/// Quality level of a practice text, defining how well-structured it is.
+enum QualityLevel: String, Codable, Sendable, CaseIterable {
+    /// Clean pyramid structure, easy to extract governing thought and supports.
+    case wellStructured = "well-structured"
+    /// Conclusion exists but is buried in paragraph 2-3 instead of leading.
+    case buriedLead = "buried-lead"
+    /// No clear structure; the user must identify that structure is missing.
+    case rambling
+    /// Appears structured but contains a hidden logical flaw.
+    case adversarial
+}
+
+/// A structural flaw embedded in an adversarial practice text.
+struct StructuralFlaw: Codable, Sendable, Equatable {
+    /// The type of flaw (e.g. "false_dichotomy", "circular_reasoning", "non_sequitur").
+    let type: String
+    /// Human-readable description of the flaw.
+    let description: String
+    /// Where in the text the flaw occurs (e.g. "paragraph 2", "support pillar 3").
+    let location: String
+}
+
+/// Answer key for a practice text, describing its pyramid structure.
+struct AnswerKey: Codable, Sendable, Equatable {
+    /// The main conclusion / governing thought of the text.
+    let governingThought: String
+    /// Support groups with labels and evidence nodes.
+    let supports: [SupportGroup]
+    /// Structural assessment explaining the text's architecture.
+    let structuralAssessment: String
+    /// For adversarial texts: description of the hidden structural flaw.
+    let structuralFlaw: StructuralFlaw?
+    /// For rambling texts: a proposed restructure showing how the text could be improved.
+    let proposedRestructure: String?
+
+    init(
+        governingThought: String,
+        supports: [SupportGroup],
+        structuralAssessment: String,
+        structuralFlaw: StructuralFlaw? = nil,
+        proposedRestructure: String? = nil
+    ) {
+        self.governingThought = governingThought
+        self.supports = supports
+        self.structuralAssessment = structuralAssessment
+        self.structuralFlaw = structuralFlaw
+        self.proposedRestructure = proposedRestructure
+    }
+}
+
+/// A labeled support group with evidence nodes.
+struct SupportGroup: Codable, Sendable, Equatable {
+    /// Label for this support pillar (e.g. "Health impact", "Economic argument").
+    let label: String
+    /// Evidence nodes supporting this pillar.
+    let evidence: [String]
+}
+
+/// Metadata about a generated practice text.
+struct PracticeTextMetadata: Codable, Sendable, Equatable {
+    let qualityLevel: QualityLevel
+    let difficultyRating: Int
+    let topicDomain: String
+    let language: String
+    let wordCount: Int
+    let targetLevel: Int
+}
+
+/// A practice text with its answer key and metadata, used in Break mode exercises.
+struct PracticeText: Codable, Sendable, Identifiable, Equatable {
+    let id: String
+    let text: String
+    let answerKey: AnswerKey
+    let metadata: PracticeTextMetadata
+}

--- a/app/SayItRight/Intelligence/TextGenerator/PracticeTextFileWriter.swift
+++ b/app/SayItRight/Intelligence/TextGenerator/PracticeTextFileWriter.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// Writes generated practice texts to JSON files in the staging directory.
+///
+/// Output files follow the naming convention: `{id}.json`
+/// Files are written to a configurable staging directory for human review
+/// before being moved to the final `content/practice-texts/` directory.
+struct PracticeTextFileWriter: Sendable {
+
+    private let outputDirectory: URL
+
+    init(outputDirectory: URL) {
+        self.outputDirectory = outputDirectory
+    }
+
+    /// Write a single practice text to a JSON file.
+    func write(_ practiceText: PracticeText) throws {
+        try FileManager.default.createDirectory(
+            at: outputDirectory,
+            withIntermediateDirectories: true
+        )
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+
+        let data = try encoder.encode(practiceText)
+        let fileURL = outputDirectory.appendingPathComponent("\(practiceText.id).json")
+        try data.write(to: fileURL, options: .atomic)
+    }
+
+    /// Write multiple practice texts, returning the paths of successfully written files.
+    func writeAll(_ texts: [PracticeText]) throws -> [URL] {
+        var written: [URL] = []
+        for text in texts {
+            try write(text)
+            let fileURL = outputDirectory.appendingPathComponent("\(text.id).json")
+            written.append(fileURL)
+        }
+        return written
+    }
+}

--- a/app/SayItRight/Intelligence/TextGenerator/PracticeTextGenerator.swift
+++ b/app/SayItRight/Intelligence/TextGenerator/PracticeTextGenerator.swift
@@ -1,0 +1,405 @@
+import Foundation
+
+/// Configuration for generating a batch of practice texts.
+struct GenerationConfig: Sendable {
+    let qualityLevel: QualityLevel
+    let language: String
+    let targetLevel: Int
+    let topicDomain: String
+    let targetWordCount: ClosedRange<Int>
+    let count: Int
+
+    init(
+        qualityLevel: QualityLevel,
+        language: String = "en",
+        targetLevel: Int = 1,
+        topicDomain: String = "technology",
+        targetWordCount: ClosedRange<Int> = 100...400,
+        count: Int = 1
+    ) {
+        self.qualityLevel = qualityLevel
+        self.language = language
+        self.targetLevel = targetLevel
+        self.topicDomain = topicDomain
+        self.targetWordCount = targetWordCount
+        self.count = count
+    }
+}
+
+/// Generates practice texts by calling the Anthropic Claude API.
+///
+/// This is a pipeline tool for content creation — it generates texts with
+/// structured answer keys that are reviewed by a human before being bundled
+/// into the app. Output goes to a staging directory for review.
+struct PracticeTextGenerator: Sendable {
+
+    private let apiKey: String
+    private let model: String
+    private let apiURL: URL
+
+    init(
+        apiKey: String,
+        model: String = "claude-sonnet-4-5-20250514",
+        apiURL: URL = URL(string: "https://api.anthropic.com/v1/messages")!
+    ) {
+        self.apiKey = apiKey
+        self.model = model
+        self.apiURL = apiURL
+    }
+
+    // MARK: - Public API
+
+    /// Generate a single practice text with the given configuration.
+    func generate(config: GenerationConfig, idPrefix: String = "pt-gen") async throws -> PracticeText {
+        let prompt = buildPrompt(for: config)
+        let responseJSON = try await callAPI(systemPrompt: systemPrompt(for: config), userPrompt: prompt)
+        let practiceText = try parseResponse(responseJSON, config: config, idPrefix: idPrefix)
+        return practiceText
+    }
+
+    /// Generate a batch of practice texts, respecting rate limits.
+    func generateBatch(
+        configs: [GenerationConfig],
+        idStart: Int = 1,
+        delayBetweenRequests: UInt64 = 2_000_000_000 // 2 seconds
+    ) async throws -> [PracticeText] {
+        var results: [PracticeText] = []
+        var currentID = idStart
+
+        for config in configs {
+            for _ in 0..<config.count {
+                let idPrefix = String(format: "pt-%03d", currentID)
+                let text = try await generate(config: config, idPrefix: idPrefix)
+                results.append(text)
+                currentID += 1
+
+                // Rate limiting: pause between requests
+                try await Task.sleep(nanoseconds: delayBetweenRequests)
+            }
+        }
+
+        return results
+    }
+
+    // MARK: - Prompt Construction
+
+    /// System prompt establishing the generator's role and output format.
+    func systemPrompt(for config: GenerationConfig) -> String {
+        let languageName = config.language == "de" ? "German" : "English"
+
+        return """
+        You are a practice text generator for an educational app that teaches \
+        structured thinking and the Pyramid Principle. Your job is to produce \
+        natural-sounding texts that students will analyze for structural quality.
+
+        CRITICAL RULES:
+        1. The text must sound like it was written by a real person — NOT like \
+        AI-generated content. Use natural phrasing, varied sentence lengths, \
+        and occasional colloquialisms appropriate for the topic.
+        2. The text must be written entirely in \(languageName).
+        3. The text must be between \(config.targetWordCount.lowerBound) and \
+        \(config.targetWordCount.upperBound) words.
+        4. The topic should be engaging and relevant for teenagers and young adults (13+).
+        5. The text must be age-appropriate — no graphic violence, explicit content, \
+        or deeply disturbing themes.
+
+        You MUST respond with ONLY a valid JSON object, no markdown formatting, \
+        no code fences, no explanation. Just the raw JSON.
+        """
+    }
+
+    /// Build the user prompt specifying what kind of text to generate.
+    func buildPrompt(for config: GenerationConfig) -> String {
+        let qualityInstructions = qualityLevelInstructions(for: config.qualityLevel)
+        let levelContext = learnerLevelContext(for: config.targetLevel)
+        let languageName = config.language == "de" ? "German" : "English"
+
+        return """
+        Generate a practice text with the following specifications:
+
+        QUALITY LEVEL: \(config.qualityLevel.rawValue)
+        \(qualityInstructions)
+
+        TOPIC DOMAIN: \(config.topicDomain)
+        LANGUAGE: \(languageName)
+        TARGET LEARNER LEVEL: \(config.targetLevel)
+        \(levelContext)
+
+        TARGET LENGTH: \(config.targetWordCount.lowerBound)-\(config.targetWordCount.upperBound) words
+
+        OUTPUT FORMAT (JSON only, no markdown):
+        {
+          "text": "<the practice text>",
+          "answer_key": {
+            "governing_thought": "<the main conclusion or thesis>",
+            "supports": [
+              {
+                "label": "<short label for this support group>",
+                "evidence": ["<evidence node 1>", "<evidence node 2>"]
+              }
+            ],
+            "structural_assessment": "<explanation of the text's structural quality>"\(config.qualityLevel == .adversarial ? ",\n    \"structural_flaw\": {\n      \"type\": \"<flaw type: false_dichotomy | circular_reasoning | non_sequitur | hasty_generalization | straw_man | false_equivalence | appeal_to_authority | correlation_as_causation>\",\n      \"description\": \"<what the flaw is and why it's problematic>\",\n      \"location\": \"<where in the text the flaw occurs>\"\n    }" : "")\(config.qualityLevel == .rambling ? ",\n    \"proposed_restructure\": \"<how this text should be restructured into a proper pyramid>\"" : "")
+          },
+          "topic_domain": "\(config.topicDomain)",
+          "difficulty_rating": <1-5 integer>
+        }
+        """
+    }
+
+    // MARK: - Quality Level Instructions
+
+    private func qualityLevelInstructions(for level: QualityLevel) -> String {
+        switch level {
+        case .wellStructured:
+            return """
+            INSTRUCTIONS: Create a text with clean pyramid structure.
+            - Lead with the governing thought (conclusion first)
+            - Follow with 2-4 distinct support pillars, each with specific evidence
+            - Each support should be mutually exclusive and collectively exhaustive (MECE)
+            - The structure should be easy to extract — this is a model text
+            - Include a brief counterargument that is acknowledged and dismissed
+            """
+
+        case .buriedLead:
+            return """
+            INSTRUCTIONS: Create a text where the conclusion EXISTS but is BURIED.
+            - Start with background, context, statistics, or a story (1-2 paragraphs)
+            - Place the actual governing thought in paragraph 2 or 3, often after \
+            a transitional phrase like "Yet...", "However...", "The real issue is..."
+            - The supporting arguments should be solid once the reader finds the thesis
+            - The text should feel like a newspaper feature article or an essay that \
+            "builds up" to its point instead of leading with it
+            - Common real-world pattern: the writer knows their point but buries it \
+            under preamble
+            """
+
+        case .rambling:
+            return """
+            INSTRUCTIONS: Create a text with NO clear organizing structure.
+            - The text should contain good individual points but in scattered order
+            - Jump between subtopics without clear transitions
+            - Split related arguments across non-adjacent paragraphs
+            - Include a weak or non-committal conclusion ("something needs to change")
+            - Use conversational, stream-of-consciousness style
+            - The reader should be able to identify THAT structure is missing
+            - There IS content worth restructuring — the problem is organization, \
+            not substance
+            """
+
+        case .adversarial:
+            return """
+            INSTRUCTIONS: Create a text that APPEARS well-structured but contains \
+            a HIDDEN logical flaw.
+            - Surface structure should look like a clean pyramid (conclusion first, \
+            supports follow)
+            - Embed ONE of these structural flaws:
+              * False dichotomy: presents only two options when more exist
+              * Circular reasoning: conclusion restates a premise as proof
+              * Non sequitur: a support doesn't actually support the conclusion
+              * Hasty generalization: one example treated as universal proof
+              * Straw man: misrepresents an opposing view to dismiss it easily
+              * False equivalence: treats unequal things as equal
+              * Appeal to authority: uses authority instead of evidence
+              * Correlation as causation: mistakes correlation for causation
+            - The flaw should be subtle enough to require careful reading to spot
+            - The text should be convincing on first read — the flaw reveals itself \
+            on analysis
+            """
+        }
+    }
+
+    // MARK: - Learner Level Context
+
+    private func learnerLevelContext(for level: Int) -> String {
+        switch level {
+        case 1:
+            return """
+            LEVEL CONTEXT (L1 "Plain Talk"): Foundations.
+            - Simple, clear language. Short to medium paragraphs.
+            - Focus: lead with answer, one idea per block, "so what?" test.
+            - Vocabulary appropriate for 13-15 year olds.
+            """
+        case 2:
+            return """
+            LEVEL CONTEXT (L2 "Order"): Grouping & logic.
+            - Moderate complexity. MECE grouping, deductive vs. inductive reasoning.
+            - May include SCQ (Situation-Complication-Question) framing.
+            - Vocabulary appropriate for 15-17 year olds.
+            """
+        case 3:
+            return """
+            LEVEL CONTEXT (L3 "Architecture"): Advanced structures.
+            - Complex, multi-layered arguments. Issue trees, vertical/horizontal logic.
+            - May include synthesis of multiple viewpoints.
+            - University-level vocabulary and reasoning complexity.
+            """
+        case 4:
+            return """
+            LEVEL CONTEXT (L4 "Mastery"): Real-world application.
+            - Professional-grade text complexity. Executive summaries, presentations.
+            - Dense argumentation with nuanced evidence.
+            - Professional vocabulary, real-world references.
+            """
+        default:
+            return "LEVEL CONTEXT: General audience, moderate complexity."
+        }
+    }
+
+    // MARK: - API Communication
+
+    private func callAPI(systemPrompt: String, userPrompt: String) async throws -> String {
+        var request = URLRequest(url: apiURL)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue(apiKey, forHTTPHeaderField: "x-api-key")
+        request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
+        request.timeoutInterval = 120
+
+        let body: [String: Any] = [
+            "model": model,
+            "max_tokens": 4096,
+            "system": systemPrompt,
+            "messages": [
+                ["role": "user", "content": userPrompt]
+            ]
+        ]
+
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw GeneratorError.invalidResponse
+        }
+
+        guard httpResponse.statusCode == 200 else {
+            let errorBody = String(data: data, encoding: .utf8) ?? "unknown"
+            throw GeneratorError.apiError(statusCode: httpResponse.statusCode, body: errorBody)
+        }
+
+        // Parse the Anthropic API response to extract the text content
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let content = json["content"] as? [[String: Any]],
+              let firstBlock = content.first,
+              let text = firstBlock["text"] as? String
+        else {
+            throw GeneratorError.unexpectedResponseFormat
+        }
+
+        return text
+    }
+
+    // MARK: - Response Parsing
+
+    private func parseResponse(_ responseJSON: String, config: GenerationConfig, idPrefix: String) throws -> PracticeText {
+        // Strip any markdown code fences if the model wrapped the JSON
+        let cleaned = responseJSON
+            .replacingOccurrences(of: "```json", with: "")
+            .replacingOccurrences(of: "```", with: "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard let data = cleaned.data(using: .utf8) else {
+            throw GeneratorError.invalidJSON(cleaned)
+        }
+
+        guard let raw = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw GeneratorError.invalidJSON(cleaned)
+        }
+
+        // Extract text
+        guard let text = raw["text"] as? String else {
+            throw GeneratorError.missingField("text")
+        }
+
+        // Extract answer key
+        guard let answerKeyRaw = raw["answer_key"] as? [String: Any] else {
+            throw GeneratorError.missingField("answer_key")
+        }
+
+        guard let governingThought = answerKeyRaw["governing_thought"] as? String else {
+            throw GeneratorError.missingField("answer_key.governing_thought")
+        }
+
+        guard let supportsRaw = answerKeyRaw["supports"] as? [[String: Any]] else {
+            throw GeneratorError.missingField("answer_key.supports")
+        }
+
+        let supports = supportsRaw.compactMap { supportDict -> SupportGroup? in
+            guard let label = supportDict["label"] as? String,
+                  let evidence = supportDict["evidence"] as? [String]
+            else { return nil }
+            return SupportGroup(label: label, evidence: evidence)
+        }
+
+        guard !supports.isEmpty else {
+            throw GeneratorError.missingField("answer_key.supports (empty)")
+        }
+
+        let structuralAssessment = answerKeyRaw["structural_assessment"] as? String ?? ""
+
+        // Optional fields
+        var structuralFlaw: StructuralFlaw?
+        if let flawRaw = answerKeyRaw["structural_flaw"] as? [String: Any],
+           let flawType = flawRaw["type"] as? String,
+           let flawDesc = flawRaw["description"] as? String,
+           let flawLoc = flawRaw["location"] as? String {
+            structuralFlaw = StructuralFlaw(type: flawType, description: flawDesc, location: flawLoc)
+        }
+
+        let proposedRestructure = answerKeyRaw["proposed_restructure"] as? String
+
+        let difficultyRating = raw["difficulty_rating"] as? Int ?? config.targetLevel
+        let topicDomain = raw["topic_domain"] as? String ?? config.topicDomain
+
+        let wordCount = text.split(separator: " ").count
+
+        let answerKey = AnswerKey(
+            governingThought: governingThought,
+            supports: supports,
+            structuralAssessment: structuralAssessment,
+            structuralFlaw: structuralFlaw,
+            proposedRestructure: proposedRestructure
+        )
+
+        let metadata = PracticeTextMetadata(
+            qualityLevel: config.qualityLevel,
+            difficultyRating: difficultyRating,
+            topicDomain: topicDomain,
+            language: config.language,
+            wordCount: wordCount,
+            targetLevel: config.targetLevel
+        )
+
+        return PracticeText(
+            id: "\(idPrefix)-\(config.language)",
+            text: text,
+            answerKey: answerKey,
+            metadata: metadata
+        )
+    }
+}
+
+// MARK: - Errors
+
+enum GeneratorError: Error, CustomStringConvertible {
+    case invalidResponse
+    case apiError(statusCode: Int, body: String)
+    case unexpectedResponseFormat
+    case invalidJSON(String)
+    case missingField(String)
+
+    var description: String {
+        switch self {
+        case .invalidResponse:
+            return "Invalid HTTP response"
+        case .apiError(let code, let body):
+            return "API error (\(code)): \(body)"
+        case .unexpectedResponseFormat:
+            return "Unexpected response format from Anthropic API"
+        case .invalidJSON(let raw):
+            return "Failed to parse JSON from response: \(raw.prefix(200))"
+        case .missingField(let field):
+            return "Missing required field: \(field)"
+        }
+    }
+}

--- a/app/SayItRight/Tests/PracticeTextGeneratorTests.swift
+++ b/app/SayItRight/Tests/PracticeTextGeneratorTests.swift
@@ -1,0 +1,285 @@
+import Foundation
+import Testing
+@testable import SayItRight
+
+@Suite("PracticeText Model Tests")
+struct PracticeTextModelTests {
+
+    // MARK: - QualityLevel
+
+    @Test("QualityLevel raw values match expected strings")
+    func qualityLevelRawValues() {
+        #expect(QualityLevel.wellStructured.rawValue == "well-structured")
+        #expect(QualityLevel.buriedLead.rawValue == "buried-lead")
+        #expect(QualityLevel.rambling.rawValue == "rambling")
+        #expect(QualityLevel.adversarial.rawValue == "adversarial")
+    }
+
+    @Test("QualityLevel has exactly four cases")
+    func qualityLevelCaseCount() {
+        #expect(QualityLevel.allCases.count == 4)
+    }
+
+    @Test("QualityLevel round-trips through JSON encoding")
+    func qualityLevelCodable() throws {
+        for level in QualityLevel.allCases {
+            let data = try JSONEncoder().encode(level)
+            let decoded = try JSONDecoder().decode(QualityLevel.self, from: data)
+            #expect(decoded == level)
+        }
+    }
+
+    // MARK: - StructuralFlaw
+
+    @Test("StructuralFlaw encodes and decodes correctly")
+    func structuralFlawCodable() throws {
+        let flaw = StructuralFlaw(
+            type: "false_dichotomy",
+            description: "Presents only two options when more exist",
+            location: "paragraph 2"
+        )
+        let data = try JSONEncoder().encode(flaw)
+        let decoded = try JSONDecoder().decode(StructuralFlaw.self, from: data)
+        #expect(decoded == flaw)
+        #expect(decoded.type == "false_dichotomy")
+        #expect(decoded.location == "paragraph 2")
+    }
+
+    // MARK: - SupportGroup
+
+    @Test("SupportGroup encodes with label and evidence")
+    func supportGroupCodable() throws {
+        let group = SupportGroup(
+            label: "Health impact",
+            evidence: ["Reduces stress by 30%", "Improves sleep quality"]
+        )
+        let data = try JSONEncoder().encode(group)
+        let decoded = try JSONDecoder().decode(SupportGroup.self, from: data)
+        #expect(decoded == group)
+        #expect(decoded.evidence.count == 2)
+    }
+
+    // MARK: - AnswerKey
+
+    @Test("AnswerKey with structural flaw for adversarial texts")
+    func answerKeyWithFlaw() throws {
+        let key = AnswerKey(
+            governingThought: "Social media improves democracy",
+            supports: [
+                SupportGroup(label: "Access", evidence: ["Everyone can participate"]),
+                SupportGroup(label: "Speed", evidence: ["Instant information sharing"])
+            ],
+            structuralAssessment: "Appears well-structured but contains a false equivalence",
+            structuralFlaw: StructuralFlaw(
+                type: "false_equivalence",
+                description: "Treats online engagement as equal to meaningful political participation",
+                location: "support pillar 1"
+            )
+        )
+
+        let data = try JSONEncoder().encode(key)
+        let decoded = try JSONDecoder().decode(AnswerKey.self, from: data)
+        #expect(decoded.governingThought == key.governingThought)
+        #expect(decoded.structuralFlaw != nil)
+        #expect(decoded.structuralFlaw?.type == "false_equivalence")
+        #expect(decoded.proposedRestructure == nil)
+    }
+
+    @Test("AnswerKey with proposed restructure for rambling texts")
+    func answerKeyWithRestructure() throws {
+        let key = AnswerKey(
+            governingThought: "Fast fashion is harmful",
+            supports: [
+                SupportGroup(label: "Environment", evidence: ["Pollution", "Waste"])
+            ],
+            structuralAssessment: "No clear organizing principle",
+            proposedRestructure: "Lead with thesis, then group by environment, workers, economics"
+        )
+
+        let data = try JSONEncoder().encode(key)
+        let decoded = try JSONDecoder().decode(AnswerKey.self, from: data)
+        #expect(decoded.proposedRestructure != nil)
+        #expect(decoded.structuralFlaw == nil)
+    }
+
+    // MARK: - PracticeTextMetadata
+
+    @Test("PracticeTextMetadata encodes all fields")
+    func metadataCodable() throws {
+        let meta = PracticeTextMetadata(
+            qualityLevel: .adversarial,
+            difficultyRating: 3,
+            topicDomain: "technology",
+            language: "de",
+            wordCount: 250,
+            targetLevel: 2
+        )
+
+        let data = try JSONEncoder().encode(meta)
+        let decoded = try JSONDecoder().decode(PracticeTextMetadata.self, from: data)
+        #expect(decoded == meta)
+        #expect(decoded.qualityLevel == .adversarial)
+        #expect(decoded.language == "de")
+    }
+
+    // MARK: - PracticeText (full model)
+
+    @Test("PracticeText full round-trip encoding")
+    func practiceTextCodable() throws {
+        let text = PracticeText(
+            id: "pt-042-en",
+            text: "Smartphones should be banned from classrooms.",
+            answerKey: AnswerKey(
+                governingThought: "Ban smartphones from classrooms",
+                supports: [
+                    SupportGroup(label: "Distraction", evidence: ["Students check phones every 3 minutes"]),
+                    SupportGroup(label: "Cognitive drain", evidence: ["Brain drain effect reduces capacity"])
+                ],
+                structuralAssessment: "Clean pyramid with conclusion first"
+            ),
+            metadata: PracticeTextMetadata(
+                qualityLevel: .wellStructured,
+                difficultyRating: 1,
+                topicDomain: "technology",
+                language: "en",
+                wordCount: 8,
+                targetLevel: 1
+            )
+        )
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(text)
+        let decoded = try JSONDecoder().decode(PracticeText.self, from: data)
+
+        #expect(decoded.id == "pt-042-en")
+        #expect(decoded.answerKey.supports.count == 2)
+        #expect(decoded.metadata.qualityLevel == .wellStructured)
+        #expect(decoded.metadata.wordCount == 8)
+    }
+}
+
+@Suite("PracticeTextGenerator Prompt Tests")
+struct PracticeTextGeneratorPromptTests {
+
+    private func makeGenerator() -> PracticeTextGenerator {
+        PracticeTextGenerator(apiKey: "test-key")
+    }
+
+    @Test("System prompt includes language specification")
+    func systemPromptLanguage() {
+        let generator = makeGenerator()
+
+        let enConfig = GenerationConfig(qualityLevel: .wellStructured, language: "en")
+        let enPrompt = generator.systemPrompt(for: enConfig)
+        #expect(enPrompt.contains("English"))
+        #expect(!enPrompt.contains("German"))
+
+        let deConfig = GenerationConfig(qualityLevel: .wellStructured, language: "de")
+        let dePrompt = generator.systemPrompt(for: deConfig)
+        #expect(dePrompt.contains("German"))
+    }
+
+    @Test("System prompt includes word count range")
+    func systemPromptWordCount() {
+        let generator = makeGenerator()
+        let config = GenerationConfig(qualityLevel: .wellStructured, targetWordCount: 150...350)
+        let prompt = generator.systemPrompt(for: config)
+        #expect(prompt.contains("150"))
+        #expect(prompt.contains("350"))
+    }
+
+    @Test("Build prompt includes quality level instructions")
+    func buildPromptQualityLevel() {
+        let generator = makeGenerator()
+
+        for quality in QualityLevel.allCases {
+            let config = GenerationConfig(qualityLevel: quality)
+            let prompt = generator.buildPrompt(for: config)
+            #expect(prompt.contains(quality.rawValue))
+        }
+    }
+
+    @Test("Adversarial prompt requests structural_flaw field")
+    func adversarialPromptIncludesFlaw() {
+        let generator = makeGenerator()
+        let config = GenerationConfig(qualityLevel: .adversarial)
+        let prompt = generator.buildPrompt(for: config)
+        #expect(prompt.contains("structural_flaw"))
+        #expect(prompt.contains("flaw type"))
+    }
+
+    @Test("Rambling prompt requests proposed_restructure field")
+    func ramblingPromptIncludesRestructure() {
+        let generator = makeGenerator()
+        let config = GenerationConfig(qualityLevel: .rambling)
+        let prompt = generator.buildPrompt(for: config)
+        #expect(prompt.contains("proposed_restructure"))
+    }
+
+    @Test("Well-structured prompt does not request flaw or restructure")
+    func wellStructuredPromptNoExtras() {
+        let generator = makeGenerator()
+        let config = GenerationConfig(qualityLevel: .wellStructured)
+        let prompt = generator.buildPrompt(for: config)
+        #expect(!prompt.contains("structural_flaw"))
+        #expect(!prompt.contains("proposed_restructure"))
+    }
+
+    @Test("Prompt includes topic domain")
+    func promptIncludesDomain() {
+        let generator = makeGenerator()
+        let config = GenerationConfig(qualityLevel: .wellStructured, topicDomain: "school")
+        let prompt = generator.buildPrompt(for: config)
+        #expect(prompt.contains("school"))
+    }
+
+    @Test("Prompt includes target level context")
+    func promptIncludesLevel() {
+        let generator = makeGenerator()
+
+        let l1 = GenerationConfig(qualityLevel: .wellStructured, targetLevel: 1)
+        #expect(generator.buildPrompt(for: l1).contains("Plain Talk"))
+
+        let l2 = GenerationConfig(qualityLevel: .wellStructured, targetLevel: 2)
+        #expect(generator.buildPrompt(for: l2).contains("Order"))
+
+        let l3 = GenerationConfig(qualityLevel: .wellStructured, targetLevel: 3)
+        #expect(generator.buildPrompt(for: l3).contains("Architecture"))
+
+        let l4 = GenerationConfig(qualityLevel: .wellStructured, targetLevel: 4)
+        #expect(generator.buildPrompt(for: l4).contains("Mastery"))
+    }
+}
+
+@Suite("GenerationConfig Tests")
+struct GenerationConfigTests {
+
+    @Test("Default config has sensible defaults")
+    func defaultConfig() {
+        let config = GenerationConfig(qualityLevel: .wellStructured)
+        #expect(config.language == "en")
+        #expect(config.targetLevel == 1)
+        #expect(config.topicDomain == "technology")
+        #expect(config.targetWordCount == 100...400)
+        #expect(config.count == 1)
+    }
+
+    @Test("Custom config preserves all values")
+    func customConfig() {
+        let config = GenerationConfig(
+            qualityLevel: .adversarial,
+            language: "de",
+            targetLevel: 3,
+            topicDomain: "society",
+            targetWordCount: 200...300,
+            count: 5
+        )
+        #expect(config.qualityLevel == .adversarial)
+        #expect(config.language == "de")
+        #expect(config.targetLevel == 3)
+        #expect(config.topicDomain == "society")
+        #expect(config.targetWordCount == 200...300)
+        #expect(config.count == 5)
+    }
+}

--- a/content/practice-texts/staging/.gitkeep
+++ b/content/practice-texts/staging/.gitkeep
@@ -1,0 +1,3 @@
+# Staging directory for generated practice texts
+# Review files here before moving approved ones to content/practice-texts/
+# Files in this directory should NOT be committed to git.

--- a/scripts/generate-practice-texts.swift
+++ b/scripts/generate-practice-texts.swift
@@ -1,0 +1,455 @@
+#!/usr/bin/env swift
+
+// generate-practice-texts.swift
+//
+// Batch script that generates practice texts via the Claude API.
+// Outputs JSON files to content/practice-texts/staging/ for human review.
+//
+// Usage:
+//   ANTHROPIC_API_KEY=sk-... swift scripts/generate-practice-texts.swift [options]
+//
+// Options:
+//   --quality <level>     Quality level: well-structured, buried-lead, rambling, adversarial
+//                         (default: all four)
+//   --language <lang>     Language: en, de, or both (default: both)
+//   --level <n>           Target learner level: 1-4 (default: 1)
+//   --domain <domain>     Topic domain: technology, school, society, everyday (default: all)
+//   --count <n>           Number of texts per quality/language combination (default: 2)
+//   --id-start <n>        Starting ID number (default: 100)
+//   --output <dir>        Output directory (default: content/practice-texts/staging)
+//   --model <model>       Claude model to use (default: claude-sonnet-4-5-20250514)
+
+import Foundation
+
+// MARK: - Types (self-contained for script use)
+
+enum ScriptQualityLevel: String, CaseIterable {
+    case wellStructured = "well-structured"
+    case buriedLead = "buried-lead"
+    case rambling
+    case adversarial
+}
+
+// MARK: - Argument Parsing
+
+struct ScriptConfig {
+    var qualityLevels: [ScriptQualityLevel] = ScriptQualityLevel.allCases
+    var languages: [String] = ["en", "de"]
+    var targetLevel: Int = 1
+    var domains: [String] = ["technology", "school", "society", "everyday"]
+    var countPerCombination: Int = 2
+    var idStart: Int = 100
+    var outputDir: String = "content/practice-texts/staging"
+    var model: String = "claude-sonnet-4-5-20250514"
+    var apiKey: String = ""
+}
+
+func parseArgs() -> ScriptConfig {
+    var config = ScriptConfig()
+    let args = CommandLine.arguments
+
+    var i = 1
+    while i < args.count {
+        switch args[i] {
+        case "--quality":
+            i += 1
+            if i < args.count {
+                if args[i] == "all" {
+                    config.qualityLevels = ScriptQualityLevel.allCases
+                } else {
+                    config.qualityLevels = args[i].split(separator: ",").compactMap {
+                        ScriptQualityLevel(rawValue: String($0))
+                    }
+                }
+            }
+        case "--language":
+            i += 1
+            if i < args.count {
+                config.languages = args[i] == "both" ? ["en", "de"] : [args[i]]
+            }
+        case "--level":
+            i += 1
+            if i < args.count { config.targetLevel = Int(args[i]) ?? 1 }
+        case "--domain":
+            i += 1
+            if i < args.count {
+                config.domains = args[i] == "all"
+                    ? ["technology", "school", "society", "everyday"]
+                    : args[i].split(separator: ",").map(String.init)
+            }
+        case "--count":
+            i += 1
+            if i < args.count { config.countPerCombination = Int(args[i]) ?? 2 }
+        case "--id-start":
+            i += 1
+            if i < args.count { config.idStart = Int(args[i]) ?? 100 }
+        case "--output":
+            i += 1
+            if i < args.count { config.outputDir = args[i] }
+        case "--model":
+            i += 1
+            if i < args.count { config.model = args[i] }
+        case "--help", "-h":
+            printUsage()
+            exit(0)
+        default:
+            break
+        }
+        i += 1
+    }
+
+    // API key from environment
+    if let key = ProcessInfo.processInfo.environment["ANTHROPIC_API_KEY"] {
+        config.apiKey = key
+    }
+
+    return config
+}
+
+func printUsage() {
+    print("""
+    Usage: ANTHROPIC_API_KEY=sk-... swift scripts/generate-practice-texts.swift [options]
+
+    Options:
+      --quality <level>     well-structured, buried-lead, rambling, adversarial, or all
+      --language <lang>     en, de, or both (default: both)
+      --level <n>           Target learner level 1-4 (default: 1)
+      --domain <domain>     technology, school, society, everyday, or all (default: all)
+      --count <n>           Texts per quality/language/domain combo (default: 2)
+      --id-start <n>        Starting ID number (default: 100)
+      --output <dir>        Output directory (default: content/practice-texts/staging)
+      --model <model>       Claude model (default: claude-sonnet-4-5-20250514)
+    """)
+}
+
+// MARK: - Generation Prompt
+
+func systemPrompt(qualityLevel: ScriptQualityLevel, language: String, wordRange: ClosedRange<Int>) -> String {
+    let languageName = language == "de" ? "German" : "English"
+    return """
+    You are a practice text generator for an educational app that teaches \
+    structured thinking and the Pyramid Principle. Your job is to produce \
+    natural-sounding texts that students will analyze for structural quality.
+
+    CRITICAL RULES:
+    1. The text must sound like it was written by a real person — NOT like \
+    AI-generated content. Use natural phrasing, varied sentence lengths, \
+    and occasional colloquialisms appropriate for the topic.
+    2. The text must be written entirely in \(languageName).
+    3. The text must be between \(wordRange.lowerBound) and \(wordRange.upperBound) words.
+    4. The topic should be engaging and relevant for teenagers and young adults (13+).
+    5. The text must be age-appropriate — no graphic violence, explicit content, \
+    or deeply disturbing themes.
+
+    You MUST respond with ONLY a valid JSON object, no markdown formatting, \
+    no code fences, no explanation. Just the raw JSON.
+    """
+}
+
+func qualityInstructions(for level: ScriptQualityLevel) -> String {
+    switch level {
+    case .wellStructured:
+        return """
+        INSTRUCTIONS: Create a text with clean pyramid structure.
+        - Lead with the governing thought (conclusion first)
+        - Follow with 2-4 distinct support pillars, each with specific evidence
+        - Each support should be mutually exclusive and collectively exhaustive (MECE)
+        - The structure should be easy to extract — this is a model text
+        - Include a brief counterargument that is acknowledged and dismissed
+        """
+    case .buriedLead:
+        return """
+        INSTRUCTIONS: Create a text where the conclusion EXISTS but is BURIED.
+        - Start with background, context, statistics, or a story (1-2 paragraphs)
+        - Place the actual governing thought in paragraph 2 or 3
+        - The supporting arguments should be solid once the reader finds the thesis
+        - The text should feel like a newspaper feature or essay that builds up to its point
+        """
+    case .rambling:
+        return """
+        INSTRUCTIONS: Create a text with NO clear organizing structure.
+        - Good individual points but scattered without hierarchy
+        - Jump between subtopics without clear transitions
+        - Split related arguments across non-adjacent paragraphs
+        - Weak or non-committal conclusion
+        - Conversational, stream-of-consciousness style
+        """
+    case .adversarial:
+        return """
+        INSTRUCTIONS: Create a text that APPEARS well-structured but has a HIDDEN logical flaw.
+        - Surface structure should look like a clean pyramid
+        - Embed ONE subtle flaw: false_dichotomy, circular_reasoning, non_sequitur, \
+        hasty_generalization, straw_man, false_equivalence, appeal_to_authority, \
+        or correlation_as_causation
+        - The flaw should require careful reading to spot
+        - The text should be convincing on first read
+        """
+    }
+}
+
+func levelContext(for level: Int) -> String {
+    switch level {
+    case 1: return "LEVEL: L1 Plain Talk — simple language, 13-15 year olds."
+    case 2: return "LEVEL: L2 Order — moderate complexity, MECE grouping, 15-17 year olds."
+    case 3: return "LEVEL: L3 Architecture — complex arguments, university-level."
+    case 4: return "LEVEL: L4 Mastery — professional-grade complexity."
+    default: return "LEVEL: General audience."
+    }
+}
+
+func buildUserPrompt(quality: ScriptQualityLevel, domain: String, language: String, level: Int) -> String {
+    let languageName = language == "de" ? "German" : "English"
+    let flawField = quality == .adversarial ? """
+    ,
+        "structural_flaw": {
+          "type": "<flaw type>",
+          "description": "<what the flaw is>",
+          "location": "<where it occurs>"
+        }
+    """ : ""
+    let restructureField = quality == .rambling ? """
+    ,
+        "proposed_restructure": "<how to restructure into a proper pyramid>"
+    """ : ""
+
+    return """
+    Generate a practice text with these specs:
+
+    QUALITY: \(quality.rawValue)
+    \(qualityInstructions(for: quality))
+
+    DOMAIN: \(domain)
+    LANGUAGE: \(languageName)
+    \(levelContext(for: level))
+
+    LENGTH: 100-400 words
+
+    Respond with ONLY this JSON (no markdown):
+    {
+      "text": "<the text>",
+      "answer_key": {
+        "governing_thought": "<main conclusion>",
+        "supports": [
+          { "label": "<support label>", "evidence": ["<evidence>"] }
+        ],
+        "structural_assessment": "<analysis of structure>"\(flawField)\(restructureField)
+      },
+      "topic_domain": "\(domain)",
+      "difficulty_rating": <1-5>
+    }
+    """
+}
+
+// MARK: - API Call
+
+func callClaudeAPI(apiKey: String, model: String, systemPrompt: String, userPrompt: String) async throws -> String {
+    let url = URL(string: "https://api.anthropic.com/v1/messages")!
+    var request = URLRequest(url: url)
+    request.httpMethod = "POST"
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    request.setValue(apiKey, forHTTPHeaderField: "x-api-key")
+    request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
+    request.timeoutInterval = 120
+
+    let body: [String: Any] = [
+        "model": model,
+        "max_tokens": 4096,
+        "system": systemPrompt,
+        "messages": [["role": "user", "content": userPrompt]]
+    ]
+
+    request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+    let (data, response) = try await URLSession.shared.data(for: request)
+
+    guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+        let code = (response as? HTTPURLResponse)?.statusCode ?? -1
+        let body = String(data: data, encoding: .utf8) ?? "unknown"
+        throw NSError(domain: "API", code: code, userInfo: [NSLocalizedDescriptionKey: "API error (\(code)): \(body)"])
+    }
+
+    guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+          let content = json["content"] as? [[String: Any]],
+          let first = content.first,
+          let text = first["text"] as? String
+    else {
+        throw NSError(domain: "API", code: -1, userInfo: [NSLocalizedDescriptionKey: "Unexpected response format"])
+    }
+
+    return text
+}
+
+// MARK: - Output Writing
+
+func writeOutput(_ jsonString: String, id: String, language: String, outputDir: String) throws -> URL {
+    let fm = FileManager.default
+    let dirURL = URL(fileURLWithPath: outputDir)
+    try fm.createDirectory(at: dirURL, withIntermediateDirectories: true)
+
+    // Parse and re-serialize with the id and proper formatting
+    let cleaned = jsonString
+        .replacingOccurrences(of: "```json", with: "")
+        .replacingOccurrences(of: "```", with: "")
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+
+    guard let data = cleaned.data(using: .utf8),
+          var parsed = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+    else {
+        throw NSError(domain: "Parse", code: -1, userInfo: [NSLocalizedDescriptionKey: "Invalid JSON"])
+    }
+
+    // Add id and enrich metadata
+    parsed["id"] = id
+    if var meta = parsed["metadata"] as? [String: Any] {
+        meta["language"] = language
+        parsed["metadata"] = meta
+    } else {
+        // Build metadata from top-level fields
+        let text = parsed["text"] as? String ?? ""
+        let wordCount = text.split(separator: " ").count
+        let answerKey = parsed["answer_key"] as? [String: Any]
+
+        // Restructure to match PracticeText format
+        var output: [String: Any] = [
+            "id": id,
+            "text": text,
+            "answerKey": [
+                "governingThought": answerKey?["governing_thought"] ?? "",
+                "supports": (answerKey?["supports"] as? [[String: Any]])?.map { s in
+                    [
+                        "label": s["label"] ?? "",
+                        "evidence": s["evidence"] ?? []
+                    ] as [String: Any]
+                } ?? [],
+                "structuralAssessment": answerKey?["structural_assessment"] ?? ""
+            ] as [String: Any],
+            "metadata": [
+                "qualityLevel": parsed["quality_level"] ?? parsed["topic_domain"].map { _ in "" } ?? "",
+                "difficultyRating": parsed["difficulty_rating"] ?? 1,
+                "topicDomain": parsed["topic_domain"] ?? "",
+                "language": language,
+                "wordCount": wordCount,
+                "targetLevel": 1
+            ] as [String: Any]
+        ]
+
+        // Add optional fields to answer key
+        if var ak = output["answerKey"] as? [String: Any] {
+            if let flaw = answerKey?["structural_flaw"] {
+                ak["structuralFlaw"] = flaw
+            }
+            if let restructure = answerKey?["proposed_restructure"] {
+                ak["proposedRestructure"] = restructure
+            }
+            output["answerKey"] = ak
+        }
+
+        parsed = output
+    }
+
+    let outputData = try JSONSerialization.data(
+        withJSONObject: parsed,
+        options: [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+    )
+
+    let filename = "\(id).json"
+    let fileURL = dirURL.appendingPathComponent(filename)
+    try outputData.write(to: fileURL, options: .atomic)
+    return fileURL
+}
+
+// MARK: - Main
+
+func main() async {
+    let config = parseArgs()
+
+    guard !config.apiKey.isEmpty else {
+        print("ERROR: Set ANTHROPIC_API_KEY environment variable")
+        print("  ANTHROPIC_API_KEY=sk-... swift scripts/generate-practice-texts.swift")
+        exit(1)
+    }
+
+    let totalTexts = config.qualityLevels.count * config.languages.count
+        * config.domains.count * config.countPerCombination
+    print("Practice Text Generator")
+    print("=======================")
+    print("Quality levels: \(config.qualityLevels.map(\.rawValue).joined(separator: ", "))")
+    print("Languages: \(config.languages.joined(separator: ", "))")
+    print("Domains: \(config.domains.joined(separator: ", "))")
+    print("Level: \(config.targetLevel)")
+    print("Count per combination: \(config.countPerCombination)")
+    print("Total texts to generate: \(totalTexts)")
+    print("Output: \(config.outputDir)")
+    print("Model: \(config.model)")
+    print("ID range: \(config.idStart) - \(config.idStart + totalTexts - 1)")
+    print("")
+
+    var currentID = config.idStart
+    var successCount = 0
+    var failCount = 0
+
+    for quality in config.qualityLevels {
+        for domain in config.domains {
+            for language in config.languages {
+                for n in 1...config.countPerCombination {
+                    let id = String(format: "pt-%03d-%@", currentID, language)
+                    print("[\(currentID)] Generating \(quality.rawValue) / \(domain) / \(language) (\(n)/\(config.countPerCombination))...", terminator: " ")
+
+                    do {
+                        let sysPrompt = systemPrompt(
+                            qualityLevel: quality,
+                            language: language,
+                            wordRange: 100...400
+                        )
+                        let userPrompt = buildUserPrompt(
+                            quality: quality,
+                            domain: domain,
+                            language: language,
+                            level: config.targetLevel
+                        )
+
+                        let response = try await callClaudeAPI(
+                            apiKey: config.apiKey,
+                            model: config.model,
+                            systemPrompt: sysPrompt,
+                            userPrompt: userPrompt
+                        )
+
+                        let fileURL = try writeOutput(
+                            response,
+                            id: id,
+                            language: language,
+                            outputDir: config.outputDir
+                        )
+
+                        print("OK -> \(fileURL.lastPathComponent)")
+                        successCount += 1
+                    } catch {
+                        print("FAILED: \(error)")
+                        failCount += 1
+                    }
+
+                    currentID += 1
+
+                    // Rate limiting: 2 second pause between requests
+                    if currentID < config.idStart + totalTexts {
+                        try? await Task.sleep(nanoseconds: 2_000_000_000)
+                    }
+                }
+            }
+        }
+    }
+
+    print("")
+    print("Done! \(successCount) generated, \(failCount) failed.")
+    print("Review files in: \(config.outputDir)")
+    print("After review, move approved files to content/practice-texts/")
+}
+
+// Entry point
+Task {
+    await main()
+    exit(0)
+}
+
+RunLoop.main.run()


### PR DESCRIPTION
## Summary
- Add `PracticeText` model with `AnswerKey`, `SupportGroup`, `StructuralFlaw`, and `QualityLevel` enum in Content layer
- Add `PracticeTextGenerator` (Intelligence layer) for Claude API-driven text generation with quality-level-specific prompts
- Add `PracticeTextFileWriter` for writing generated texts to staging directory
- Add standalone batch script `scripts/generate-practice-texts.swift` with CLI options for quality, language, level, domain, count
- Support all four quality levels: well-structured, buried-lead, rambling, adversarial
- Answer key format includes `supports` array (label + evidence), `structuralFlaw` for adversarial, `proposedRestructure` for rambling
- 15 unit tests covering model codability, prompt construction, and config defaults

## Test plan
- [x] All 37 tests pass (15 new + 22 existing)
- [x] macOS build succeeds
- [ ] Manual: run `ANTHROPIC_API_KEY=... swift scripts/generate-practice-texts.swift --quality well-structured --language en --count 1` and verify JSON output
- [ ] Manual: review generated text quality for each quality level

Closes #41