### PR TITLE
feat: iPad chat layout with NavigationSplitView sidebar (#24)

### DIFF
--- a/app/SayItRight/Presentation/Chat/AdaptiveChatView.swift
+++ b/app/SayItRight/Presentation/Chat/AdaptiveChatView.swift
@@ -1,0 +1,172 @@
+import SwiftUI
+
+/// Platform-adaptive root view for the chat experience.
+///
+/// - **iPhone** (compact width): Shows `ChatView` directly in a `NavigationStack`.
+/// - **iPad** (regular width): Uses `NavigationSplitView` with a session sidebar
+///   and the chat detail area centered at ~650pt max width.
+/// - **Mac**: Uses `NavigationSplitView` matching the iPad layout with keyboard focus.
+///
+/// This view reads `horizontalSizeClass` to decide which layout to present.
+/// It supports portrait and landscape orientations, multitasking (Slide Over,
+/// Split View), and smooth rotation transitions.
+struct AdaptiveChatView: View {
+    @Bindable var viewModel: ChatViewModel
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+
+    @State private var selectedSessionType: SessionTypeItem? = SessionTypeItem.allTypes.first
+    @State private var showSettings = false
+    @State private var columnVisibility: NavigationSplitViewVisibility = .automatic
+
+    var language: String = "en"
+
+    var body: some View {
+        Group {
+            #if os(macOS)
+            splitLayout
+            #else
+            if horizontalSizeClass == .regular {
+                splitLayout
+            } else {
+                compactLayout
+            }
+            #endif
+        }
+        .animation(.easeInOut(duration: 0.3), value: horizontalSizeClass)
+        .sheet(isPresented: $showSettings) {
+            SettingsView()
+                .environment(AppSettings.shared)
+        }
+        .onChange(of: selectedSessionType) { _, newValue in
+            if let sessionType = newValue {
+                viewModel.sessionType = sessionType.id
+            }
+        }
+    }
+
+    // MARK: - Split Layout (iPad / Mac)
+
+    private var splitLayout: some View {
+        NavigationSplitView(columnVisibility: $columnVisibility) {
+            SidebarView(
+                selectedSessionType: $selectedSessionType,
+                language: language,
+                onSettingsTapped: { showSettings = true }
+            )
+            .navigationSplitViewColumnWidth(min: 240, ideal: 280, max: 340)
+        } detail: {
+            chatDetail
+        }
+    }
+
+    private var chatDetail: some View {
+        ChatView(viewModel: viewModel)
+            .navigationTitle(detailTitle)
+            #if !os(macOS)
+            .navigationBarTitleDisplayMode(.inline)
+            #endif
+            .toolbar {
+                ToolbarItem(placement: .automatic) {
+                    Button(action: { viewModel.clearConversation() }) {
+                        Label(
+                            language == "de" ? "Neues Gesprach" : "New Chat",
+                            systemImage: "plus.message"
+                        )
+                    }
+                    .disabled(viewModel.messages.isEmpty)
+                }
+            }
+    }
+
+    private var detailTitle: String {
+        guard let session = selectedSessionType else {
+            return language == "de" ? "Gesprach" : "Chat"
+        }
+        return session.title(language: language)
+    }
+
+    // MARK: - Compact Layout (iPhone)
+
+    #if !os(macOS)
+    private var compactLayout: some View {
+        NavigationStack {
+            ChatView(viewModel: viewModel)
+                .navigationTitle(language == "de" ? "Sag's richtig!" : "Say it right!")
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .topBarTrailing) {
+                        Button(action: { showSettings = true }) {
+                            Image(systemName: "gearshape")
+                        }
+                    }
+                }
+        }
+    }
+    #endif
+}
+
+// MARK: - Previews
+
+#Preview("iPhone — Compact") {
+    AdaptiveChatView(
+        viewModel: .previewMidConversation,
+        language: "en"
+    )
+    .environment(\.horizontalSizeClass, .compact)
+    .environment(AppSettings.shared)
+}
+
+#Preview("iPad — Portrait", traits: .portrait) {
+    AdaptiveChatView(
+        viewModel: .previewMidConversation,
+        language: "en"
+    )
+    .environment(\.horizontalSizeClass, .regular)
+    .environment(AppSettings.shared)
+}
+
+#Preview("iPad — Landscape", traits: .landscapeLeft) {
+    AdaptiveChatView(
+        viewModel: .previewMidConversation,
+        language: "en"
+    )
+    .environment(\.horizontalSizeClass, .regular)
+    .environment(AppSettings.shared)
+}
+
+#Preview("iPad — German") {
+    AdaptiveChatView(
+        viewModel: .previewMidConversation,
+        language: "de"
+    )
+    .environment(\.horizontalSizeClass, .regular)
+    .environment(AppSettings.shared)
+}
+
+#Preview("iPad — Empty State") {
+    AdaptiveChatView(
+        viewModel: ChatViewModel(),
+        language: "en"
+    )
+    .environment(\.horizontalSizeClass, .regular)
+    .environment(AppSettings.shared)
+}
+
+#Preview("iPad — Dark Mode") {
+    AdaptiveChatView(
+        viewModel: .previewMidConversation,
+        language: "en"
+    )
+    .environment(\.horizontalSizeClass, .regular)
+    .environment(AppSettings.shared)
+    .preferredColorScheme(.dark)
+}
+
+#Preview("Mac") {
+    AdaptiveChatView(
+        viewModel: .previewMidConversation,
+        language: "en"
+    )
+    .environment(AppSettings.shared)
+    .frame(width: 1024, height: 700)
+}

