### PR TITLE
SIR-066: Drop zone system for pyramid builder

### DIFF
--- a/app/SayItRight/Presentation/PyramidBuilder/DropZone.swift
+++ b/app/SayItRight/Presentation/PyramidBuilder/DropZone.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+// MARK: - Drop Zone
+
+/// Represents a valid placement position in the pyramid tree.
+///
+/// Drop zones are computed from the current tree state. Each zone identifies
+/// where a new child block could be inserted — under which parent, at which
+/// child index, and at what canvas position.
+struct DropZone: Identifiable, Sendable, Equatable {
+    let id: String
+    /// The node ID of the parent this zone belongs to.
+    let parentID: String
+    /// The child index at which a block would be inserted.
+    let childIndex: Int
+    /// The centre point of the drop zone in canvas coordinates.
+    let center: CGPoint
+    /// The size of the drop zone target area.
+    let size: CGSize
+
+    var frame: CGRect {
+        CGRect(
+            x: center.x - size.width / 2,
+            y: center.y - size.height / 2,
+            width: size.width,
+            height: size.height
+        )
+    }
+}
+
+// MARK: - Drop Zone State
+
+/// Visual state of a drop zone during drag interaction.
+enum DropZoneVisualState: Sendable, Equatable {
+    /// Zone is visible but not targeted.
+    case available
+    /// A dragged block is hovering within proximity.
+    case highlighted
+}
+
+// MARK: - Drop Zone Configuration
+
+/// Configurable parameters for drop zone proximity detection.
+struct DropZoneConfiguration: Sendable {
+    /// Maximum distance (in points) from a dragged block centre to a drop zone
+    /// centre for the zone to be considered a valid target.
+    var snapDistance: CGFloat = 80
+
+    /// Size of drop zone indicator.
+    var zoneSize: CGSize = CGSize(width: 140, height: 50)
+
+    static let `default` = DropZoneConfiguration()
+}

