### PR TITLE
feat: add SessionManager for session lifecycle orchestration (SIR-022)

### DIFF
--- a/app/SayItRight/Intelligence/ConversationManager/SessionManager.swift
+++ b/app/SayItRight/Intelligence/ConversationManager/SessionManager.swift
@@ -1,0 +1,212 @@
+import Foundation
+
+/// Central coordinator for coaching sessions.
+///
+/// `SessionManager` orchestrates the full session lifecycle: starting a session
+/// (assembling the system prompt and requesting Barbara's greeting), sending
+/// learner messages and streaming Barbara's responses, managing context window
+/// limits, and ending sessions with a summary.
+///
+/// It owns the conversation state and wires together `AnthropicService`,
+/// `SystemPromptAssembler`, and `ResponseParser`.
+@MainActor
+@Observable
+final class SessionManager {
+
+    // MARK: - Observable State
+
+    /// All messages in the current session.
+    private(set) var messages: [ChatMessage] = []
+
+    /// Current session lifecycle state.
+    private(set) var sessionState: SessionState = .idle
+
+    /// Metadata collected from Barbara's responses during this session.
+    private(set) var sessionMetadata: [BarbaraMetadata] = []
+
+    /// The active session type, if any.
+    private(set) var activeSessionType: SessionType?
+
+    // MARK: - Dependencies
+
+    private let anthropicService: AnthropicService
+    private let systemPromptAssembler: SystemPromptAssembler
+    private let responseParser: ResponseParser
+
+    // MARK: - Configuration
+
+    /// Maximum number of messages before older ones are summarized.
+    static let contextWindowThreshold = 50
+
+    /// The assembled system prompt for the current session.
+    private var systemPrompt: String = ""
+
+    // MARK: - Init
+
+    init(
+        anthropicService: AnthropicService = .shared,
+        systemPromptAssembler: SystemPromptAssembler = SystemPromptAssembler(),
+        responseParser: ResponseParser = ResponseParser()
+    ) {
+        self.anthropicService = anthropicService
+        self.systemPromptAssembler = systemPromptAssembler
+        self.responseParser = responseParser
+    }
+
+    // MARK: - Public API
+
+    /// Start a new coaching session.
+    ///
+    /// Assembles the system prompt from the learner profile and session type,
+    /// then sends a greeting request to Barbara so she opens the conversation.
+    ///
+    /// - Parameters:
+    ///   - type: The session type to start.
+    ///   - profile: The learner's current profile.
+    ///   - language: Language code ("en" or "de").
+    func startSession(type: SessionType, profile: LearnerProfile, language: String) async {
+        // Reset any previous session state
+        messages = []
+        sessionMetadata = []
+        activeSessionType = type
+        sessionState = .loading
+
+        // Assemble system prompt
+        systemPrompt = systemPromptAssembler.assemble(
+            level: profile.currentLevel,
+            sessionType: type.rawValue,
+            language: language,
+            profileJSON: profile.toPromptJSON()
+        )
+
+        // Request Barbara's greeting
+        await streamBarbaraResponse()
+    }
+
+    /// Send a learner message and stream Barbara's response.
+    ///
+    /// - Parameter text: The learner's message text.
+    func sendMessage(text: String) async {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        guard sessionState == .active else { return }
+
+        // Add the learner message
+        let learnerMessage = ChatMessage(role: .learner, text: trimmed)
+        messages.append(learnerMessage)
+
+        // Check context window limits
+        if messages.count > Self.contextWindowThreshold {
+            summarizeOlderMessages()
+        }
+
+        // Stream Barbara's response
+        await streamBarbaraResponse()
+    }
+
+    /// End the current session.
+    ///
+    /// Clears conversation state and returns to idle. The session summary
+    /// (last metadata) remains accessible until a new session starts.
+    func endSession() {
+        activeSessionType = nil
+        sessionState = .idle
+        messages = []
+        systemPrompt = ""
+        // sessionMetadata is preserved until next startSession
+    }
+
+    // MARK: - Private: Streaming
+
+    private func streamBarbaraResponse() async {
+        sessionState = .loading
+
+        // Create a placeholder streaming message
+        let streamingMessage = ChatMessage(
+            role: .barbara,
+            text: "",
+            isStreaming: true
+        )
+        messages.append(streamingMessage)
+        let streamingIndex = messages.count - 1
+
+        do {
+            // Build API messages from conversation history (exclude empty streaming placeholder)
+            let apiMessages = messages
+                .filter { !$0.text.isEmpty }
+                .map { message in
+                    APIMessage(
+                        role: message.role == .barbara ? "assistant" : "user",
+                        content: message.text
+                    )
+                }
+
+            // Stream response from Anthropic
+            let stream = await anthropicService.sendMessage(
+                systemPrompt: systemPrompt,
+                messages: apiMessages
+            )
+
+            var fullText = ""
+            for try await chunk in stream {
+                fullText += chunk
+                messages[streamingIndex].text = fullText
+            }
+
+            // Parse the complete response for hidden metadata
+            let parsed = responseParser.parse(fullResponse: fullText)
+            messages[streamingIndex].text = parsed.visibleText
+            messages[streamingIndex].isStreaming = false
+
+            if let metadata = parsed.metadata {
+                messages[streamingIndex].metadata = metadata
+                sessionMetadata.append(metadata)
+            }
+
+            sessionState = .active
+
+        } catch {
+            // Remove the empty streaming message on error
+            if messages[streamingIndex].text.isEmpty {
+                messages.remove(at: streamingIndex)
+            } else {
+                messages[streamingIndex].isStreaming = false
+            }
+            sessionState = .error(error.localizedDescription)
+        }
+    }
+
+    // MARK: - Private: Context Window Management
+
+    /// Summarize older messages when the conversation exceeds the threshold.
+    ///
+    /// Keeps the first message (Barbara's greeting) and the most recent messages,
+    /// replacing the middle portion with a summary message.
+    private func summarizeOlderMessages() {
+        let keepRecentCount = 20
+        let keepFromStart = 1 // Keep Barbara's greeting
+
+        guard messages.count > keepFromStart + keepRecentCount else { return }
+
+        let startMessages = Array(messages.prefix(keepFromStart))
+        let middleMessages = Array(messages.dropFirst(keepFromStart).dropLast(keepRecentCount))
+        let recentMessages = Array(messages.suffix(keepRecentCount))
+
+        // Build a text summary of the middle messages
+        let summaryLines = middleMessages.map { msg in
+            let role = msg.role == .barbara ? "Barbara" : "Learner"
+            let truncated = String(msg.text.prefix(200))
+            return "[\(role)] \(truncated)"
+        }
+
+        let summaryText = "[Session context summary — \(middleMessages.count) earlier messages condensed]\n\n"
+            + summaryLines.joined(separator: "\n")
+
+        let summaryMessage = ChatMessage(
+            role: .barbara,
+            text: summaryText
+        )
+
+        messages = startMessages + [summaryMessage] + recentMessages
+    }
+}

