### PR TITLE
feat: draggable pyramid block (SIR-065)

### DIFF
--- a/app/SayItRight/Presentation/PyramidBuilder/DraggableBlockView.swift
+++ b/app/SayItRight/Presentation/PyramidBuilder/DraggableBlockView.swift
@@ -1,0 +1,265 @@
+import SwiftUI
+
+// MARK: - Draggable Block View
+
+/// A draggable block for the pyramid builder canvas.
+///
+/// Displays a text snippet colour-coded by block type. Supports drag gesture
+/// with tactile feedback: lifts on pickup (scale + shadow), follows finger/cursor
+/// smoothly, and snaps back with spring animation when released.
+///
+/// The block reports drag state changes through its `onDragChanged` and
+/// `onDragEnded` callbacks so the parent canvas can handle drop zone logic.
+struct DraggableBlockView: View {
+    let block: PyramidBlock
+    var visualState: BlockVisualState = .idle
+
+    /// Called continuously during drag with the current translation.
+    var onDragChanged: ((DragGesture.Value) -> Void)?
+    /// Called when the drag ends with the final translation.
+    var onDragEnded: ((DragGesture.Value) -> Void)?
+
+    @State private var dragOffset: CGSize = .zero
+    @State private var isDragging: Bool = false
+
+    // MARK: - Body
+
+    var body: some View {
+        blockContent
+            .offset(dragOffset)
+            .scaleEffect(currentScale)
+            .shadow(
+                color: .black.opacity(shadowOpacity),
+                radius: shadowRadius,
+                x: 0,
+                y: shadowRadius / 2
+            )
+            .zIndex(isDragging ? 1000 : 0)
+            .gesture(dragGesture)
+            .animation(.spring(response: 0.3, dampingFraction: 0.7), value: isDragging)
+            .animation(.spring(response: 0.3, dampingFraction: 0.7), value: dragOffset)
+            .accessibilityLabel(block.text)
+            .accessibilityHint("Draggable block. \(block.type.label).")
+            .accessibilityAddTraits(.isButton)
+    }
+
+    // MARK: - Block Content
+
+    private var blockContent: some View {
+        Text(block.text)
+            .font(.subheadline)
+            .fontWeight(.medium)
+            .foregroundStyle(.white)
+            .multilineTextAlignment(.center)
+            .lineLimit(3)
+            .padding(.horizontal, BlockDimensions.horizontalPadding)
+            .padding(.vertical, BlockDimensions.verticalPadding)
+            .frame(
+                minWidth: BlockDimensions.minWidth,
+                maxWidth: BlockDimensions.maxWidth,
+                minHeight: BlockDimensions.minHeight,
+                maxHeight: BlockDimensions.maxHeight
+            )
+            .background(backgroundShape)
+            .overlay(borderOverlay)
+    }
+
+    // MARK: - Background & Border
+
+    private var backgroundShape: some View {
+        RoundedRectangle(cornerRadius: BlockDimensions.cornerRadius)
+            .fill(blockColor)
+    }
+
+    private var borderOverlay: some View {
+        RoundedRectangle(cornerRadius: BlockDimensions.cornerRadius)
+            .strokeBorder(borderColor, lineWidth: borderWidth)
+    }
+
+    // MARK: - Drag Gesture
+
+    private var dragGesture: some Gesture {
+        DragGesture(coordinateSpace: .global)
+            .onChanged { value in
+                isDragging = true
+                dragOffset = value.translation
+                onDragChanged?(value)
+            }
+            .onEnded { value in
+                isDragging = false
+                onDragEnded?(value)
+                // Snap back — parent can override position if dropped in valid zone.
+                dragOffset = .zero
+            }
+    }
+
+    // MARK: - Visual State Properties
+
+    private var effectiveState: BlockVisualState {
+        isDragging ? .dragging : visualState
+    }
+
+    private var currentScale: CGFloat {
+        switch effectiveState {
+        case .idle: 1.0
+        case .hovering: 1.02
+        case .dragging: 1.05
+        case .placed: 1.0
+        case .error: 1.0
+        }
+    }
+
+    private var shadowOpacity: Double {
+        switch effectiveState {
+        case .idle: 0.08
+        case .hovering: 0.12
+        case .dragging: 0.25
+        case .placed: 0.06
+        case .error: 0.08
+        }
+    }
+
+    private var shadowRadius: CGFloat {
+        switch effectiveState {
+        case .idle: 2
+        case .hovering: 4
+        case .dragging: 12
+        case .placed: 1
+        case .error: 2
+        }
+    }
+
+    private var blockColor: Color {
+        switch effectiveState {
+        case .error: Color.red.opacity(0.7)
+        default: block.type.color
+        }
+    }
+
+    private var borderColor: Color {
+        switch effectiveState {
+        case .idle: .white.opacity(0.15)
+        case .hovering: .white.opacity(0.3)
+        case .dragging: .white.opacity(0.4)
+        case .placed: .white.opacity(0.2)
+        case .error: .red
+        }
+    }
+
+    private var borderWidth: CGFloat {
+        switch effectiveState {
+        case .error: 2
+        default: 1
+        }
+    }
+}
+
+// MARK: - Previews
+
+#Preview("All Block Types — Idle") {
+    VStack(spacing: 16) {
+        ForEach(BlockType.allCases, id: \.rawValue) { type in
+            DraggableBlockView(
+                block: PyramidBlock(
+                    text: type.label,
+                    type: type
+                )
+            )
+        }
+    }
+    .padding()
+    .background(Color.clear)
+}
+
+#Preview("Text Length Variations") {
+    VStack(spacing: 16) {
+        DraggableBlockView(
+            block: PyramidBlock(text: "Short", type: .governingThought)
+        )
+        DraggableBlockView(
+            block: PyramidBlock(text: "Medium length claim here", type: .supportPoint)
+        )
+        DraggableBlockView(
+            block: PyramidBlock(
+                text: "This is a longer piece of evidence that should wrap to multiple lines",
+                type: .evidence
+            )
+        )
+    }
+    .padding()
+}
+
+#Preview("All Visual States") {
+    DraggableBlockVisualStatesPreview()
+}
+
+/// Shows every visual state side by side for design review.
+private struct DraggableBlockVisualStatesPreview: View {
+    private let states: [(String, BlockVisualState)] = [
+        ("Idle", .idle),
+        ("Hovering", .hovering),
+        ("Dragging", .dragging),
+        ("Placed", .placed),
+        ("Error", .error),
+    ]
+
+    var body: some View {
+        VStack(spacing: 20) {
+            ForEach(states, id: \.0) { label, state in
+                VStack(spacing: 4) {
+                    Text(label)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    DraggableBlockView(
+                        block: PyramidBlock(
+                            text: "Climate policy requires action",
+                            type: .governingThought
+                        ),
+                        visualState: state
+                    )
+                }
+            }
+        }
+        .padding(32)
+    }
+}
+
+#Preview("Interactive Drag") {
+    DraggableBlockInteractivePreview()
+}
+
+/// Interactive preview to test drag behaviour.
+private struct DraggableBlockInteractivePreview: View {
+    @State private var statusText = "Drag a block to see it in action"
+
+    var body: some View {
+        VStack(spacing: 32) {
+            Text(statusText)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            DraggableBlockView(
+                block: PyramidBlock(
+                    text: "Drag me around!",
+                    type: .supportPoint
+                ),
+                onDragChanged: { value in
+                    let x = Int(value.translation.width)
+                    let y = Int(value.translation.height)
+                    statusText = "Dragging: (\(x), \(y))"
+                },
+                onDragEnded: { _ in
+                    statusText = "Dropped — snapped back"
+                }
+            )
+
+            DraggableBlockView(
+                block: PyramidBlock(
+                    text: "Me too!",
+                    type: .evidence
+                )
+            )
+        }
+        .padding(40)
+    }
+}