--- a/app/SayItRight/Presentation/PyramidBuilder/DropZoneView.swift
+++ b/app/SayItRight/Presentation/PyramidBuilder/DropZoneView.swift
@@ -1,0 +1,248 @@
+import SwiftUI
+
+// MARK: - Drop Zone View
+
+/// Visual indicator for a valid drop position in the pyramid tree.
+///
+/// Renders as a dashed-border rounded rectangle that pulses when highlighted.
+/// When a block is being dragged, drop zones appear at valid placement positions.
+/// The nearest zone within snap distance highlights to signal it will accept the drop.
+struct DropZoneView: View {
+    let zone: DropZone
+    var visualState: DropZoneVisualState = .available
+
+    var body: some View {
+        RoundedRectangle(cornerRadius: BlockDimensions.cornerRadius)
+            .strokeBorder(
+                style: StrokeStyle(lineWidth: borderWidth, dash: [8, 4])
+            )
+            .foregroundStyle(borderColor)
+            .background(
+                RoundedRectangle(cornerRadius: BlockDimensions.cornerRadius)
+                    .fill(fillColor)
+            )
+            .frame(width: zone.size.width, height: zone.size.height)
+            .scaleEffect(visualState == .highlighted ? 1.05 : 1.0)
+            .opacity(opacity)
+            .animation(.easeInOut(duration: 0.2), value: visualState)
+            .accessibilityLabel("Drop zone")
+            .accessibilityHint(
+                visualState == .highlighted
+                    ? "Release to place block here"
+                    : "Drag a block here to place it"
+            )
+    }
+
+    // MARK: - Visual Properties
+
+    private var borderColor: Color {
+        switch visualState {
+        case .available:
+            Color.secondary.opacity(0.5)
+        case .highlighted:
+            Color.accentColor
+        }
+    }
+
+    private var fillColor: Color {
+        switch visualState {
+        case .available:
+            Color.secondary.opacity(0.05)
+        case .highlighted:
+            Color.accentColor.opacity(0.15)
+        }
+    }
+
+    private var borderWidth: CGFloat {
+        switch visualState {
+        case .available: 1.5
+        case .highlighted: 2.5
+        }
+    }
+
+    private var opacity: Double {
+        switch visualState {
+        case .available: 0.6
+        case .highlighted: 1.0
+        }
+    }
+}
+
+// MARK: - Drop Zone Overlay
+
+/// Overlay that renders all active drop zones on the pyramid canvas.
+///
+/// Use this as an overlay on the canvas view. It positions each drop zone
+/// at its computed canvas coordinates and applies highlighting based on
+/// the currently highlighted zone ID.
+struct DropZoneOverlay: View {
+    let zones: [DropZone]
+    let highlightedZoneID: String?
+
+    var body: some View {
+        ZStack {
+            ForEach(zones) { zone in
+                DropZoneView(
+                    zone: zone,
+                    visualState: zone.id == highlightedZoneID ? .highlighted : .available
+                )
+                .position(zone.center)
+            }
+        }
+    }
+}
+
+// MARK: - Unplaced Blocks Pool
+
+/// A container displaying the blocks that have not yet been placed in the tree.
+///
+/// On iPad this appears as a sidebar; on Mac as a top bar.
+/// Blocks can be dragged from here onto the pyramid canvas.
+struct UnplacedBlocksPool: View {
+    let blocks: [PyramidBlock]
+    var onDragChanged: ((PyramidBlock, DragGesture.Value) -> Void)?
+    var onDragEnded: ((PyramidBlock, DragGesture.Value) -> Void)?
+
+    var body: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 12) {
+                ForEach(blocks) { block in
+                    DraggableBlockView(
+                        block: block,
+                        onDragChanged: { value in
+                            onDragChanged?(block, value)
+                        },
+                        onDragEnded: { value in
+                            onDragEnded?(block, value)
+                        }
+                    )
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 8)
+        }
+        .background(
+            RoundedRectangle(cornerRadius: 16)
+                .fill(.ultraThinMaterial)
+        )
+    }
+}
+
+// MARK: - Previews
+
+#Preview("Drop Zone — Available") {
+    DropZoneView(
+        zone: DropZone(
+            id: "preview-zone",
+            parentID: "root",
+            childIndex: 0,
+            center: CGPoint(x: 200, y: 150),
+            size: CGSize(width: 140, height: 50)
+        ),
+        visualState: .available
+    )
+    .padding(40)
+}
+
+#Preview("Drop Zone — Highlighted") {
+    DropZoneView(
+        zone: DropZone(
+            id: "preview-zone",
+            parentID: "root",
+            childIndex: 0,
+            center: CGPoint(x: 200, y: 150),
+            size: CGSize(width: 140, height: 50)
+        ),
+        visualState: .highlighted
+    )
+    .padding(40)
+}
+
+#Preview("Drop Zone States Side by Side") {
+    DropZoneStatesPreview()
+}
+
+/// Shows both visual states for design review.
+private struct DropZoneStatesPreview: View {
+    var body: some View {
+        HStack(spacing: 32) {
+            VStack(spacing: 8) {
+                Text("Available").font(.caption).foregroundStyle(.secondary)
+                DropZoneView(
+                    zone: DropZone(
+                        id: "a",
+                        parentID: "root",
+                        childIndex: 0,
+                        center: .zero,
+                        size: CGSize(width: 140, height: 50)
+                    ),
+                    visualState: .available
+                )
+            }
+            VStack(spacing: 8) {
+                Text("Highlighted").font(.caption).foregroundStyle(.secondary)
+                DropZoneView(
+                    zone: DropZone(
+                        id: "b",
+                        parentID: "root",
+                        childIndex: 0,
+                        center: .zero,
+                        size: CGSize(width: 140, height: 50)
+                    ),
+                    visualState: .highlighted
+                )
+            }
+        }
+        .padding(40)
+    }
+}
+
+#Preview("Drop Zone Overlay") {
+    DropZoneOverlayPreview()
+}
+
+/// Preview showing multiple drop zones on a canvas.
+private struct DropZoneOverlayPreview: View {
+    var body: some View {
+        ZStack {
+            Color(white: 0.95)
+            DropZoneOverlay(
+                zones: [
+                    DropZone(
+                        id: "z1",
+                        parentID: "root",
+                        childIndex: 0,
+                        center: CGPoint(x: 200, y: 100),
+                        size: CGSize(width: 140, height: 50)
+                    ),
+                    DropZone(
+                        id: "z2",
+                        parentID: "root",
+                        childIndex: 1,
+                        center: CGPoint(x: 400, y: 100),
+                        size: CGSize(width: 140, height: 50)
+                    ),
+                    DropZone(
+                        id: "z3",
+                        parentID: "child1",
+                        childIndex: 0,
+                        center: CGPoint(x: 200, y: 220),
+                        size: CGSize(width: 140, height: 50)
+                    ),
+                ],
+                highlightedZoneID: "z2"
+            )
+        }
+        .frame(width: 600, height: 400)
+    }
+}
+
+#Preview("Unplaced Blocks Pool") {
+    UnplacedBlocksPool(blocks: [
+        PyramidBlock(text: "Climate change is urgent", type: .governingThought),
+        PyramidBlock(text: "Rising temperatures", type: .supportPoint),
+        PyramidBlock(text: "Arctic ice melting", type: .evidence),
+        PyramidBlock(text: "Economic impact", type: .supportPoint),
+    ])
+    .padding()
+}