--- a/app/SayItRight/Intelligence/ConversationManager/SessionState.swift
+++ b/app/SayItRight/Intelligence/ConversationManager/SessionState.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// The lifecycle state of a coaching session.
+enum SessionState: Sendable, Equatable {
+    /// No active session. Ready to start one.
+    case idle
+
+    /// A session is running and accepting messages.
+    case active
+
+    /// Waiting for Barbara's response from the API.
+    case loading
+
+    /// An error occurred. The message describes what went wrong.
+    case error(String)
+}

--- a/app/SayItRight/Intelligence/ConversationManager/SessionType.swift
+++ b/app/SayItRight/Intelligence/ConversationManager/SessionType.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// Available coaching session types that Barbara can lead.
+///
+/// Each type maps to a prompt template file in the `PromptSessions` bundle
+/// directory and defines the interaction pattern for that exercise.
+enum SessionType: String, CaseIterable, Identifiable, Sendable {
+    case sayItClearly = "say-it-clearly"
+    case findThePoint = "find-the-point"
+
+    var id: String { rawValue }
+
+    /// Localised display name for the session picker.
+    func displayName(language: String) -> String {
+        switch self {
+        case .sayItClearly:
+            language == "de" ? "Sag's klar" : "Say it clearly"
+        case .findThePoint:
+            language == "de" ? "Finde den Punkt" : "Find the point"
+        }
+    }
+
+    /// Short description shown beneath the session name.
+    func subtitle(language: String) -> String {
+        switch self {
+        case .sayItClearly:
+            language == "de"
+                ? "Formuliere eine strukturierte Antwort. Barbara bewertet die Pyramidenqualit\u{00E4}t."
+                : "Formulate a structured response. Barbara evaluates pyramid quality."
+        case .findThePoint:
+            language == "de"
+                ? "Finde den Kerngedanken in einem Text. Barbara pr\u{00FC}ft dein Verst\u{00E4}ndnis."
+                : "Extract the governing thought from a text. Barbara checks your understanding."
+        }
+    }
+
+    /// SF Symbol name for the session type icon.
+    var iconName: String {
+        switch self {
+        case .sayItClearly: "text.bubble"
+        case .findThePoint: "magnifyingglass"
+        }
+    }
+}