--- a/app/SayItRight/Presentation/PyramidBuilder/PyramidBlock.swift
+++ b/app/SayItRight/Presentation/PyramidBuilder/PyramidBlock.swift
@@ -1,0 +1,74 @@
+import Foundation
+import SwiftUI
+
+// MARK: - Block Type
+
+/// The structural role a block plays in the pyramid.
+enum BlockType: String, Sendable, CaseIterable, Codable {
+    case governingThought
+    case supportPoint
+    case evidence
+
+    /// Display colour for each block type.
+    var color: Color {
+        switch self {
+        case .governingThought: Color(red: 0.20, green: 0.45, blue: 0.75) // deep blue
+        case .supportPoint: Color(red: 0.30, green: 0.65, blue: 0.50)     // teal green
+        case .evidence: Color(red: 0.55, green: 0.55, blue: 0.65)         // slate grey
+        }
+    }
+
+    /// Human-readable label.
+    var label: String {
+        switch self {
+        case .governingThought: "Governing Thought"
+        case .supportPoint: "Support Point"
+        case .evidence: "Evidence"
+        }
+    }
+}
+
+// MARK: - Block Visual State
+
+/// Visual state of a draggable block.
+enum BlockVisualState: Sendable, Equatable {
+    case idle
+    case hovering
+    case dragging
+    case placed
+    case error
+}
+
+// MARK: - Pyramid Block
+
+/// The model for a single draggable block in the pyramid builder.
+///
+/// Each block holds a text snippet (claim, support point, or evidence)
+/// and metadata about its type and assigned level in the pyramid.
+struct PyramidBlock: Identifiable, Sendable, Equatable, Codable {
+    let id: UUID
+    let text: String
+    let type: BlockType
+    /// The pyramid level this block is assigned to, if placed.
+    var level: Int?
+
+    init(id: UUID = UUID(), text: String, type: BlockType, level: Int? = nil) {
+        self.id = id
+        self.text = text
+        self.type = type
+        self.level = level
+    }
+}
+
+// MARK: - Block Dimensions
+
+/// Constants controlling block sizing.
+enum BlockDimensions {
+    static let minWidth: CGFloat = 120
+    static let maxWidth: CGFloat = 300
+    static let minHeight: CGFloat = 44
+    static let maxHeight: CGFloat = 120
+    static let horizontalPadding: CGFloat = 16
+    static let verticalPadding: CGFloat = 10
+    static let cornerRadius: CGFloat = 12
+}