--- a/app/SayItRight/Presentation/PyramidBuilder/PyramidTreeState.swift
+++ b/app/SayItRight/Presentation/PyramidBuilder/PyramidTreeState.swift
@@ -1,0 +1,349 @@
+import Foundation
+import SwiftUI
+
+// MARK: - Placed Block
+
+/// A block that has been placed in the pyramid tree.
+struct PlacedBlock: Identifiable, Sendable, Equatable {
+    let id: UUID
+    let block: PyramidBlock
+    /// The parent block's ID, or nil if this is the root.
+    var parentID: UUID?
+    /// Ordered child IDs.
+    var childIDs: [UUID]
+
+    init(block: PyramidBlock, parentID: UUID? = nil, childIDs: [UUID] = []) {
+        self.id = block.id
+        self.block = block
+        self.parentID = parentID
+        self.childIDs = childIDs
+    }
+}
+
+// MARK: - Pyramid Tree State
+
+/// Observable state managing the pyramid tree: placed blocks, unplaced pool,
+/// drop zone computation, and drag-drop interactions.
+///
+/// This is the central model that ties together the tree layout engine,
+/// drop zones, and block placement logic.
+@MainActor
+@Observable
+final class PyramidTreeState {
+
+    // MARK: - Properties
+
+    /// Blocks that have been placed in the tree, keyed by ID.
+    private(set) var placedBlocks: [UUID: PlacedBlock] = [:]
+
+    /// Blocks not yet placed in the tree (the unplaced pool).
+    private(set) var unplacedBlocks: [PyramidBlock] = []
+
+    /// The ID of the root block, if one has been placed.
+    private(set) var rootBlockID: UUID?
+
+    /// Currently computed drop zones based on tree state.
+    private(set) var dropZones: [DropZone] = []
+
+    /// The drop zone currently highlighted (nearest to dragged block).
+    private(set) var highlightedZoneID: String?
+
+    /// Whether a drag is in progress.
+    private(set) var isDragging: Bool = false
+
+    /// The ID of the block currently being dragged, if any.
+    private(set) var draggedBlockID: UUID?
+
+    /// Drop zone configuration (snap distance, zone size).
+    var configuration: DropZoneConfiguration = .default
+
+    /// Layout engine for computing positions.
+    var layoutEngine: TreeLayoutEngine = TreeLayoutEngine()
+
+    /// Canvas size for layout computation.
+    var canvasSize: CGSize = CGSize(width: 800, height: 600)
+
+    /// Computed layout for placed blocks.
+    private(set) var nodeLayouts: [String: NodeLayout] = [:]
+
+    // MARK: - Initialisation
+
+    init(blocks: [PyramidBlock] = []) {
+        self.unplacedBlocks = blocks
+    }
+
+    // MARK: - Tree Construction
+
+    /// Build a TreeNode hierarchy from placed blocks, starting at the given root.
+    func buildTreeNode(from blockID: UUID) -> TreeNode? {
+        guard let placed = placedBlocks[blockID] else { return nil }
+        let children = placed.childIDs.compactMap { buildTreeNode(from: $0) }
+        return TreeNode(
+            id: blockID.uuidString,
+            size: CGSize(width: 160, height: 60),
+            children: children
+        )
+    }
+
+    /// Recompute layout and drop zones after any tree mutation.
+    func recomputeLayout() {
+        guard let rootID = rootBlockID,
+              let rootNode = buildTreeNode(from: rootID) else {
+            nodeLayouts = [:]
+            dropZones = computeDropZonesForEmptyTree()
+            return
+        }
+
+        nodeLayouts = layoutEngine.layout(root: rootNode, in: canvasSize)
+        dropZones = computeDropZones(root: rootID)
+    }
+
+    // MARK: - Block Placement
+
+    /// Place a block as the root of the tree.
+    func placeAsRoot(_ block: PyramidBlock) {
+        guard rootBlockID == nil else { return }
+        let placed = PlacedBlock(block: block, parentID: nil)
+        placedBlocks[block.id] = placed
+        rootBlockID = block.id
+        removeFromUnplaced(block.id)
+        recomputeLayout()
+    }
+
+    /// Place a block as a child of the given parent at the specified index.
+    func placeBlock(_ block: PyramidBlock, underParent parentID: UUID, atIndex index: Int) {
+        guard var parent = placedBlocks[parentID] else { return }
+
+        // Prevent duplicate placement.
+        guard placedBlocks[block.id] == nil else { return }
+
+        let placed = PlacedBlock(block: block, parentID: parentID)
+        placedBlocks[block.id] = placed
+
+        let clampedIndex = min(index, parent.childIDs.count)
+        parent.childIDs.insert(block.id, at: clampedIndex)
+        placedBlocks[parentID] = parent
+
+        removeFromUnplaced(block.id)
+        recomputeLayout()
+    }
+
+    /// Remove a block from the tree and return it (and all descendants) to the unplaced pool.
+    func removeBlock(_ blockID: UUID) {
+        guard let placed = placedBlocks[blockID] else { return }
+
+        // Collect all descendant IDs (depth-first).
+        let descendantIDs = collectDescendants(of: blockID)
+
+        // Remove from parent's child list.
+        if let parentID = placed.parentID, var parent = placedBlocks[parentID] {
+            parent.childIDs.removeAll { $0 == blockID }
+            placedBlocks[parentID] = parent
+        }
+
+        // If removing root, clear rootBlockID.
+        if blockID == rootBlockID {
+            rootBlockID = nil
+        }
+
+        // Move block and all descendants to unplaced pool.
+        let allIDs = [blockID] + descendantIDs
+        for id in allIDs {
+            if let removed = placedBlocks.removeValue(forKey: id) {
+                unplacedBlocks.append(removed.block)
+            }
+        }
+
+        recomputeLayout()
+    }
+
+    /// Move a placed block to a different parent (reparenting).
+    func reparentBlock(_ blockID: UUID, toParent newParentID: UUID, atIndex index: Int) {
+        guard let placed = placedBlocks[blockID] else { return }
+        guard newParentID != blockID else { return }
+
+        // Prevent circular reparenting: newParent must not be a descendant of blockID.
+        let descendants = collectDescendants(of: blockID)
+        guard !descendants.contains(newParentID) else { return }
+
+        // Remove from old parent.
+        if let oldParentID = placed.parentID, var oldParent = placedBlocks[oldParentID] {
+            oldParent.childIDs.removeAll { $0 == blockID }
+            placedBlocks[oldParentID] = oldParent
+        }
+
+        // Add to new parent.
+        var newParent = placedBlocks[newParentID]!
+        let clampedIndex = min(index, newParent.childIDs.count)
+        newParent.childIDs.insert(blockID, at: clampedIndex)
+        placedBlocks[newParentID] = newParent
+
+        // Update the block's parentID.
+        var updatedBlock = placed
+        updatedBlock.parentID = newParentID
+        placedBlocks[blockID] = updatedBlock
+
+        recomputeLayout()
+    }
+
+    // MARK: - Drag Interaction
+
+    /// Begin a drag interaction for the given block.
+    func beginDrag(blockID: UUID) {
+        isDragging = true
+        draggedBlockID = blockID
+        // Show drop zones during drag.
+        if dropZones.isEmpty {
+            recomputeLayout()
+        }
+    }
+
+    /// Update drag position and highlight the nearest valid drop zone.
+    func updateDrag(position: CGPoint) {
+        highlightedZoneID = nearestZone(to: position)?.id
+    }
+
+    /// End the drag interaction.
+    ///
+    /// - Parameter position: The final position of the dragged block centre.
+    /// - Returns: The drop zone the block was dropped on, or nil if outside all zones.
+    @discardableResult
+    func endDrag(position: CGPoint) -> DropZone? {
+        let zone = nearestZone(to: position)
+        isDragging = false
+        highlightedZoneID = nil
+
+        guard let zone = zone, let draggedID = draggedBlockID else {
+            // Dropped outside — handle return to pool if block was placed.
+            if let draggedID = draggedBlockID, placedBlocks[draggedID] != nil {
+                removeBlock(draggedID)
+            }
+            draggedBlockID = nil
+            return nil
+        }
+
+        // Determine if this is a new placement, or a reparent.
+        if let draggedBlock = unplacedBlocks.first(where: { $0.id == draggedID }) {
+            // New placement from unplaced pool.
+            if zone.parentID == "root" {
+                placeAsRoot(draggedBlock)
+            } else if let parentUUID = UUID(uuidString: zone.parentID) {
+                placeBlock(draggedBlock, underParent: parentUUID, atIndex: zone.childIndex)
+            }
+        } else if placedBlocks[draggedID] != nil {
+            // Reparenting an already-placed block.
+            if let parentUUID = UUID(uuidString: zone.parentID) {
+                reparentBlock(draggedID, toParent: parentUUID, atIndex: zone.childIndex)
+            }
+        }
+
+        draggedBlockID = nil
+        return zone
+    }
+
+    // MARK: - Drop Zone Computation
+
+    /// Compute drop zones for an empty tree (just a single root zone).
+    private func computeDropZonesForEmptyTree() -> [DropZone] {
+        let rootCenter = CGPoint(x: canvasSize.width / 2, y: 50)
+        return [
+            DropZone(
+                id: "root-zone",
+                parentID: "root",
+                childIndex: 0,
+                center: rootCenter,
+                size: configuration.zoneSize
+            )
+        ]
+    }
+
+    /// Compute drop zones based on current tree state.
+    ///
+    /// For each placed node, zones are created for adding a new child after
+    /// the existing children. This uses the layout engine to determine positions.
+    private func computeDropZones(root rootID: UUID) -> [DropZone] {
+        var zones: [DropZone] = []
+        computeDropZonesRecursive(nodeID: rootID, zones: &zones)
+        return zones
+    }
+
+    private func computeDropZonesRecursive(nodeID: UUID, zones: inout [DropZone]) {
+        guard let placed = placedBlocks[nodeID],
+              let layout = nodeLayouts[nodeID.uuidString] else { return }
+
+        // Zone for adding a new child to this node.
+        let childCount = placed.childIDs.count
+        let childY = layout.center.y + layout.size.height / 2
+            + layoutEngine.verticalSpacing + configuration.zoneSize.height / 2
+
+        if childCount == 0 {
+            // Single zone directly below parent.
+            let zone = DropZone(
+                id: "zone-\(nodeID.uuidString)-child-0",
+                parentID: nodeID.uuidString,
+                childIndex: 0,
+                center: CGPoint(x: layout.center.x, y: childY),
+                size: configuration.zoneSize
+            )
+            zones.append(zone)
+        } else {
+            // Zone after the last child.
+            if let lastChildID = placed.childIDs.last,
+               let lastChildLayout = nodeLayouts[lastChildID.uuidString] {
+                let newX = lastChildLayout.center.x + lastChildLayout.size.width / 2
+                    + layoutEngine.horizontalSpacing + configuration.zoneSize.width / 2
+                let zone = DropZone(
+                    id: "zone-\(nodeID.uuidString)-child-\(childCount)",
+                    parentID: nodeID.uuidString,
+                    childIndex: childCount,
+                    center: CGPoint(x: newX, y: lastChildLayout.center.y),
+                    size: configuration.zoneSize
+                )
+                zones.append(zone)
+            }
+        }
+
+        // Recurse into children to create zones for sub-levels.
+        for childID in placed.childIDs {
+            computeDropZonesRecursive(nodeID: childID, zones: &zones)
+        }
+    }
+
+    // MARK: - Proximity Detection
+
+    /// Find the nearest drop zone within snap distance.
+    func nearestZone(to point: CGPoint) -> DropZone? {
+        var closest: DropZone?
+        var closestDistance: CGFloat = .infinity
+
+        for zone in dropZones {
+            let dx = point.x - zone.center.x
+            let dy = point.y - zone.center.y
+            let distance = sqrt(dx * dx + dy * dy)
+
+            if distance < configuration.snapDistance && distance < closestDistance {
+                closest = zone
+                closestDistance = distance
+            }
+        }
+
+        return closest
+    }
+
+    // MARK: - Helpers
+
+    private func removeFromUnplaced(_ blockID: UUID) {
+        unplacedBlocks.removeAll { $0.id == blockID }
+    }
+
+    /// Collect all descendant IDs of a node (not including the node itself).
+    private func collectDescendants(of blockID: UUID) -> [UUID] {
+        guard let placed = placedBlocks[blockID] else { return [] }
+        var result: [UUID] = []
+        for childID in placed.childIDs {
+            result.append(childID)
+            result.append(contentsOf: collectDescendants(of: childID))
+        }
+        return result
+    }
+}