--- a/app/SayItRight/Presentation/Chat/ChatViewModel.swift
+++ b/app/SayItRight/Presentation/Chat/ChatViewModel.swift
@@ -1,8 +1,11 @@
 import Foundation
 
-/// Drives the chat UI: manages message history, sends learner input to the
-/// Anthropic API via `AnthropicService`, and streams Barbara's response
-/// back token by token.
+/// Drives the chat UI by observing a `SessionManager` for message state.
+///
+/// `ChatViewModel` acts as a thin presentation adapter: it reads messages and
+/// loading state from the `SessionManager` and forwards user input to it.
+/// When no `SessionManager` is provided it falls back to standalone mode
+/// (useful for previews and tests).
 ///
 /// Observed by `ChatView` for reactive UI updates.
 @MainActor
@@ -12,32 +15,68 @@ final class ChatViewModel {
     // MARK: - Published State
 
     /// All messages in the current conversation.
-    /// Use `send()` or `setMessages(_:)` to modify from outside.
-    private(set) var messages: [ChatMessage] = []
+    /// Reads from SessionManager when available, otherwise uses local storage.
+    var messages: [ChatMessage] {
+        get { sessionManager?.messages ?? _localMessages }
+        set {
+            if sessionManager != nil {
+                // SessionManager owns messages; ignore direct sets
+            } else {
+                _localMessages = newValue
+            }
+        }
+    }
 
-    /// Replace the message list (used for previews and tests).
+    /// Replace the message list (used for previews and tests in standalone mode).
     func setMessages(_ newMessages: [ChatMessage]) {
-        messages = newMessages
+        _localMessages = newMessages
     }
 
     /// The text currently being composed by the learner.
     var inputText: String = ""
 
     /// Whether Barbara is currently generating a response.
-    private(set) var isLoading: Bool = false
+    var isLoading: Bool {
+        if let sm = sessionManager {
+            return sm.sessionState == .loading
+        }
+        return _localIsLoading
+    }
 
     /// The most recent error message, if any.
-    private(set) var errorMessage: String?
+    var errorMessage: String? {
+        if let sm = sessionManager {
+            if case .error(let msg) = sm.sessionState {
+                return msg
+            }
+            return nil
+        }
+        return _localErrorMessage
+    }
+
+    /// Whether there is an active session.
+    var hasActiveSession: Bool {
+        sessionManager?.sessionState == .active || sessionManager?.sessionState == .loading
+    }
+
+    // MARK: - Private State (standalone mode)
+
+    private var _localMessages: [ChatMessage] = []
+    private var _localIsLoading: Bool = false
+    private var _localErrorMessage: String?
 
     // MARK: - Dependencies
+
+    /// The session manager driving the conversation. Nil for standalone/preview mode.
+    var sessionManager: SessionManager?
 
     private let anthropicService: AnthropicService
     private let systemPromptAssembler: SystemPromptAssembler
     private let responseParser: ResponseParser
 
-    // MARK: - Session Config
+    // MARK: - Session Config (standalone mode fallback)
 
-    /// Current learner level (1–4).
+    /// Current learner level (1-4).
     var level: Int = 1
 
     /// Session type identifier (e.g. "say-it-clearly").
@@ -52,10 +91,12 @@ final class ChatViewModel {
     // MARK: - Init
 
     init(
+        sessionManager: SessionManager? = nil,
         anthropicService: AnthropicService = .shared,
         systemPromptAssembler: SystemPromptAssembler = SystemPromptAssembler(),
         responseParser: ResponseParser = ResponseParser()
     ) {
+        self.sessionManager = sessionManager
         self.anthropicService = anthropicService
         self.systemPromptAssembler = systemPromptAssembler
         self.responseParser = responseParser
@@ -68,42 +109,49 @@ final class ChatViewModel {
         let text = inputText.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !text.isEmpty, !isLoading else { return }
 
-        // Add learner message
-        let learnerMessage = ChatMessage(role: .learner, text: text)
-        messages.append(learnerMessage)
         inputText = ""
-        errorMessage = nil
 
-        // Start Barbara's response
-        Task {
-            await streamBarbaraResponse()
+        if let sm = sessionManager {
+            Task {
+                await sm.sendMessage(text: text)
+            }
+        } else {
+            // Standalone mode: direct API call
+            let learnerMessage = ChatMessage(role: .learner, text: text)
+            _localMessages.append(learnerMessage)
+            _localErrorMessage = nil
+            Task {
+                await streamBarbaraResponseStandalone()
+            }
         }
     }
 
     /// Clear all messages and reset the conversation.
     func clearConversation() {
-        messages.removeAll()
+        if let sm = sessionManager {
+            sm.endSession()
+        } else {
+            _localMessages.removeAll()
+            _localIsLoading = false
+            _localErrorMessage = nil
+        }
         inputText = ""
-        isLoading = false
-        errorMessage = nil
     }
 
-    // MARK: - Private
+    // MARK: - Private: Standalone streaming (no SessionManager)
 
-    private func streamBarbaraResponse() async {
-        isLoading = true
+    private func streamBarbaraResponseStandalone() async {
+        _localIsLoading = true
 
-        // Create a placeholder streaming message for Barbara
         let streamingMessage = ChatMessage(
             role: .barbara,
             text: "",
             isStreaming: true
         )
-        messages.append(streamingMessage)
-        let streamingIndex = messages.count - 1
+        _localMessages.append(streamingMessage)
+        let streamingIndex = _localMessages.count - 1
 
         do {
-            // Assemble system prompt
             let systemPrompt = systemPromptAssembler.assemble(
                 level: level,
                 sessionType: sessionType,
@@ -111,10 +159,8 @@ final class ChatViewModel {
                 profileJSON: profileJSON
             )
 
-            // Convert UI messages to API messages
-            let apiMessages = messages
+            let apiMessages = _localMessages
                 .filter { !$0.text.isEmpty }
-                .dropLast() // Exclude the empty streaming placeholder
                 .map { message in
                     APIMessage(
                         role: message.role == .barbara ? "assistant" : "user",
@@ -122,34 +168,31 @@ final class ChatViewModel {
                     )
                 }
 
-            // Stream response
             let stream = await anthropicService.sendMessage(
                 systemPrompt: systemPrompt,
-                messages: Array(apiMessages)
+                messages: apiMessages
             )
 
             var fullText = ""
             for try await chunk in stream {
                 fullText += chunk
-                messages[streamingIndex].text = fullText
+                _localMessages[streamingIndex].text = fullText
             }
 
-            // Parse the complete response for hidden metadata
             let parsed = responseParser.parse(fullResponse: fullText)
-            messages[streamingIndex].text = parsed.visibleText
-            messages[streamingIndex].metadata = parsed.metadata
-            messages[streamingIndex].isStreaming = false
+            _localMessages[streamingIndex].text = parsed.visibleText
+            _localMessages[streamingIndex].metadata = parsed.metadata
+            _localMessages[streamingIndex].isStreaming = false
 
         } catch {
-            // Remove the empty streaming message on error
-            if messages[streamingIndex].text.isEmpty {
-                messages.remove(at: streamingIndex)
+            if _localMessages[streamingIndex].text.isEmpty {
+                _localMessages.remove(at: streamingIndex)
             } else {
-                messages[streamingIndex].isStreaming = false
+                _localMessages[streamingIndex].isStreaming = false
             }
-            errorMessage = error.localizedDescription
+            _localErrorMessage = error.localizedDescription
         }
 
-        isLoading = false
+        _localIsLoading = false
     }
 }

--- a/app/SayItRight/Presentation/Session/SessionPickerView.swift
+++ b/app/SayItRight/Presentation/Session/SessionPickerView.swift
@@ -1,0 +1,163 @@
+import SwiftUI
+
+/// Session type selection screen shown before starting a coaching session.
+///
+/// Displays available session types as tappable cards. On selection,
+/// starts a new session via the `SessionManager`.
+struct SessionPickerView: View {
+    let sessionManager: SessionManager
+    let profile: LearnerProfile
+    let language: String
+    var onSessionStarted: (() -> Void)?
+
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 24) {
+                header
+                sessionCards
+            }
+            .padding(.horizontal, contentPadding)
+            .padding(.vertical, 24)
+        }
+        .frame(maxWidth: maxContentWidth)
+        .frame(maxWidth: .infinity)
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        VStack(spacing: 8) {
+            Text(language == "de" ? "Was m\u{00F6}chtest du \u{00FC}ben?" : "What would you like to practise?")
+                .font(.title2)
+                .fontWeight(.bold)
+
+            Text(language == "de" ? "W\u{00E4}hle eine \u{00DC}bung" : "Choose an exercise")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    // MARK: - Session Cards
+
+    private var sessionCards: some View {
+        VStack(spacing: 16) {
+            ForEach(SessionType.allCases) { sessionType in
+                SessionCardView(
+                    sessionType: sessionType,
+                    language: language
+                ) {
+                    Task {
+                        await sessionManager.startSession(
+                            type: sessionType,
+                            profile: profile,
+                            language: language
+                        )
+                        onSessionStarted?()
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Layout
+
+    private var maxContentWidth: CGFloat {
+        #if os(macOS)
+        600
+        #else
+        horizontalSizeClass == .regular ? 500 : .infinity
+        #endif
+    }
+
+    private var contentPadding: CGFloat {
+        #if os(macOS)
+        24
+        #else
+        horizontalSizeClass == .regular ? 24 : 16
+        #endif
+    }
+}
+
+// MARK: - Session Card
+
+/// A single tappable card representing a session type.
+struct SessionCardView: View {
+    let sessionType: SessionType
+    let language: String
+    let onTap: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            HStack(spacing: 16) {
+                Image(systemName: sessionType.iconName)
+                    .font(.title2)
+                    .foregroundStyle(Color.accentColor)
+                    .frame(width: 44, height: 44)
+                    .background(Color.accentColor.opacity(0.12))
+                    .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(sessionType.displayName(language: language))
+                        .font(.headline)
+                        .foregroundStyle(.primary)
+
+                    Text(sessionType.subtitle(language: language))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                }
+
+                Spacer()
+
+                Image(systemName: "chevron.right")
+                    .font(.body)
+                    .foregroundStyle(.tertiary)
+            }
+            .padding(16)
+            .background(
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .fill(.background)
+                    .shadow(color: .black.opacity(0.06), radius: 6, y: 2)
+            )
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+// MARK: - Previews
+
+#Preview("English") {
+    SessionPickerView(
+        sessionManager: SessionManager(),
+        profile: .createDefault(),
+        language: "en"
+    )
+}
+
+#Preview("German") {
+    SessionPickerView(
+        sessionManager: SessionManager(),
+        profile: .createDefault(language: "de"),
+        language: "de"
+    )
+}
+
+#Preview("iPad") {
+    SessionPickerView(
+        sessionManager: SessionManager(),
+        profile: .createDefault(),
+        language: "en"
+    )
+    .environment(\.horizontalSizeClass, .regular)
+}
+
+#Preview("Dark Mode") {
+    SessionPickerView(
+        sessionManager: SessionManager(),
+        profile: .createDefault(),
+        language: "en"
+    )
+    .preferredColorScheme(.dark)
+}

--- a/app/SayItRight/Tests/SessionManagerTests.swift
+++ b/app/SayItRight/Tests/SessionManagerTests.swift
@@ -1,0 +1,186 @@
+import Testing
+@testable import SayItRight
+
+// MARK: - SessionType Tests
+
+@Suite("SessionType")
+struct SessionTypeTests {
+
+    @Test("English display names")
+    func englishDisplayNames() {
+        #expect(SessionType.sayItClearly.displayName(language: "en") == "Say it clearly")
+        #expect(SessionType.findThePoint.displayName(language: "en") == "Find the point")
+    }
+
+    @Test("German display names")
+    func germanDisplayNames() {
+        #expect(SessionType.sayItClearly.displayName(language: "de") == "Sag's klar")
+        #expect(SessionType.findThePoint.displayName(language: "de") == "Finde den Punkt")
+    }
+
+    @Test("Each session type has a raw value matching prompt file naming")
+    func rawValues() {
+        #expect(SessionType.sayItClearly.rawValue == "say-it-clearly")
+        #expect(SessionType.findThePoint.rawValue == "find-the-point")
+    }
+
+    @Test("Each session type has an icon name")
+    func iconNames() {
+        for sessionType in SessionType.allCases {
+            #expect(!sessionType.iconName.isEmpty)
+        }
+    }
+
+    @Test("Each session type has subtitles in both languages")
+    func subtitles() {
+        for sessionType in SessionType.allCases {
+            #expect(!sessionType.subtitle(language: "en").isEmpty)
+            #expect(!sessionType.subtitle(language: "de").isEmpty)
+        }
+    }
+}
+
+// MARK: - SessionState Tests
+
+@Suite("SessionState")
+struct SessionStateTests {
+
+    @Test("Idle equals idle")
+    func idleEquality() {
+        #expect(SessionState.idle == SessionState.idle)
+    }
+
+    @Test("Error states with same message are equal")
+    func errorEquality() {
+        #expect(SessionState.error("oops") == SessionState.error("oops"))
+    }
+
+    @Test("Error states with different messages are not equal")
+    func errorInequality() {
+        #expect(SessionState.error("a") != SessionState.error("b"))
+    }
+
+    @Test("Different states are not equal")
+    func differentStates() {
+        #expect(SessionState.idle != SessionState.active)
+        #expect(SessionState.active != SessionState.loading)
+    }
+}
+
+// MARK: - SessionManager Tests
+
+@Suite("SessionManager")
+struct SessionManagerTests {
+
+    @Test("Initial state is idle with no messages")
+    @MainActor
+    func initialState() {
+        let manager = SessionManager()
+        #expect(manager.sessionState == .idle)
+        #expect(manager.messages.isEmpty)
+        #expect(manager.activeSessionType == nil)
+        #expect(manager.sessionMetadata.isEmpty)
+    }
+
+    @Test("endSession resets state to idle")
+    @MainActor
+    func endSessionResetsState() {
+        let manager = SessionManager()
+        // Manually verify endSession clears everything
+        manager.endSession()
+        #expect(manager.sessionState == .idle)
+        #expect(manager.messages.isEmpty)
+        #expect(manager.activeSessionType == nil)
+    }
+
+    @Test("sendMessage does nothing when session is idle")
+    @MainActor
+    func sendMessageWhenIdle() async {
+        let manager = SessionManager()
+        await manager.sendMessage(text: "Hello")
+        // No messages should be added because session is idle
+        #expect(manager.messages.isEmpty)
+    }
+
+    @Test("sendMessage ignores empty text")
+    @MainActor
+    func sendMessageIgnoresEmpty() async {
+        let manager = SessionManager()
+        await manager.sendMessage(text: "")
+        #expect(manager.messages.isEmpty)
+        await manager.sendMessage(text: "   \n  ")
+        #expect(manager.messages.isEmpty)
+    }
+
+    @Test("Context window threshold is 50")
+    @MainActor
+    func contextWindowThreshold() {
+        #expect(SessionManager.contextWindowThreshold == 50)
+    }
+}
+
+// MARK: - ChatViewModel Integration Tests
+
+@Suite("ChatViewModel with SessionManager")
+struct ChatViewModelSessionTests {
+
+    @Test("ViewModel in standalone mode has no active session")
+    @MainActor
+    func standaloneMode() {
+        let vm = ChatViewModel()
+        #expect(!vm.hasActiveSession)
+        #expect(!vm.isLoading)
+        #expect(vm.errorMessage == nil)
+    }
+
+    @Test("ViewModel reads messages from SessionManager when provided")
+    @MainActor
+    func readsFromSessionManager() {
+        let sm = SessionManager()
+        let vm = ChatViewModel(sessionManager: sm)
+        // SessionManager starts with empty messages
+        #expect(vm.messages.isEmpty)
+    }
+
+    @Test("ViewModel reflects SessionManager loading state")
+    @MainActor
+    func reflectsLoadingState() {
+        let sm = SessionManager()
+        let vm = ChatViewModel(sessionManager: sm)
+        // SessionManager starts idle, not loading
+        #expect(!vm.isLoading)
+    }
+
+    @Test("clearConversation calls endSession on SessionManager")
+    @MainActor
+    func clearConversationEndsSession() {
+        let sm = SessionManager()
+        let vm = ChatViewModel(sessionManager: sm)
+        vm.clearConversation()
+        #expect(sm.sessionState == .idle)
+        #expect(vm.inputText.isEmpty)
+    }
+
+    @Test("Standalone mode setMessages works")
+    @MainActor
+    func standaloneSetMessages() {
+        let vm = ChatViewModel()
+        let msgs = [
+            ChatMessage(role: .barbara, text: "Hello"),
+            ChatMessage(role: .learner, text: "Hi"),
+        ]
+        vm.setMessages(msgs)
+        #expect(vm.messages.count == 2)
+    }
+
+    @Test("Standalone mode clearConversation resets")
+    @MainActor
+    func standaloneClear() {
+        let vm = ChatViewModel()
+        vm.setMessages([ChatMessage(role: .barbara, text: "Hi")])
+        vm.inputText = "test"
+        vm.clearConversation()
+        #expect(vm.messages.isEmpty)
+        #expect(vm.inputText.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary

- Add `SessionManager` as the central coordinator for coaching session lifecycle (start, send, end)
- Add `SessionType` enum with localized names/subtitles and `SessionState` lifecycle enum
- Add `SessionPickerView` with tappable cards for session type selection
- Wire `ChatViewModel` to read from `SessionManager` when provided (standalone fallback preserved)
- Context window management: summarizes older messages when conversation exceeds 50 messages
- Metadata from each Barbara response stored in memory for session duration

## Test plan

- [x] `SessionType`: English/German display names, raw values match prompt file naming, icons and subtitles present
- [x] `SessionState`: equality semantics for all cases
- [x] `SessionManager`: initial state is idle, endSession resets, sendMessage guards against idle/empty
- [x] `ChatViewModel` integration: reads from SessionManager, reflects loading state, clearConversation delegates
- [x] All 167 tests pass (macOS)
- [x] SwiftUI previews for SessionPickerView (English, German, iPad, Dark Mode)

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)