--- a/app/SayItRight/Tests/PyramidBlockTests.swift
+++ b/app/SayItRight/Tests/PyramidBlockTests.swift
@@ -1,0 +1,113 @@
+import Testing
+import Foundation
+@testable import SayItRight
+
+@Suite("PyramidBlock")
+struct PyramidBlockTests {
+
+    // MARK: - Block Creation
+
+    @Test func blockCreatedWithDefaults() {
+        let block = PyramidBlock(text: "Test claim", type: .governingThought)
+
+        #expect(block.text == "Test claim")
+        #expect(block.type == .governingThought)
+        #expect(block.level == nil)
+    }
+
+    @Test func blockCreatedWithLevel() {
+        let block = PyramidBlock(text: "Evidence", type: .evidence, level: 2)
+
+        #expect(block.level == 2)
+        #expect(block.type == .evidence)
+    }
+
+    @Test func blockHasUniqueId() {
+        let a = PyramidBlock(text: "A", type: .supportPoint)
+        let b = PyramidBlock(text: "A", type: .supportPoint)
+
+        #expect(a.id != b.id)
+    }
+
+    @Test func blockWithExplicitId() {
+        let id = UUID()
+        let block = PyramidBlock(id: id, text: "Custom ID", type: .evidence)
+
+        #expect(block.id == id)
+    }
+
+    // MARK: - Block Type
+
+    @Test func allBlockTypesHaveDistinctLabels() {
+        let labels = BlockType.allCases.map(\.label)
+        let uniqueLabels = Set(labels)
+
+        #expect(labels.count == uniqueLabels.count)
+    }
+
+    @Test func allBlockTypesExist() {
+        #expect(BlockType.allCases.count == 3)
+        #expect(BlockType.allCases.contains(.governingThought))
+        #expect(BlockType.allCases.contains(.supportPoint))
+        #expect(BlockType.allCases.contains(.evidence))
+    }
+
+    // MARK: - Equatable
+
+    @Test func blocksWithSameIdAreEqual() {
+        let id = UUID()
+        let a = PyramidBlock(id: id, text: "Same", type: .supportPoint)
+        let b = PyramidBlock(id: id, text: "Same", type: .supportPoint)
+
+        #expect(a == b)
+    }
+
+    @Test func blocksWithDifferentIdsAreNotEqual() {
+        let a = PyramidBlock(text: "Same text", type: .supportPoint)
+        let b = PyramidBlock(text: "Same text", type: .supportPoint)
+
+        #expect(a != b)
+    }
+
+    // MARK: - Codable
+
+    @Test func blockRoundTripsThroughJSON() throws {
+        let original = PyramidBlock(text: "Encode me", type: .governingThought, level: 0)
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(PyramidBlock.self, from: data)
+
+        #expect(decoded == original)
+        #expect(decoded.text == "Encode me")
+        #expect(decoded.type == .governingThought)
+        #expect(decoded.level == 0)
+    }
+
+    @Test func blockTypeRoundTripsThroughJSON() throws {
+        for blockType in BlockType.allCases {
+            let data = try JSONEncoder().encode(blockType)
+            let decoded = try JSONDecoder().decode(BlockType.self, from: data)
+            #expect(decoded == blockType)
+        }
+    }
+
+    // MARK: - Block Dimensions
+
+    @Test func dimensionConstraintsAreReasonable() {
+        #expect(BlockDimensions.minWidth > 0)
+        #expect(BlockDimensions.maxWidth > BlockDimensions.minWidth)
+        #expect(BlockDimensions.minHeight > 0)
+        #expect(BlockDimensions.maxHeight > BlockDimensions.minHeight)
+        #expect(BlockDimensions.cornerRadius > 0)
+    }
+
+    // MARK: - Visual State
+
+    @Test func allVisualStatesAreDistinct() {
+        let states: [BlockVisualState] = [.idle, .hovering, .dragging, .placed, .error]
+        for i in 0..<states.count {
+            for j in (i + 1)..<states.count {
+                #expect(states[i] != states[j])
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `PyramidBlock` model with `BlockType` (governing thought, support point, evidence), `BlockVisualState` (idle, hovering, dragging, placed, error), and `BlockDimensions` constants
- Add `DraggableBlockView` with `DragGesture`-based interaction: 1.05x scale + shadow lift on pickup, smooth following during drag, spring snap-back on release
- Colour-coded blocks by structural role, with error state override
- VoiceOver accessibility labels and hints on all blocks
- 12 unit tests covering model creation, equality, Codable round-trip, dimension constraints

## Test plan
- [x] All 71 tests pass (including 12 new PyramidBlock tests)
- [x] macOS build succeeds
- [ ] Verify SwiftUI previews render all visual states correctly
- [ ] Test drag interaction in interactive preview on iPad simulator
- [ ] Confirm VoiceOver reads block text and type

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)