--- a/app/SayItRight/Tests/DropZoneTests.swift
+++ b/app/SayItRight/Tests/DropZoneTests.swift
@@ -1,0 +1,330 @@
+import Testing
+import Foundation
+@testable import SayItRight
+
+// MARK: - Drop Zone Model Tests
+
+@Suite("DropZone Model")
+struct DropZoneModelTests {
+
+    @Test("frame computes correctly from centre and size")
+    func frameComputation() {
+        let zone = DropZone(
+            id: "test",
+            parentID: "parent",
+            childIndex: 0,
+            center: CGPoint(x: 200, y: 100),
+            size: CGSize(width: 140, height: 50)
+        )
+
+        #expect(zone.frame.origin.x == 130)
+        #expect(zone.frame.origin.y == 75)
+        #expect(zone.frame.width == 140)
+        #expect(zone.frame.height == 50)
+    }
+
+    @Test("default configuration has reasonable snap distance")
+    func defaultConfiguration() {
+        let config = DropZoneConfiguration.default
+        #expect(config.snapDistance == 80)
+        #expect(config.zoneSize.width == 140)
+        #expect(config.zoneSize.height == 50)
+    }
+}
+
+// MARK: - Pyramid Tree State Tests
+
+@Suite("PyramidTreeState")
+struct PyramidTreeStateTests {
+
+    @MainActor
+    private func makeState(blocks: [PyramidBlock] = []) -> PyramidTreeState {
+        let state = PyramidTreeState(blocks: blocks)
+        state.canvasSize = CGSize(width: 800, height: 600)
+        return state
+    }
+
+    private func sampleBlocks() -> [PyramidBlock] {
+        [
+            PyramidBlock(text: "Main claim", type: .governingThought),
+            PyramidBlock(text: "Support A", type: .supportPoint),
+            PyramidBlock(text: "Support B", type: .supportPoint),
+            PyramidBlock(text: "Evidence 1", type: .evidence),
+        ]
+    }
+
+    @MainActor
+    @Test("initialises with blocks in unplaced pool")
+    func initialState() {
+        let blocks = sampleBlocks()
+        let state = makeState(blocks: blocks)
+
+        #expect(state.unplacedBlocks.count == 4)
+        #expect(state.placedBlocks.isEmpty)
+        #expect(state.rootBlockID == nil)
+    }
+
+    @MainActor
+    @Test("place block as root")
+    func placeAsRoot() {
+        let blocks = sampleBlocks()
+        let state = makeState(blocks: blocks)
+        let root = blocks[0]
+
+        state.placeAsRoot(root)
+
+        #expect(state.rootBlockID == root.id)
+        #expect(state.placedBlocks.count == 1)
+        #expect(state.unplacedBlocks.count == 3)
+        #expect(state.placedBlocks[root.id]?.parentID == nil)
+    }
+
+    @MainActor
+    @Test("cannot place second root")
+    func cannotPlaceSecondRoot() {
+        let blocks = sampleBlocks()
+        let state = makeState(blocks: blocks)
+
+        state.placeAsRoot(blocks[0])
+        state.placeAsRoot(blocks[1])
+
+        #expect(state.rootBlockID == blocks[0].id)
+        #expect(state.placedBlocks.count == 1)
+    }
+
+    @MainActor
+    @Test("place child block under parent")
+    func placeChild() {
+        let blocks = sampleBlocks()
+        let state = makeState(blocks: blocks)
+
+        state.placeAsRoot(blocks[0])
+        state.placeBlock(blocks[1], underParent: blocks[0].id, atIndex: 0)
+
+        #expect(state.placedBlocks.count == 2)
+        #expect(state.unplacedBlocks.count == 2)
+        #expect(state.placedBlocks[blocks[0].id]?.childIDs == [blocks[1].id])
+        #expect(state.placedBlocks[blocks[1].id]?.parentID == blocks[0].id)
+    }
+
+    @MainActor
+    @Test("place multiple children preserves order")
+    func placeMultipleChildren() {
+        let blocks = sampleBlocks()
+        let state = makeState(blocks: blocks)
+
+        state.placeAsRoot(blocks[0])
+        state.placeBlock(blocks[1], underParent: blocks[0].id, atIndex: 0)
+        state.placeBlock(blocks[2], underParent: blocks[0].id, atIndex: 1)
+
+        let children = state.placedBlocks[blocks[0].id]?.childIDs
+        #expect(children == [blocks[1].id, blocks[2].id])
+    }
+
+    @MainActor
+    @Test("remove block returns it and descendants to pool")
+    func removeBlock() {
+        let blocks = sampleBlocks()
+        let state = makeState(blocks: blocks)
+
+        state.placeAsRoot(blocks[0])
+        state.placeBlock(blocks[1], underParent: blocks[0].id, atIndex: 0)
+        state.placeBlock(blocks[3], underParent: blocks[1].id, atIndex: 0)
+
+        // Remove blocks[1] — should also remove blocks[3] (descendant).
+        state.removeBlock(blocks[1].id)
+
+        #expect(state.placedBlocks.count == 1) // only root remains
+        #expect(state.unplacedBlocks.count == 3) // blocks[1], blocks[2], blocks[3] in pool
+        #expect(state.placedBlocks[blocks[0].id]?.childIDs.isEmpty == true)
+    }
+
+    @MainActor
+    @Test("remove root clears tree")
+    func removeRoot() {
+        let blocks = sampleBlocks()
+        let state = makeState(blocks: blocks)
+
+        state.placeAsRoot(blocks[0])
+        state.placeBlock(blocks[1], underParent: blocks[0].id, atIndex: 0)
+
+        state.removeBlock(blocks[0].id)
+
+        #expect(state.rootBlockID == nil)
+        #expect(state.placedBlocks.isEmpty)
+        #expect(state.unplacedBlocks.count == 4)
+    }
+
+    @MainActor
+    @Test("reparent block moves to new parent")
+    func reparentBlock() {
+        let blocks = sampleBlocks()
+        let state = makeState(blocks: blocks)
+
+        state.placeAsRoot(blocks[0])
+        state.placeBlock(blocks[1], underParent: blocks[0].id, atIndex: 0)
+        state.placeBlock(blocks[2], underParent: blocks[0].id, atIndex: 1)
+        state.placeBlock(blocks[3], underParent: blocks[1].id, atIndex: 0)
+
+        // Move evidence from under Support A to under Support B.
+        state.reparentBlock(blocks[3].id, toParent: blocks[2].id, atIndex: 0)
+
+        #expect(state.placedBlocks[blocks[1].id]?.childIDs.isEmpty == true)
+        #expect(state.placedBlocks[blocks[2].id]?.childIDs == [blocks[3].id])
+        #expect(state.placedBlocks[blocks[3].id]?.parentID == blocks[2].id)
+    }
+
+    @MainActor
+    @Test("reparent prevents circular reference")
+    func reparentPreventsCircular() {
+        let blocks = sampleBlocks()
+        let state = makeState(blocks: blocks)
+
+        state.placeAsRoot(blocks[0])
+        state.placeBlock(blocks[1], underParent: blocks[0].id, atIndex: 0)
+        state.placeBlock(blocks[3], underParent: blocks[1].id, atIndex: 0)
+
+        // Try to move blocks[1] under its own child blocks[3] — should be rejected.
+        state.reparentBlock(blocks[1].id, toParent: blocks[3].id, atIndex: 0)
+
+        // blocks[1] should still be under blocks[0].
+        #expect(state.placedBlocks[blocks[1].id]?.parentID == blocks[0].id)
+    }
+
+    @MainActor
+    @Test("no two blocks can occupy the same position")
+    func preventDuplicatePlacement() {
+        let blocks = sampleBlocks()
+        let state = makeState(blocks: blocks)
+
+        state.placeAsRoot(blocks[0])
+        state.placeBlock(blocks[1], underParent: blocks[0].id, atIndex: 0)
+
+        // Try to place blocks[1] again — should be rejected.
+        state.placeBlock(blocks[1], underParent: blocks[0].id, atIndex: 1)
+
+        #expect(state.placedBlocks[blocks[0].id]?.childIDs.count == 1)
+    }
+
+    // MARK: - Drop Zone Computation
+
+    @MainActor
+    @Test("empty tree has root drop zone")
+    func emptyTreeDropZones() {
+        let state = makeState(blocks: sampleBlocks())
+        state.recomputeLayout()
+
+        #expect(!state.dropZones.isEmpty)
+        #expect(state.dropZones.first?.parentID == "root")
+    }
+
+    @MainActor
+    @Test("tree with root has child drop zone")
+    func rootHasChildDropZone() {
+        let blocks = sampleBlocks()
+        let state = makeState(blocks: blocks)
+
+        state.placeAsRoot(blocks[0])
+
+        let childZones = state.dropZones.filter { $0.parentID == blocks[0].id.uuidString }
+        #expect(!childZones.isEmpty)
+    }
+
+    // MARK: - Proximity Detection
+
+    @MainActor
+    @Test("nearest zone returns zone within snap distance")
+    func nearestZoneWithinDistance() {
+        let state = makeState(blocks: sampleBlocks())
+        state.recomputeLayout()
+
+        guard let zone = state.dropZones.first else {
+            Issue.record("Expected at least one drop zone")
+            return
+        }
+
+        // Point very close to zone centre.
+        let nearby = CGPoint(x: zone.center.x + 10, y: zone.center.y + 10)
+        let result = state.nearestZone(to: nearby)
+
+        #expect(result?.id == zone.id)
+    }
+
+    @MainActor
+    @Test("nearest zone returns nil when too far")
+    func nearestZoneOutOfRange() {
+        let state = makeState(blocks: sampleBlocks())
+        state.recomputeLayout()
+
+        // Point far from any zone.
+        let farAway = CGPoint(x: 9999, y: 9999)
+        let result = state.nearestZone(to: farAway)
+
+        #expect(result == nil)
+    }
+
+    // MARK: - Drag Interaction
+
+    @MainActor
+    @Test("drag lifecycle updates state correctly")
+    func dragLifecycle() {
+        let blocks = sampleBlocks()
+        let state = makeState(blocks: blocks)
+        state.recomputeLayout()
+
+        state.beginDrag(blockID: blocks[0].id)
+        #expect(state.isDragging)
+        #expect(state.draggedBlockID == blocks[0].id)
+
+        // Update with position near root zone.
+        if let zone = state.dropZones.first {
+            state.updateDrag(position: zone.center)
+            #expect(state.highlightedZoneID == zone.id)
+        }
+
+        state.endDrag(position: CGPoint(x: 9999, y: 9999))
+        #expect(!state.isDragging)
+        #expect(state.draggedBlockID == nil)
+        #expect(state.highlightedZoneID == nil)
+    }
+
+    @MainActor
+    @Test("drop on valid zone places block from pool")
+    func dropOnValidZone() {
+        let blocks = sampleBlocks()
+        let state = makeState(blocks: blocks)
+        state.recomputeLayout()
+
+        guard let rootZone = state.dropZones.first(where: { $0.parentID == "root" }) else {
+            Issue.record("Expected root drop zone")
+            return
+        }
+
+        state.beginDrag(blockID: blocks[0].id)
+        let result = state.endDrag(position: rootZone.center)
+
+        #expect(result != nil)
+        #expect(state.rootBlockID == blocks[0].id)
+        #expect(state.unplacedBlocks.count == 3)
+    }
+
+    @MainActor
+    @Test("drop outside valid zone returns placed block to pool")
+    func dropOutsideReturnsToPool() {
+        let blocks = sampleBlocks()
+        let state = makeState(blocks: blocks)
+
+        state.placeAsRoot(blocks[0])
+        state.placeBlock(blocks[1], underParent: blocks[0].id, atIndex: 0)
+
+        #expect(state.placedBlocks.count == 2)
+
+        // Drag blocks[1] and drop far away.
+        state.beginDrag(blockID: blocks[1].id)
+        let result = state.endDrag(position: CGPoint(x: 9999, y: 9999))
+
+        #expect(result == nil)
+        #expect(state.placedBlocks.count == 1) // only root remains
+        #expect(state.unplacedBlocks.contains(where: { $0.id == blocks[1].id }))
+    }
+}


### PR DESCRIPTION
## Summary
- Drop zone model with proximity detection and configurable snap distance (default 80pt)
- `DropZoneView` with available/highlighted visual states (dashed border, fill, scale animation)
- `DropZoneOverlay` for rendering all active zones on the canvas
- `UnplacedBlocksPool` showing draggable blocks not yet placed in the tree
- `PyramidTreeState` managing block placement, removal, reparenting with circular reference prevention
- Drop zones adapt dynamically as blocks are placed/removed from the tree
- 18 tests covering all acceptance criteria

## Test plan
- [x] Build succeeds on macOS (xcodebuild)
- [x] All 151 tests pass (18 new DropZone/PyramidTreeState tests)
- [x] Place block as root, place children, verify order
- [x] Remove block returns it and descendants to unplaced pool
- [x] Reparent block moves to new parent, circular reference rejected
- [x] No two blocks can occupy the same position
- [x] Drop outside valid zone returns placed block to pool
- [x] Proximity detection: nearest zone within snap distance, nil when too far
- [x] Drag lifecycle updates state correctly
- [x] SwiftUI previews for all visual states

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)