--- a/app/SayItRight/Presentation/Chat/ChatView.swift
+++ b/app/SayItRight/Presentation/Chat/ChatView.swift
@@ -124,7 +124,7 @@ struct ChatView: View {
         return 700
         #else
         if horizontalSizeClass == .regular {
-            return 600
+            return 650
         }
         return .infinity
         #endif

--- a/app/SayItRight/Presentation/Session/SidebarView.swift
+++ b/app/SayItRight/Presentation/Session/SidebarView.swift
@@ -1,0 +1,191 @@
+import SwiftUI
+
+/// Session type descriptor for the sidebar picker.
+struct SessionTypeItem: Identifiable, Hashable, Sendable {
+    let id: String
+    let titleEN: String
+    let titleDE: String
+    let subtitle: String
+    let icon: String
+
+    /// Display title based on current language setting.
+    func title(language: String) -> String {
+        language == "de" ? titleDE : titleEN
+    }
+}
+
+/// Predefined session types available in the sidebar.
+extension SessionTypeItem {
+    static let allTypes: [SessionTypeItem] = [
+        SessionTypeItem(
+            id: "say-it-clearly",
+            titleEN: "Say it clearly",
+            titleDE: "Sag's klar",
+            subtitle: "Quick structured response drill",
+            icon: "text.bubble"
+        ),
+        SessionTypeItem(
+            id: "find-the-point",
+            titleEN: "Find the point",
+            titleDE: "Finde den Punkt",
+            subtitle: "Extract governing thought",
+            icon: "scope"
+        ),
+        SessionTypeItem(
+            id: "fix-this-mess",
+            titleEN: "Fix this mess",
+            titleDE: "Raum das auf",
+            subtitle: "Restructure a bad argument",
+            icon: "arrow.triangle.2.circlepath"
+        ),
+        SessionTypeItem(
+            id: "build-the-pyramid",
+            titleEN: "Build the pyramid",
+            titleDE: "Bau die Pyramide",
+            subtitle: "Visual tree construction",
+            icon: "triangle"
+        ),
+        SessionTypeItem(
+            id: "elevator-pitch",
+            titleEN: "The elevator pitch",
+            titleDE: "30 Sekunden",
+            subtitle: "Timed spoken drill",
+            icon: "timer"
+        ),
+        SessionTypeItem(
+            id: "spot-the-gap",
+            titleEN: "Spot the gap",
+            titleDE: "Finde die Lucke",
+            subtitle: "Find structural weakness",
+            icon: "magnifyingglass"
+        ),
+        SessionTypeItem(
+            id: "decode-and-rebuild",
+            titleEN: "Decode and rebuild",
+            titleDE: "Entschlusseln und Neubauen",
+            subtitle: "Full-cycle read + restructure",
+            icon: "arrow.2.squarepath"
+        ),
+    ]
+}
+
+/// Sidebar for the iPad layout showing session type picker,
+/// Barbara's status, and a settings access point.
+///
+/// Designed for `NavigationSplitView` sidebar column on iPad.
+/// On iPhone this view is not used — the compact layout goes
+/// directly to `ChatView`.
+struct SidebarView: View {
+    @Binding var selectedSessionType: SessionTypeItem?
+    var language: String = "en"
+    var onSettingsTapped: () -> Void = {}
+
+    var body: some View {
+        List(selection: $selectedSessionType) {
+            barbaraStatusSection
+            sessionTypeSection
+            settingsSection
+        }
+        .listStyle(.sidebar)
+        .navigationTitle(language == "de" ? "Sag's richtig!" : "Say it right!")
+    }
+
+    // MARK: - Barbara Status
+
+    private var barbaraStatusSection: some View {
+        Section {
+            HStack(spacing: 12) {
+                BarbaraAvatarView(mood: .attentive, size: .header)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Barbara")
+                        .font(.headline)
+
+                    Text(language == "de"
+                         ? "Bereit loszulegen."
+                         : "Ready when you are.")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .padding(.vertical, 8)
+        }
+    }
+
+    // MARK: - Session Types
+
+    private var sessionTypeSection: some View {
+        Section(language == "de" ? "Ubungstypen" : "Session Types") {
+            ForEach(SessionTypeItem.allTypes) { sessionType in
+                sessionTypeRow(sessionType)
+                    .tag(sessionType)
+            }
+        }
+    }
+
+    private func sessionTypeRow(_ item: SessionTypeItem) -> some View {
+        Label {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(item.title(language: language))
+                    .font(.body)
+
+                Text(item.subtitle)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        } icon: {
+            Image(systemName: item.icon)
+                .foregroundStyle(Color.accentColor)
+        }
+        .padding(.vertical, 4)
+    }
+
+    // MARK: - Settings
+
+    private var settingsSection: some View {
+        Section {
+            Button(action: onSettingsTapped) {
+                Label(
+                    language == "de" ? "Einstellungen" : "Settings",
+                    systemImage: "gearshape"
+                )
+            }
+        }
+    }
+}
+
+// MARK: - Previews
+
+#Preview("Sidebar — English") {
+    NavigationSplitView {
+        SidebarView(
+            selectedSessionType: .constant(SessionTypeItem.allTypes.first),
+            language: "en"
+        )
+    } detail: {
+        Text("Detail area")
+    }
+}
+
+#Preview("Sidebar — German") {
+    NavigationSplitView {
+        SidebarView(
+            selectedSessionType: .constant(nil),
+            language: "de"
+        )
+    } detail: {
+        Text("Detail area")
+    }
+}
+
+#Preview("Sidebar — Dark Mode") {
+    NavigationSplitView {
+        SidebarView(
+            selectedSessionType: .constant(SessionTypeItem.allTypes[1]),
+            language: "en"
+        )
+    } detail: {
+        Text("Detail area")
+    }
+    .preferredColorScheme(.dark)
+}

--- a/app/SayItRight/Tests/SidebarViewTests.swift
+++ b/app/SayItRight/Tests/SidebarViewTests.swift
@@ -1,0 +1,87 @@
+import Testing
+@testable import SayItRight
+
+@Suite("SessionTypeItem")
+struct SessionTypeItemTests {
+
+    @Test("All session types have unique IDs")
+    func uniqueIDs() {
+        let ids = SessionTypeItem.allTypes.map(\.id)
+        let uniqueIDs = Set(ids)
+        #expect(ids.count == uniqueIDs.count)
+    }
+
+    @Test("All session types have both language titles")
+    func bothLanguages() {
+        for item in SessionTypeItem.allTypes {
+            #expect(!item.titleEN.isEmpty, "EN title missing for \(item.id)")
+            #expect(!item.titleDE.isEmpty, "DE title missing for \(item.id)")
+        }
+    }
+
+    @Test("Title returns English for en language")
+    func titleEnglish() {
+        let item = SessionTypeItem.allTypes[0]
+        #expect(item.title(language: "en") == item.titleEN)
+    }
+
+    @Test("Title returns German for de language")
+    func titleGerman() {
+        let item = SessionTypeItem.allTypes[0]
+        #expect(item.title(language: "de") == item.titleDE)
+    }
+
+    @Test("All session types have SF Symbol icons")
+    func iconsNotEmpty() {
+        for item in SessionTypeItem.allTypes {
+            #expect(!item.icon.isEmpty, "Icon missing for \(item.id)")
+        }
+    }
+
+    @Test("All session types have subtitles")
+    func subtitlesNotEmpty() {
+        for item in SessionTypeItem.allTypes {
+            #expect(!item.subtitle.isEmpty, "Subtitle missing for \(item.id)")
+        }
+    }
+
+    @Test("Expected session type count matches curriculum")
+    func expectedCount() {
+        #expect(SessionTypeItem.allTypes.count == 7)
+    }
+
+    @Test("SessionTypeItem conforms to Hashable")
+    func hashable() {
+        let a = SessionTypeItem.allTypes[0]
+        let b = SessionTypeItem.allTypes[1]
+        let set: Set<SessionTypeItem> = [a, b, a]
+        #expect(set.count == 2)
+    }
+
+    @Test("Say it clearly is first session type")
+    func firstType() {
+        let first = SessionTypeItem.allTypes[0]
+        #expect(first.id == "say-it-clearly")
+        #expect(first.titleEN == "Say it clearly")
+    }
+}
+
+@Suite("AdaptiveChatView Integration")
+struct AdaptiveChatViewTests {
+
+    @MainActor
+    @Test("ViewModel session type updates from selection")
+    func sessionTypeSync() {
+        let vm = ChatViewModel()
+        let sessionType = SessionTypeItem.allTypes[2] // "fix-this-mess"
+        vm.sessionType = sessionType.id
+        #expect(vm.sessionType == "fix-this-mess")
+    }
+
+    @MainActor
+    @Test("Default session type is say-it-clearly")
+    func defaultSessionType() {
+        let vm = ChatViewModel()
+        #expect(vm.sessionType == "say-it-clearly")
+    }
+}


### PR DESCRIPTION
## Summary
- Add `SidebarView` with session type picker (all 7 types), Barbara greeting/status, and settings access
- Add `AdaptiveChatView` that uses `NavigationSplitView` on iPad/Mac (regular size class) and `NavigationStack` on iPhone (compact)
- Update `ChatView` max content width from 600pt to 650pt for iPad
- Sidebar column width constrained to 240-340pt range
- Supports portrait/landscape, multitasking (Slide Over, Split View), and smooth rotation

## Test plan
- [x] Build succeeds on macOS (xcodebuild)
- [x] All 158 tests pass including 10 new tests for SessionTypeItem and AdaptiveChatView
- [ ] Verify iPad layout in simulator: portrait and landscape
- [ ] Verify sidebar selection updates chat session type
- [ ] Verify multitasking: Slide Over and Split View
- [ ] Verify iPhone compact layout unchanged

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)