### PR TITLE
feat: text deduplication tracker (SIR-050)

### DIFF
--- a/app/SayItRight/SayItRight.xcodeproj/project.pbxproj
+++ b/app/SayItRight/SayItRight.xcodeproj/project.pbxproj
@@ -21,18 +21,21 @@
 		0EB7A9CA948A196FA81EBD88 /* TTSPlaybackService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4F296F432E8A069994E5167 /* TTSPlaybackService.swift */; };
 		0F0F6EFEABD224BE50436E3C /* DropZone.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28E6F9B9D6818D8BCF742BCC /* DropZone.swift */; };
 		0FBDF4EC860A70831CBBB2F0 /* SessionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8EF7D134A239EF29A060F8C /* SessionType.swift */; };
-		0FF5F084E19A127FE73502C0 /* Config.plist in Resources */ = {isa = PBXBuildFile; fileRef = 87C3E174CED5835D593C922D /* Config.plist */; };
 		109845A5BD28BDC5307C4A51 /* KeychainService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BCBA23B5D640E11325097D0 /* KeychainService.swift */; };
 		112C860A4101D395FAA0F637 /* TreeLayoutEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8D4F615BD301FC609D050A /* TreeLayoutEngineTests.swift */; };
 		11F8D4B4ACCE017B7DA2CEC3 /* PracticeTextGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400403CA410CF7A0E750127F /* PracticeTextGenerator.swift */; };
 		1307449DE0CB3798F0EA6C91 /* ParentSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B08B6C7C928249161C6C0AC /* ParentSettingsView.swift */; };
+		1460EBA977EDC2340452180C /* SayItClearlyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47BCCF7B7169BFF3B4722C58 /* SayItClearlyView.swift */; };
 		14CE5BE581E0C8BD9D97C4CF /* SessionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8EF7D134A239EF29A060F8C /* SessionType.swift */; };
 		15C2944B9C7F642A1F1CE5E0 /* TreeLayoutEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8D4F615BD301FC609D050A /* TreeLayoutEngineTests.swift */; };
+		17805A9B8E4E6A4F93F3D8A5 /* SeenTextsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC1974647876CBDFA39B8A71 /* SeenTextsStore.swift */; };
 		180A80A7954F7CD067B7C8DB /* ThinkingIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF9D188FA8779E14011857FD /* ThinkingIndicatorView.swift */; };
+		1851700C174060BC3AC3208C /* SayItClearlySessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9512DE8E01F6C1AB4E4B8C /* SayItClearlySessionTests.swift */; };
 		1A0A534D8D6C7F327BD1F572 /* StreamingSentenceDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F1615A68359E9BF1E15F1C0 /* StreamingSentenceDetector.swift */; };
 		1CDA6E9592B48813ECDFA8D7 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DD215422DC5781D0AFDAAEE /* OnboardingView.swift */; };
 		1DA60359B8EB91B16DB3188F /* ConfigProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2927967CBDF0913F5EDD0EC7 /* ConfigProvider.swift */; };
 		1F4DE59430E6D724194CD0C6 /* Config.template.plist in Resources */ = {isa = PBXBuildFile; fileRef = E040537D24996C58EBA537D8 /* Config.template.plist */; };
+		1FD2F0E1A94E7F60D96B6601 /* SayItClearlySession.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB7D3646F6A2ED3962F6EC0C /* SayItClearlySession.swift */; };
 		232A2240F8CDCBF5093977DA /* BarbaraAvatarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A553A59D04C7ABFA86CF117E /* BarbaraAvatarTests.swift */; };
 		25C8BCA79939B0F44945A97F /* SidebarViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1161CE00FACCF6715D7034A1 /* SidebarViewTests.swift */; };
 		26EF845803D483A39BCEA37B /* StreamingSentenceDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E4E18B61DA2D4BD3AB29AD9 /* StreamingSentenceDetectorTests.swift */; };
@@ -45,6 +48,7 @@
 		2B62856D49AD9FB989384F80 /* AnthropicModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10F6CAB4EBA45B17A293C4C0 /* AnthropicModel.swift */; };
 		2B6D34E742035859B43FF43E /* MessageBubbleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A0D6917A3C05487B814E35 /* MessageBubbleView.swift */; };
 		2C1D8AB58512AA4B4605815E /* AnthropicService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C28CC98EB4FCDC9137D15433 /* AnthropicService.swift */; };
+		2D4D59D45FD3FDC4D737C08B /* PracticeTextLibraryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C70ADBF790944D3353F4FA32 /* PracticeTextLibraryTests.swift */; };
 		2DDE080F3029A0750773ED22 /* BarbaraVoiceProfileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A6B15AE1ED645EEDFCA7DF5 /* BarbaraVoiceProfileTests.swift */; };
 		2F52829C24DE0D1E7D980EB2 /* FirstLaunchSetupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E493E1B347AC7D15C639949F /* FirstLaunchSetupView.swift */; };
 		32D5314255E68AE513C355B9 /* StreamingTTSCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DF0427FCB8E6843FA1E136B /* StreamingTTSCoordinatorTests.swift */; };
@@ -55,6 +59,7 @@
 		396A7EF23BB5D5C0D9B29F87 /* DropZoneTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFA22F5F2A41A4A96CFE4C47 /* DropZoneTests.swift */; };
 		3A691C0923E2348327202674 /* SayItRightApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE9990EFFDBC213F3F1D0B19 /* SayItRightApp.swift */; };
 		3C009DF5A5015AB1595F05B2 /* DebugLogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D7F67899A791B97B42902B0 /* DebugLogView.swift */; };
+		3C3D496429C02F2A19997126 /* SeenTextsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E399297963E1A59A4C958BFA /* SeenTextsTests.swift */; };
 		3D30DF4F7A2D515EBD37FF5F /* SessionManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57ACC716C56B7F8E16DBDFB3 /* SessionManagerTests.swift */; };
 		4333A9801B4794A47C8D0EB7 /* MacOSAdaptationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2648E59B50498C1D83FD795F /* MacOSAdaptationTests.swift */; };
 		465D99D2F607EE3A29C71228 /* Topic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 188F1F9BBC0111EE4F4EB660 /* Topic.swift */; };
@@ -63,6 +68,7 @@
 		487E6CBCA4808690CB6B31C4 /* DebugLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1355D670E0F227DE429EAB9 /* DebugLogger.swift */; };
 		496007D2A4A26B62F5B29D3D /* SayItRight.xcodeproj in Resources */ = {isa = PBXBuildFile; fileRef = 3FAF495135EB918BBBE3A021 /* SayItRight.xcodeproj */; };
 		49828FC1CE9DAC9540F13C29 /* AdaptiveChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0756AEBC135E6923ED87C8A0 /* AdaptiveChatView.swift */; };
+		4B2A43D61DD2CE7ADE73132C /* PracticeTextLibrary_de.json in Resources */ = {isa = PBXBuildFile; fileRef = BEE1CAA3817E82AA6D53AF15 /* PracticeTextLibrary_de.json */; };
 		4DBA3C9AB5E598841BC408FA /* TreeLayoutEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4AEE9C322510B2451BC0B6B /* TreeLayoutEngine.swift */; };
 		537119E6E50C56A7FBE6CF59 /* AudioSessionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED72B2F78895FD96D69C5698 /* AudioSessionManager.swift */; };
 		5673D8240DB6073E30B4EAF5 /* LearnerProfileStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7340051027E1031862796AD /* LearnerProfileStore.swift */; };
@@ -70,6 +76,7 @@
 		57BFD8048F458724D5220EE4 /* SidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F227EDAC8833CE0EA075111 /* SidebarView.swift */; };
 		58C18276239608ABD6F07EBB /* AudioSessionManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D5A7EA09817CE62F1FE9796 /* AudioSessionManagerTests.swift */; };
 		5DA2F76EA751F3EF0CB55386 /* StreamingTTSCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DF0427FCB8E6843FA1E136B /* StreamingTTSCoordinatorTests.swift */; };
+		5E86220B69F94E1D80BE6E21 /* PracticeTextLibrary_en.json in Resources */ = {isa = PBXBuildFile; fileRef = E021EB6D73273983DB9E14F6 /* PracticeTextLibrary_en.json */; };
 		5F51449B08403989803DD749 /* ResponseParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 192E20839A759A3AF4CC7D51 /* ResponseParser.swift */; };
 		5F73FE131A1DB6BA939A2C5A /* AdaptiveChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0756AEBC135E6923ED87C8A0 /* AdaptiveChatView.swift */; };
 		60E3C43BE15EA0EBE21C942A /* ThinkingIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF9D188FA8779E14011857FD /* ThinkingIndicatorView.swift */; };
@@ -87,19 +94,23 @@
 		75AE4B49A8AA6C07DFCFE084 /* SayItRightApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE9990EFFDBC213F3F1D0B19 /* SayItRightApp.swift */; };
 		779DEBCF437A97E109B3E8BC /* PyramidBlock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AC8B2C13C23B149624FD027 /* PyramidBlock.swift */; };
 		78D4EC3D68AAF8BB663C0E46 /* ChatViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23B4EEBCB3D583F917C7B25 /* ChatViewModel.swift */; };
+		7917EA24942281486B8ACB77 /* TopicBank.json in Resources */ = {isa = PBXBuildFile; fileRef = 4C7E28ABC6EA21CD4558AB69 /* TopicBank.json */; };
 		7A274863874522A22D93C22B /* LearnerProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49EB5CEF2D12A478BB1EA7AF /* LearnerProfile.swift */; };
 		7A4E20F4593829C0C31A4AEC /* BarbaraVoiceProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F4D31053E77ACAC3D6E7D2 /* BarbaraVoiceProfile.swift */; };
 		7B05C7916E626A00EABE4E1E /* VoiceInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F66A4FE516B8A86073D9B3 /* VoiceInputView.swift */; };
 		7C4F19780556D70FC8120784 /* PracticeTextFileWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39FB9A6BB2DA0BC61384039F /* PracticeTextFileWriter.swift */; };
 		7DC18453FA528BB316169109 /* PracticeTextGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400403CA410CF7A0E750127F /* PracticeTextGenerator.swift */; };
+		803EEA750EBA59009E814F7C /* SayItClearlyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47BCCF7B7169BFF3B4722C58 /* SayItClearlyView.swift */; };
 		81160A48F23B0693F8B6BE38 /* VoiceInputViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FFAF667809AFED071F2163 /* VoiceInputViewModel.swift */; };
 		812AC213EB49FEC705555E09 /* ResponseParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8D179C236AD14B5C8076627 /* ResponseParserTests.swift */; };
+		81E23FA9C56B29B66E3ECD13 /* SeenTextsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC1974647876CBDFA39B8A71 /* SeenTextsStore.swift */; };
 		8253B0ABF87DA1DEF424AB4E /* MicrophoneButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8309BF4EE774FABE588555F4 /* MicrophoneButton.swift */; };
 		868CC677F0EF47C03E66115E /* BarbaraAvatarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36C6BF2F47F0B8EFFC2DF98B /* BarbaraAvatarView.swift */; };
 		86AC04612F354912B3989863 /* AppVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = F70F04FAE54C5FB6BC13D7E5 /* AppVersion.swift */; };
 		89CED9375747E4D03FCB8E66 /* PracticeTextGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 761B9E06D45D03688B09D463 /* PracticeTextGeneratorTests.swift */; };
 		8BED3E20F4C909B14BE520AA /* DropZoneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C05DDD40848A9E59E713026 /* DropZoneView.swift */; };
 		8D0594B48254C2F95AB7F9F3 /* LearnerAvatar.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE528A4BB6F7C58BD0CC3708 /* LearnerAvatar.swift */; };
+		8DE0054F17D7F85924AFAA02 /* SeenTextsTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C3D288AEDB1EF42A2CF3455 /* SeenTextsTracker.swift */; };
 		8E8D202555A73B2756F2EBB0 /* TTSPlaybackService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4F296F432E8A069994E5167 /* TTSPlaybackService.swift */; };
 		901D104DC385EA8F6044D909 /* DraggableBlockView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4373E47CEF1B184CF62920CB /* DraggableBlockView.swift */; };
 		908ED70F336A90E3DBF4E198 /* AnthropicServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F77568CC779F6818DEF9ADCC /* AnthropicServiceTests.swift */; };
@@ -110,7 +121,9 @@
 		9C6C847EC9BCCD14AE067A8A /* TTSPlaybackServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1964D965458CCC6A3A747B0 /* TTSPlaybackServiceTests.swift */; };
 		9E229F94708A12673A30600F /* PINEntryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0B8EDE7E53601DCAC1DB42 /* PINEntryView.swift */; };
 		9E94F43764B254F793A66465 /* PINEntryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0B8EDE7E53601DCAC1DB42 /* PINEntryView.swift */; };
+		A21F3D22008E858CE7D1DE45 /* PracticeTextLibrary_de.json in Resources */ = {isa = PBXBuildFile; fileRef = BEE1CAA3817E82AA6D53AF15 /* PracticeTextLibrary_de.json */; };
 		A8CD8951B7D4294936CBB7B7 /* ConnectionLinesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3915AE540EBA11321FA76BB /* ConnectionLinesView.swift */; };
+		A97A27185FAD7A443CC81A23 /* PracticeTextLibrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BFD6B8D5C586B0C9ADEEBA5 /* PracticeTextLibrary.swift */; };
 		A9B7342D214CE45653F5BAB3 /* LearnerAvatar.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE528A4BB6F7C58BD0CC3708 /* LearnerAvatar.swift */; };
 		A9BA44DA0F1F2B687C7EB602 /* AnthropicModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10F6CAB4EBA45B17A293C4C0 /* AnthropicModel.swift */; };
 		AFEA82FE224E0347257B1DFC /* DropZoneTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFA22F5F2A41A4A96CFE4C47 /* DropZoneTests.swift */; };
@@ -136,14 +149,21 @@
 		C6707E67B7475B58554F2F92 /* BarbaraVoiceProfileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A6B15AE1ED645EEDFCA7DF5 /* BarbaraVoiceProfileTests.swift */; };
 		C68A1A0B560C01274838748E /* ErrorBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E27CEE853747DCC27BA168 /* ErrorBannerView.swift */; };
 		C7BC0D0D42D99678ECC5A0D6 /* SessionPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A466760C86E7CBA8E140814 /* SessionPickerView.swift */; };
+		C7E44A72C5785F58432FD35D /* PracticeTextLibrary_en.json in Resources */ = {isa = PBXBuildFile; fileRef = E021EB6D73273983DB9E14F6 /* PracticeTextLibrary_en.json */; };
 		C8933962C661A055CCC48431 /* SidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F227EDAC8833CE0EA075111 /* SidebarView.swift */; };
 		C89D58F492C55065E008013A /* PyramidBlockTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B70EF3120BD198913EAEE0A2 /* PyramidBlockTests.swift */; };
 		CB11CF599D010F75FA77C233 /* ChatMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D08BE80207F27A8208D3CCB2 /* ChatMessage.swift */; };
 		CB5CCD79737A6748BDABC401 /* LearnerProfileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A1C0B31006940A2DBFE5E41 /* LearnerProfileTests.swift */; };
+		CBA2E68B2CD7D99D6220EB03 /* SayItClearlyCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F909A7D8C8D301AFFA580B6 /* SayItClearlyCoordinator.swift */; };
+		CBB14ED4FCF8AF6C0D25CA19 /* SayItClearlySession.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB7D3646F6A2ED3962F6EC0C /* SayItClearlySession.swift */; };
+		CD51EBAE3FC9894B5D3F4501 /* TopicBank.json in Resources */ = {isa = PBXBuildFile; fileRef = 4C7E28ABC6EA21CD4558AB69 /* TopicBank.json */; };
 		CE49D1EC9F14EE85575FA236 /* PyramidTreeState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72D83F01BEC457D843FA46B2 /* PyramidTreeState.swift */; };
+		D18F59F6E50DE4B10D1B6929 /* SayItClearlySessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9512DE8E01F6C1AB4E4B8C /* SayItClearlySessionTests.swift */; };
 		D3A1BF1A3B70AAF52594F570 /* NetworkErrorHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F95CF0998D962402B03233 /* NetworkErrorHandlerTests.swift */; };
 		D43F8B89B23167F2FA4EE2A2 /* MockSpeechRecognitionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A734FF80156849AAC5CD69 /* MockSpeechRecognitionService.swift */; };
+		D55641BDCB16A06138C8F443 /* SeenTextsTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C3D288AEDB1EF42A2CF3455 /* SeenTextsTracker.swift */; };
 		D66A3776BF922A53B0E059B8 /* TTSPlaybackServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1964D965458CCC6A3A747B0 /* TTSPlaybackServiceTests.swift */; };
+		D6A8A7F9EE4233595988BFA7 /* SayItClearlyCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F909A7D8C8D301AFFA580B6 /* SayItClearlyCoordinator.swift */; };
 		D6CD1F94E1C2E57A0888230E /* FirstLaunchSetupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C278322C149174D648ECF14 /* FirstLaunchSetupTests.swift */; };
 		DDD2F11F3AD9916F6E39F996 /* AppLanguage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1607A6E887C79A834F460459 /* AppLanguage.swift */; };
 		DE1CC7ECEADF4111754C15B0 /* VoiceInputViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FFAF667809AFED071F2163 /* VoiceInputViewModel.swift */; };
@@ -160,11 +180,13 @@
 		E82E1F599E93664105775B47 /* LearnerProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49EB5CEF2D12A478BB1EA7AF /* LearnerProfile.swift */; };
 		E964ABEE2D1CD7095C2F2CFE /* BarbaraAvatarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36C6BF2F47F0B8EFFC2DF98B /* BarbaraAvatarView.swift */; };
 		EA56A67113CF8CEB37FE4066 /* SessionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = C02627D1A73370A9B58BE9CC /* SessionState.swift */; };
+		EBE97AEDAD50F2E4A8AF50A3 /* PracticeTextLibraryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C70ADBF790944D3353F4FA32 /* PracticeTextLibraryTests.swift */; };
 		EC2B4036D1202B37FDCFF1B7 /* ParentGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B22653B114F07E9EA40C7C62 /* ParentGate.swift */; };
+		EC8D5C128F51D0CCF602CE9D /* SeenTextsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E399297963E1A59A4C958BFA /* SeenTextsTests.swift */; };
 		EE7B786DFC8E07B8C334D925 /* SpeechRecognitionServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D57221714F45B9C00201617 /* SpeechRecognitionServiceTests.swift */; };
+		F0CC71F3229103F04C025A33 /* PracticeTextLibrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BFD6B8D5C586B0C9ADEEBA5 /* PracticeTextLibrary.swift */; };
 		F138325B5D79C1F7D86FD19F /* ErrorBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E27CEE853747DCC27BA168 /* ErrorBannerView.swift */; };
 		F1F057BADCA87A05AF322BC6 /* LearnerProfileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A1C0B31006940A2DBFE5E41 /* LearnerProfileTests.swift */; };
-		F3616A8DCCA1C03700E986ED /* Config.plist in Resources */ = {isa = PBXBuildFile; fileRef = 87C3E174CED5835D593C922D /* Config.plist */; };
 		F3EA6C9E62178099319F591E /* DebugLogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D7F67899A791B97B42902B0 /* DebugLogView.swift */; };
 		F489AF2C43E8E5A051F6D164 /* NetworkErrorHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91ECF5F1EF7623373F5BBD2C /* NetworkErrorHandler.swift */; };
 		F5A28442A564B05F3EB1CFE0 /* MockSpeechRecognitionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A734FF80156849AAC5CD69 /* MockSpeechRecognitionService.swift */; };
@@ -208,8 +230,10 @@
 		192E20839A759A3AF4CC7D51 /* ResponseParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResponseParser.swift; sourceTree = "<group>"; };
 		1B08B6C7C928249161C6C0AC /* ParentSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentSettingsView.swift; sourceTree = "<group>"; };
 		1BEBAE680A83F0277794FDFA /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
+		1BFD6B8D5C586B0C9ADEEBA5 /* PracticeTextLibrary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticeTextLibrary.swift; sourceTree = "<group>"; };
 		1C278322C149174D648ECF14 /* FirstLaunchSetupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstLaunchSetupTests.swift; sourceTree = "<group>"; };
 		1DD215422DC5781D0AFDAAEE /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
+		1F909A7D8C8D301AFFA580B6 /* SayItClearlyCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SayItClearlyCoordinator.swift; sourceTree = "<group>"; };
 		1FD87491EB57716C7181C506 /* SpeechRecognitionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechRecognitionService.swift; sourceTree = "<group>"; };
 		2648E59B50498C1D83FD795F /* MacOSAdaptationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacOSAdaptationTests.swift; sourceTree = "<group>"; };
 		2679A39DC09E233E6C5FB8DC /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -217,6 +241,8 @@
 		28E6F9B9D6818D8BCF742BCC /* DropZone.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DropZone.swift; sourceTree = "<group>"; };
 		2910D8E206E77E72AE6E8631 /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
 		2927967CBDF0913F5EDD0EC7 /* ConfigProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigProvider.swift; sourceTree = "<group>"; };
+		2C3D288AEDB1EF42A2CF3455 /* SeenTextsTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeenTextsTracker.swift; sourceTree = "<group>"; };
+		2C9512DE8E01F6C1AB4E4B8C /* SayItClearlySessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SayItClearlySessionTests.swift; sourceTree = "<group>"; };
 		2D7F67899A791B97B42902B0 /* DebugLogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugLogView.swift; sourceTree = "<group>"; };
 		2DF0427FCB8E6843FA1E136B /* StreamingTTSCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamingTTSCoordinatorTests.swift; sourceTree = "<group>"; };
 		2ED4B98BAC3EA13F5C61CBCD /* ConnectionLinesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionLinesTests.swift; sourceTree = "<group>"; };
@@ -229,9 +255,11 @@
 		400403CA410CF7A0E750127F /* PracticeTextGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticeTextGenerator.swift; sourceTree = "<group>"; };
 		40319D5211156AC1671570F5 /* ChatViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatViewTests.swift; sourceTree = "<group>"; };
 		4373E47CEF1B184CF62920CB /* DraggableBlockView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraggableBlockView.swift; sourceTree = "<group>"; };
+		47BCCF7B7169BFF3B4722C58 /* SayItClearlyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SayItClearlyView.swift; sourceTree = "<group>"; };
 		48A1CF3D22441AE55554B302 /* PracticeText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticeText.swift; sourceTree = "<group>"; };
 		49EB5CEF2D12A478BB1EA7AF /* LearnerProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearnerProfile.swift; sourceTree = "<group>"; };
 		4A6B15AE1ED645EEDFCA7DF5 /* BarbaraVoiceProfileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarbaraVoiceProfileTests.swift; sourceTree = "<group>"; };
+		4C7E28ABC6EA21CD4558AB69 /* TopicBank.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = TopicBank.json; sourceTree = "<group>"; };
 		4F227EDAC8833CE0EA075111 /* SidebarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarView.swift; sourceTree = "<group>"; };
 		51E5916F947F218355F932A9 /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
 		5681C258DB07AF156A5662FE /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
@@ -252,7 +280,6 @@
 		81A63E61EA4ABC850E93CB2E /* AppSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSettings.swift; sourceTree = "<group>"; };
 		8309BF4EE774FABE588555F4 /* MicrophoneButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicrophoneButton.swift; sourceTree = "<group>"; };
 		86E2D821520E6552AE4B65B7 /* SayItRightTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = SayItRightTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		87C3E174CED5835D593C922D /* Config.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Config.plist; sourceTree = "<group>"; };
 		8AB92388718B19A2E45FBDC1 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		8D20FDE7D46349EC7346DA67 /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
 		91ECF5F1EF7623373F5BBD2C /* NetworkErrorHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkErrorHandler.swift; sourceTree = "<group>"; };
@@ -272,7 +299,9 @@
 		B4AEE9C322510B2451BC0B6B /* TreeLayoutEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TreeLayoutEngine.swift; sourceTree = "<group>"; };
 		B70EF3120BD198913EAEE0A2 /* PyramidBlockTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PyramidBlockTests.swift; sourceTree = "<group>"; };
 		B90CDF403DC2024ECF9038CA /* SayItRight.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = SayItRight.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		BB7D3646F6A2ED3962F6EC0C /* SayItClearlySession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SayItClearlySession.swift; sourceTree = "<group>"; };
 		BBA6E2AE36C0687015B8ABA6 /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
+		BEE1CAA3817E82AA6D53AF15 /* PracticeTextLibrary_de.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = PracticeTextLibrary_de.json; sourceTree = "<group>"; };
 		BF1E9442B04FA6E2B22959FE /* SayItRightTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SayItRightTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		BFA22F5F2A41A4A96CFE4C47 /* DropZoneTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DropZoneTests.swift; sourceTree = "<group>"; };
 		C02627D1A73370A9B58BE9CC /* SessionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionState.swift; sourceTree = "<group>"; };
@@ -280,6 +309,7 @@
 		C23B4EEBCB3D583F917C7B25 /* ChatViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatViewModel.swift; sourceTree = "<group>"; };
 		C28CC98EB4FCDC9137D15433 /* AnthropicService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnthropicService.swift; sourceTree = "<group>"; };
 		C3915AE540EBA11321FA76BB /* ConnectionLinesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionLinesView.swift; sourceTree = "<group>"; };
+		C70ADBF790944D3353F4FA32 /* PracticeTextLibraryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticeTextLibraryTests.swift; sourceTree = "<group>"; };
 		C7729E7948C0195AF7F2023B /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
 		C7A0D6917A3C05487B814E35 /* MessageBubbleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageBubbleView.swift; sourceTree = "<group>"; };
 		C8D179C236AD14B5C8076627 /* ResponseParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResponseParserTests.swift; sourceTree = "<group>"; };
@@ -289,8 +319,11 @@
 		D2F4D31053E77ACAC3D6E7D2 /* BarbaraVoiceProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarbaraVoiceProfile.swift; sourceTree = "<group>"; };
 		D6C50086B3A681AE4B706D0B /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
 		D7340051027E1031862796AD /* LearnerProfileStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearnerProfileStore.swift; sourceTree = "<group>"; };
+		DC1974647876CBDFA39B8A71 /* SeenTextsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeenTextsStore.swift; sourceTree = "<group>"; };
 		DE9990EFFDBC213F3F1D0B19 /* SayItRightApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SayItRightApp.swift; sourceTree = "<group>"; };
+		E021EB6D73273983DB9E14F6 /* PracticeTextLibrary_en.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = PracticeTextLibrary_en.json; sourceTree = "<group>"; };
 		E040537D24996C58EBA537D8 /* Config.template.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Config.template.plist; sourceTree = "<group>"; };
+		E399297963E1A59A4C958BFA /* SeenTextsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeenTextsTests.swift; sourceTree = "<group>"; };
 		E493E1B347AC7D15C639949F /* FirstLaunchSetupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstLaunchSetupView.swift; sourceTree = "<group>"; };
 		E4F296F432E8A069994E5167 /* TTSPlaybackService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TTSPlaybackService.swift; sourceTree = "<group>"; };
 		E53301B75E9027FAD04FAA44 /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
@@ -391,6 +424,9 @@
 			children = (
 				E53301B75E9027FAD04FAA44 /* .gitkeep */,
 				48A1CF3D22441AE55554B302 /* PracticeText.swift */,
+				BEE1CAA3817E82AA6D53AF15 /* PracticeTextLibrary_de.json */,
+				E021EB6D73273983DB9E14F6 /* PracticeTextLibrary_en.json */,
+				1BFD6B8D5C586B0C9ADEEBA5 /* PracticeTextLibrary.swift */,
 			);
 			path = PracticeTexts;
 			sourceTree = "<group>";
@@ -412,6 +448,7 @@
 			children = (
 				C7729E7948C0195AF7F2023B /* .gitkeep */,
 				188F1F9BBC0111EE4F4EB660 /* Topic.swift */,
+				4C7E28ABC6EA21CD4558AB69 /* TopicBank.json */,
 			);
 			path = ExerciseLibrary;
 			sourceTree = "<group>";
@@ -432,6 +469,8 @@
 				10F6CAB4EBA45B17A293C4C0 /* AnthropicModel.swift */,
 				C28CC98EB4FCDC9137D15433 /* AnthropicService.swift */,
 				91ECF5F1EF7623373F5BBD2C /* NetworkErrorHandler.swift */,
+				1F909A7D8C8D301AFFA580B6 /* SayItClearlyCoordinator.swift */,
+				BB7D3646F6A2ED3962F6EC0C /* SayItClearlySession.swift */,
 				70A1CB45AEA63A237D7499E4 /* SessionManager.swift */,
 				C02627D1A73370A9B58BE9CC /* SessionState.swift */,
 				F8EF7D134A239EF29A060F8C /* SessionType.swift */,
@@ -467,8 +506,11 @@
 				2648E59B50498C1D83FD795F /* MacOSAdaptationTests.swift */,
 				01F95CF0998D962402B03233 /* NetworkErrorHandlerTests.swift */,
 				761B9E06D45D03688B09D463 /* PracticeTextGeneratorTests.swift */,
+				C70ADBF790944D3353F4FA32 /* PracticeTextLibraryTests.swift */,
 				B70EF3120BD198913EAEE0A2 /* PyramidBlockTests.swift */,
 				C8D179C236AD14B5C8076627 /* ResponseParserTests.swift */,
+				2C9512DE8E01F6C1AB4E4B8C /* SayItClearlySessionTests.swift */,
+				E399297963E1A59A4C958BFA /* SeenTextsTests.swift */,
 				57ACC716C56B7F8E16DBDFB3 /* SessionManagerTests.swift */,
 				1161CE00FACCF6715D7034A1 /* SidebarViewTests.swift */,
 				3D57221714F45B9C00201617 /* SpeechRecognitionServiceTests.swift */,
@@ -539,7 +581,6 @@
 				5681C258DB07AF156A5662FE /* .gitkeep */,
 				F70F04FAE54C5FB6BC13D7E5 /* AppVersion.swift */,
 				2679A39DC09E233E6C5FB8DC /* Assets.xcassets */,
-				87C3E174CED5835D593C922D /* Config.plist */,
 				E040537D24996C58EBA537D8 /* Config.template.plist */,
 				2927967CBDF0913F5EDD0EC7 /* ConfigProvider.swift */,
 				DE9990EFFDBC213F3F1D0B19 /* SayItRightApp.swift */,
@@ -584,10 +625,20 @@
 			isa = PBXGroup;
 			children = (
 				9F024FEE5C1FC0FC7F1A33FD /* LearnerProfile */,
+				DE5AEFA6D3B7AA6DAD0AF96B /* SeenTexts */,
 				CCB1F3C07221EEF596F3CAA3 /* SessionHistory */,
 				D4D406F92E5DA5FCF8C8AE28 /* Settings */,
 			);
 			path = State;
+			sourceTree = "<group>";
+		};
+		DE5AEFA6D3B7AA6DAD0AF96B /* SeenTexts */ = {
+			isa = PBXGroup;
+			children = (
+				DC1974647876CBDFA39B8A71 /* SeenTextsStore.swift */,
+				2C3D288AEDB1EF42A2CF3455 /* SeenTextsTracker.swift */,
+			);
+			path = SeenTexts;
 			sourceTree = "<group>";
 		};
 		EF7379D2D22B82FC184E13DE /* SayItRight */ = {
@@ -631,6 +682,7 @@
 				1DD215422DC5781D0AFDAAEE /* OnboardingView.swift */,
 				1B08B6C7C928249161C6C0AC /* ParentSettingsView.swift */,
 				9A0B8EDE7E53601DCAC1DB42 /* PINEntryView.swift */,
+				47BCCF7B7169BFF3B4722C58 /* SayItClearlyView.swift */,
 				9A466760C86E7CBA8E140814 /* SessionPickerView.swift */,
 				8AB92388718B19A2E45FBDC1 /* SettingsView.swift */,
 				4F227EDAC8833CE0EA075111 /* SidebarView.swift */,
@@ -760,9 +812,11 @@
 			buildActionMask = 2147483647;
 			files = (
 				F68A7E82CAC1C17DF3417D14 /* Assets.xcassets in Resources */,
-				F3616A8DCCA1C03700E986ED /* Config.plist in Resources */,
 				1F4DE59430E6D724194CD0C6 /* Config.template.plist in Resources */,
+				4B2A43D61DD2CE7ADE73132C /* PracticeTextLibrary_de.json in Resources */,
+				5E86220B69F94E1D80BE6E21 /* PracticeTextLibrary_en.json in Resources */,
 				496007D2A4A26B62F5B29D3D /* SayItRight.xcodeproj in Resources */,
+				7917EA24942281486B8ACB77 /* TopicBank.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -771,9 +825,11 @@
 			buildActionMask = 2147483647;
 			files = (
 				487820CDB3AB1F86C7D41CD1 /* Assets.xcassets in Resources */,
-				0FF5F084E19A127FE73502C0 /* Config.plist in Resources */,
 				0346190953B25D320839884F /* Config.template.plist in Resources */,
+				A21F3D22008E858CE7D1DE45 /* PracticeTextLibrary_de.json in Resources */,
+				C7E44A72C5785F58432FD35D /* PracticeTextLibrary_en.json in Resources */,
 				BDF08178D405ECC24953BC24 /* SayItRight.xcodeproj in Resources */,
+				CD51EBAE3FC9894B5D3F4501 /* TopicBank.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -796,8 +852,11 @@
 				B199E127AAF2B4EEFF4C02CC /* MacOSAdaptationTests.swift in Sources */,
 				D3A1BF1A3B70AAF52594F570 /* NetworkErrorHandlerTests.swift in Sources */,
 				731B7002E3DBB7D9CDE10685 /* PracticeTextGeneratorTests.swift in Sources */,
+				EBE97AEDAD50F2E4A8AF50A3 /* PracticeTextLibraryTests.swift in Sources */,
 				C89D58F492C55065E008013A /* PyramidBlockTests.swift in Sources */,
 				812AC213EB49FEC705555E09 /* ResponseParserTests.swift in Sources */,
+				1851700C174060BC3AC3208C /* SayItClearlySessionTests.swift in Sources */,
+				EC8D5C128F51D0CCF602CE9D /* SeenTextsTests.swift in Sources */,
 				37C28646E0EEDAC5D185ADC7 /* SessionManagerTests.swift in Sources */,
 				25C8BCA79939B0F44945A97F /* SidebarViewTests.swift in Sources */,
 				33D97DD448F0E5566052D4BC /* SpeechRecognitionServiceTests.swift in Sources */,
@@ -825,8 +884,11 @@
 				4333A9801B4794A47C8D0EB7 /* MacOSAdaptationTests.swift in Sources */,
 				28CABE726983AF0A238983DE /* NetworkErrorHandlerTests.swift in Sources */,
 				89CED9375747E4D03FCB8E66 /* PracticeTextGeneratorTests.swift in Sources */,
+				2D4D59D45FD3FDC4D737C08B /* PracticeTextLibraryTests.swift in Sources */,
 				C37CC4D67FE88C69E19D6FF4 /* PyramidBlockTests.swift in Sources */,
 				E2E771E2E6E4B969403D183A /* ResponseParserTests.swift in Sources */,
+				D18F59F6E50DE4B10D1B6929 /* SayItClearlySessionTests.swift in Sources */,
+				3C3D496429C02F2A19997126 /* SeenTextsTests.swift in Sources */,
 				3D30DF4F7A2D515EBD37FF5F /* SessionManagerTests.swift in Sources */,
 				BC6395CBB992EB5D23FEB685 /* SidebarViewTests.swift in Sources */,
 				EE7B786DFC8E07B8C334D925 /* SpeechRecognitionServiceTests.swift in Sources */,
@@ -880,10 +942,16 @@
 				E55D26181C652FF34FB5B162 /* PracticeText.swift in Sources */,
 				E2A161E1F5258D6DBC5A3548 /* PracticeTextFileWriter.swift in Sources */,
 				11F8D4B4ACCE017B7DA2CEC3 /* PracticeTextGenerator.swift in Sources */,
+				F0CC71F3229103F04C025A33 /* PracticeTextLibrary.swift in Sources */,
 				779DEBCF437A97E109B3E8BC /* PyramidBlock.swift in Sources */,
 				CE49D1EC9F14EE85575FA236 /* PyramidTreeState.swift in Sources */,
 				033B5DE1A4166D33D74334B9 /* ResponseParser.swift in Sources */,
+				CBA2E68B2CD7D99D6220EB03 /* SayItClearlyCoordinator.swift in Sources */,
+				1FD2F0E1A94E7F60D96B6601 /* SayItClearlySession.swift in Sources */,
+				803EEA750EBA59009E814F7C /* SayItClearlyView.swift in Sources */,
 				3A691C0923E2348327202674 /* SayItRightApp.swift in Sources */,
+				17805A9B8E4E6A4F93F3D8A5 /* SeenTextsStore.swift in Sources */,
+				D55641BDCB16A06138C8F443 /* SeenTextsTracker.swift in Sources */,
 				E4C81D76331F3F76AE3D62DC /* SessionManager.swift in Sources */,
 				C7BC0D0D42D99678ECC5A0D6 /* SessionPickerView.swift in Sources */,
 				EA56A67113CF8CEB37FE4066 /* SessionState.swift in Sources */,
@@ -945,10 +1013,16 @@
 				945C5AB0AE1C1A1164802CF7 /* PracticeText.swift in Sources */,
 				7C4F19780556D70FC8120784 /* PracticeTextFileWriter.swift in Sources */,
 				7DC18453FA528BB316169109 /* PracticeTextGenerator.swift in Sources */,
+				A97A27185FAD7A443CC81A23 /* PracticeTextLibrary.swift in Sources */,
 				FCFA826700749EA41FCB4FDC /* PyramidBlock.swift in Sources */,
 				FC483FFC26C8467FF1807413 /* PyramidTreeState.swift in Sources */,
 				5F51449B08403989803DD749 /* ResponseParser.swift in Sources */,
+				D6A8A7F9EE4233595988BFA7 /* SayItClearlyCoordinator.swift in Sources */,
+				CBB14ED4FCF8AF6C0D25CA19 /* SayItClearlySession.swift in Sources */,
+				1460EBA977EDC2340452180C /* SayItClearlyView.swift in Sources */,
 				75AE4B49A8AA6C07DFCFE084 /* SayItRightApp.swift in Sources */,
+				81E23FA9C56B29B66E3ECD13 /* SeenTextsStore.swift in Sources */,
+				8DE0054F17D7F85924AFAA02 /* SeenTextsTracker.swift in Sources */,
 				E30210DD8492DB766516661E /* SessionManager.swift in Sources */,
 				FEA6E6E26B1F513C393C1444 /* SessionPickerView.swift in Sources */,
 				B9CA27CA31AD9BE7B3F31EB0 /* SessionState.swift in Sources */,

--- a/app/SayItRight/State/SeenTexts/SeenTextsStore.swift
+++ b/app/SayItRight/State/SeenTexts/SeenTextsStore.swift
@@ -1,0 +1,130 @@
+import Foundation
+
+/// Thread-safe persistence layer for seen text tracking.
+///
+/// Stores data as `seen-texts.json` in the app's Documents directory,
+/// following the same actor-based pattern as `LearnerProfileStore`.
+actor SeenTextsStore {
+    private let fileURL: URL
+    private var record: SeenTextsRecord
+
+    init(directory: URL? = nil) {
+        let dir = directory ?? FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+        self.fileURL = dir.appendingPathComponent("seen-texts.json")
+
+        if let data = try? Data(contentsOf: fileURL),
+           let loaded = try? JSONDecoder.seenTexts.decode(SeenTextsRecord.self, from: data) {
+            self.record = loaded
+        } else {
+            self.record = SeenTextsRecord()
+        }
+    }
+
+    var current: SeenTextsRecord { record }
+
+    /// Mark a text as seen for a session type, persisting immediately.
+    func markSeen(textID: String, sessionType: String, date: Date = .now) async throws {
+        record.markSeen(textID: textID, sessionType: sessionType, date: date)
+        try await save()
+    }
+
+    /// Returns the set of seen text IDs for a session type.
+    func seenIDs(for sessionType: String) -> Set<String> {
+        record.seenIDs(for: sessionType)
+    }
+
+    /// Selects an unseen text for the given criteria. If all texts at the level
+    /// have been seen, resets tracking for that level and returns a text from the
+    /// full pool, along with a flag indicating the reset occurred.
+    func selectUnseenText(
+        sessionType: String,
+        level: Int,
+        language: String,
+        library: PracticeTextLibrary,
+        quality: QualityLevel? = nil,
+        domain: String? = nil
+    ) async throws -> (text: PracticeText, didReset: Bool)? {
+        let unseen = record.unseenTexts(
+            sessionType: sessionType,
+            level: level,
+            language: language,
+            library: library
+        )
+
+        if let available = unseen {
+            // Filter further by quality/domain if requested
+            let filtered = available.filter { text in
+                (quality == nil || text.metadata.qualityLevel == quality)
+                    && (domain == nil || text.metadata.topicDomain == domain)
+            }
+            // Fall back to unfiltered if quality/domain filter is too restrictive
+            let pool = filtered.isEmpty ? available : filtered
+            guard let selected = pool.randomElement() else { return nil }
+            return (text: selected, didReset: false)
+        } else {
+            // All texts exhausted — reset for this level
+            record.resetForLevel(
+                sessionType: sessionType,
+                level: level,
+                language: language,
+                library: library
+            )
+            try await save()
+
+            // Now select from the full pool
+            let freshPool = library.texts(forTargetLevel: level, language: language)
+                .filter { $0.metadata.targetLevel == level }
+                .filter { text in
+                    (quality == nil || text.metadata.qualityLevel == quality)
+                        && (domain == nil || text.metadata.topicDomain == domain)
+                }
+            guard let selected = freshPool.randomElement() else { return nil }
+            return (text: selected, didReset: true)
+        }
+    }
+
+    /// Update the record with a transform and persist.
+    func update(_ transform: (inout SeenTextsRecord) -> Void) async throws {
+        transform(&record)
+        try await save()
+    }
+
+    func save() async throws {
+        let data = try JSONEncoder.seenTexts.encode(record)
+        let tempURL = fileURL.deletingLastPathComponent()
+            .appendingPathComponent(UUID().uuidString + ".tmp")
+        try data.write(to: tempURL, options: .atomic)
+        _ = try FileManager.default.replaceItemAt(fileURL, withItemAt: tempURL)
+    }
+
+    func reset() async throws {
+        record = SeenTextsRecord()
+        try await save()
+    }
+
+    /// Barbara's acknowledgment message when all texts at a level have been exhausted.
+    static func exhaustionMessage(language: String) -> String {
+        if language == "de" {
+            return "Du hast meine gesamte Sammlung auf diesem Level durchgearbeitet. Lass uns einige nochmal ansehen \u{2014} du wirst sie jetzt mit anderen Augen sehen."
+        } else {
+            return "You\u{2019}ve worked through my entire collection at this level. Let\u{2019}s revisit some \u{2014} you\u{2019}ll see them differently now."
+        }
+    }
+}
+
+private extension JSONEncoder {
+    static let seenTexts: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        return encoder
+    }()
+}
+
+private extension JSONDecoder {
+    static let seenTexts: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }()
+}

--- a/app/SayItRight/State/SeenTexts/SeenTextsTracker.swift
+++ b/app/SayItRight/State/SeenTexts/SeenTextsTracker.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+/// Tracks which practice text IDs the user has encountered, per session type.
+///
+/// Data model: `{ sessionType: { textID: dateSeen } }`.
+/// The date is stored to enable future cooldown logic (re-show after N days).
+struct SeenTextsRecord: Codable, Sendable, Equatable {
+    /// Map from session type raw value to a dictionary of text ID → date seen.
+    var entries: [String: [String: Date]]
+
+    init(entries: [String: [String: Date]] = [:]) {
+        self.entries = entries
+    }
+
+    /// Mark a text as seen for a given session type.
+    mutating func markSeen(textID: String, sessionType: String, date: Date = .now) {
+        var sessionEntries = entries[sessionType] ?? [:]
+        sessionEntries[textID] = date
+        entries[sessionType] = sessionEntries
+    }
+
+    /// Returns the set of text IDs seen for a given session type.
+    func seenIDs(for sessionType: String) -> Set<String> {
+        guard let sessionEntries = entries[sessionType] else { return [] }
+        return Set(sessionEntries.keys)
+    }
+
+    /// Resets all seen texts for a specific session type and difficulty level,
+    /// given the full library of texts to determine which IDs belong to that level.
+    mutating func resetForLevel(
+        sessionType: String,
+        level: Int,
+        language: String,
+        library: PracticeTextLibrary
+    ) {
+        let levelTextIDs = Set(
+            library.texts(forTargetLevel: level, language: language)
+                .filter { $0.metadata.targetLevel == level }
+                .map(\.id)
+        )
+        // Only remove entries for texts at this specific level
+        guard var sessionEntries = entries[sessionType] else { return }
+        for id in levelTextIDs {
+            sessionEntries.removeValue(forKey: id)
+        }
+        entries[sessionType] = sessionEntries.isEmpty ? nil : sessionEntries
+    }
+
+    /// Returns unseen texts from the library for a given session type, level, and language.
+    /// If all texts at that level have been seen, returns nil to signal a reset is needed.
+    func unseenTexts(
+        sessionType: String,
+        level: Int,
+        language: String,
+        library: PracticeTextLibrary
+    ) -> [PracticeText]? {
+        let candidates = library.texts(forTargetLevel: level, language: language)
+            .filter { $0.metadata.targetLevel == level }
+        let seen = seenIDs(for: sessionType)
+        let unseen = candidates.filter { !seen.contains($0.id) }
+        if unseen.isEmpty && !candidates.isEmpty {
+            return nil // signals exhaustion
+        }
+        return unseen
+    }
+}

--- a/app/SayItRight/Tests/SeenTextsTests.swift
+++ b/app/SayItRight/Tests/SeenTextsTests.swift
@@ -1,0 +1,430 @@
+import Testing
+import Foundation
+@testable import SayItRight
+
+// MARK: - Test Helpers
+
+private func makeText(id: String, level: Int = 1, language: String = "en", quality: QualityLevel = .wellStructured, domain: String = "general") -> PracticeText {
+    PracticeText(
+        id: id,
+        text: "Sample text for \(id)",
+        answerKey: AnswerKey(
+            governingThought: "Main point",
+            supports: [SupportGroup(label: "Support", evidence: ["Evidence"])],
+            structuralAssessment: "Good structure"
+        ),
+        metadata: PracticeTextMetadata(
+            qualityLevel: quality,
+            difficultyRating: 1,
+            topicDomain: domain,
+            language: language,
+            wordCount: 100,
+            targetLevel: level
+        )
+    )
+}
+
+private func makeLibrary(_ texts: [PracticeText]) -> PracticeTextLibrary {
+    PracticeTextLibrary(texts: texts)
+}
+
+// MARK: - SeenTextsRecord Tests
+
+@Suite("SeenTextsRecord")
+struct SeenTextsRecordTests {
+
+    @Test func markSeenAddsEntry() {
+        var record = SeenTextsRecord()
+        record.markSeen(textID: "pt-001", sessionType: "find-the-point")
+        let seen = record.seenIDs(for: "find-the-point")
+        #expect(seen.contains("pt-001"))
+        #expect(seen.count == 1)
+    }
+
+    @Test func markSeenMultipleTexts() {
+        var record = SeenTextsRecord()
+        record.markSeen(textID: "pt-001", sessionType: "find-the-point")
+        record.markSeen(textID: "pt-002", sessionType: "find-the-point")
+        record.markSeen(textID: "pt-003", sessionType: "find-the-point")
+        let seen = record.seenIDs(for: "find-the-point")
+        #expect(seen.count == 3)
+        #expect(seen == Set(["pt-001", "pt-002", "pt-003"]))
+    }
+
+    @Test func seenIDsPerSessionType() {
+        var record = SeenTextsRecord()
+        record.markSeen(textID: "pt-001", sessionType: "find-the-point")
+        record.markSeen(textID: "pt-002", sessionType: "fix-this-mess")
+
+        let findSeen = record.seenIDs(for: "find-the-point")
+        let fixSeen = record.seenIDs(for: "fix-this-mess")
+
+        #expect(findSeen == Set(["pt-001"]))
+        #expect(fixSeen == Set(["pt-002"]))
+    }
+
+    @Test func sameTextDifferentSessionTypes() {
+        var record = SeenTextsRecord()
+        record.markSeen(textID: "pt-001", sessionType: "find-the-point")
+
+        // Same text NOT marked as seen for different session type
+        let fixSeen = record.seenIDs(for: "fix-this-mess")
+        #expect(!fixSeen.contains("pt-001"))
+
+        // Mark it for the other session type too
+        record.markSeen(textID: "pt-001", sessionType: "fix-this-mess")
+        #expect(record.seenIDs(for: "fix-this-mess").contains("pt-001"))
+    }
+
+    @Test func seenIDsEmptyForUnknownSessionType() {
+        let record = SeenTextsRecord()
+        #expect(record.seenIDs(for: "nonexistent").isEmpty)
+    }
+
+    @Test func markSeenRecordsDate() {
+        var record = SeenTextsRecord()
+        let fixedDate = Date(timeIntervalSince1970: 1_700_000_000)
+        record.markSeen(textID: "pt-001", sessionType: "find-the-point", date: fixedDate)
+
+        let storedDate = record.entries["find-the-point"]?["pt-001"]
+        #expect(storedDate == fixedDate)
+    }
+
+    @Test func markSeenUpdatesDate() {
+        var record = SeenTextsRecord()
+        let date1 = Date(timeIntervalSince1970: 1_700_000_000)
+        let date2 = Date(timeIntervalSince1970: 1_700_100_000)
+
+        record.markSeen(textID: "pt-001", sessionType: "find-the-point", date: date1)
+        record.markSeen(textID: "pt-001", sessionType: "find-the-point", date: date2)
+
+        let storedDate = record.entries["find-the-point"]?["pt-001"]
+        #expect(storedDate == date2)
+        #expect(record.seenIDs(for: "find-the-point").count == 1)
+    }
+
+    @Test func unseenTextsReturnsOnlyUnseen() {
+        let texts = [
+            makeText(id: "pt-001", level: 1),
+            makeText(id: "pt-002", level: 1),
+            makeText(id: "pt-003", level: 1),
+        ]
+        let library = makeLibrary(texts)
+
+        var record = SeenTextsRecord()
+        record.markSeen(textID: "pt-001", sessionType: "find-the-point")
+
+        let unseen = record.unseenTexts(
+            sessionType: "find-the-point",
+            level: 1,
+            language: "en",
+            library: library
+        )
+        #expect(unseen != nil)
+        #expect(unseen!.count == 2)
+        #expect(unseen!.map(\.id).sorted() == ["pt-002", "pt-003"])
+    }
+
+    @Test func unseenTextsReturnsNilWhenExhausted() {
+        let texts = [
+            makeText(id: "pt-001", level: 1),
+            makeText(id: "pt-002", level: 1),
+        ]
+        let library = makeLibrary(texts)
+
+        var record = SeenTextsRecord()
+        record.markSeen(textID: "pt-001", sessionType: "find-the-point")
+        record.markSeen(textID: "pt-002", sessionType: "find-the-point")
+
+        let unseen = record.unseenTexts(
+            sessionType: "find-the-point",
+            level: 1,
+            language: "en",
+            library: library
+        )
+        #expect(unseen == nil)
+    }
+
+    @Test func unseenTextsFiltersbyLanguage() {
+        let texts = [
+            makeText(id: "pt-001-en", level: 1, language: "en"),
+            makeText(id: "pt-001-de", level: 1, language: "de"),
+        ]
+        let library = makeLibrary(texts)
+
+        var record = SeenTextsRecord()
+        record.markSeen(textID: "pt-001-en", sessionType: "find-the-point")
+
+        let unseenEN = record.unseenTexts(
+            sessionType: "find-the-point",
+            level: 1,
+            language: "en",
+            library: library
+        )
+        #expect(unseenEN == nil) // only EN text was seen, and only EN text exists
+
+        let unseenDE = record.unseenTexts(
+            sessionType: "find-the-point",
+            level: 1,
+            language: "de",
+            library: library
+        )
+        #expect(unseenDE != nil)
+        #expect(unseenDE!.count == 1)
+    }
+
+    @Test func unseenTextsFiltersByLevel() {
+        let texts = [
+            makeText(id: "pt-001", level: 1),
+            makeText(id: "pt-002", level: 2),
+        ]
+        let library = makeLibrary(texts)
+
+        var record = SeenTextsRecord()
+        record.markSeen(textID: "pt-001", sessionType: "find-the-point")
+
+        // Level 1: exhausted
+        let unseenL1 = record.unseenTexts(
+            sessionType: "find-the-point",
+            level: 1,
+            language: "en",
+            library: library
+        )
+        #expect(unseenL1 == nil)
+
+        // Level 2: still has unseen
+        let unseenL2 = record.unseenTexts(
+            sessionType: "find-the-point",
+            level: 2,
+            language: "en",
+            library: library
+        )
+        #expect(unseenL2 != nil)
+        #expect(unseenL2!.count == 1)
+    }
+
+    @Test func resetForLevelClearsOnlyThatLevel() {
+        let texts = [
+            makeText(id: "pt-001", level: 1),
+            makeText(id: "pt-002", level: 1),
+            makeText(id: "pt-003", level: 2),
+        ]
+        let library = makeLibrary(texts)
+
+        var record = SeenTextsRecord()
+        record.markSeen(textID: "pt-001", sessionType: "find-the-point")
+        record.markSeen(textID: "pt-002", sessionType: "find-the-point")
+        record.markSeen(textID: "pt-003", sessionType: "find-the-point")
+
+        record.resetForLevel(sessionType: "find-the-point", level: 1, language: "en", library: library)
+
+        let seen = record.seenIDs(for: "find-the-point")
+        #expect(!seen.contains("pt-001"))
+        #expect(!seen.contains("pt-002"))
+        #expect(seen.contains("pt-003")) // Level 2 not reset
+    }
+
+    @Test func resetForLevelDoesNotAffectOtherSessionTypes() {
+        let texts = [makeText(id: "pt-001", level: 1)]
+        let library = makeLibrary(texts)
+
+        var record = SeenTextsRecord()
+        record.markSeen(textID: "pt-001", sessionType: "find-the-point")
+        record.markSeen(textID: "pt-001", sessionType: "fix-this-mess")
+
+        record.resetForLevel(sessionType: "find-the-point", level: 1, language: "en", library: library)
+
+        #expect(record.seenIDs(for: "find-the-point").isEmpty)
+        #expect(record.seenIDs(for: "fix-this-mess").contains("pt-001"))
+    }
+
+    @Test func emptyLibraryUnseenTextsReturnsEmptyArray() {
+        let library = makeLibrary([])
+        let record = SeenTextsRecord()
+
+        let unseen = record.unseenTexts(
+            sessionType: "find-the-point",
+            level: 1,
+            language: "en",
+            library: library
+        )
+        #expect(unseen != nil)
+        #expect(unseen!.isEmpty)
+    }
+
+    @Test func codableRoundTrip() throws {
+        var record = SeenTextsRecord()
+        let date = Date(timeIntervalSince1970: 1_700_000_000)
+        record.markSeen(textID: "pt-001", sessionType: "find-the-point", date: date)
+        record.markSeen(textID: "pt-002", sessionType: "fix-this-mess", date: date)
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(record)
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(SeenTextsRecord.self, from: data)
+
+        #expect(decoded == record)
+        #expect(decoded.seenIDs(for: "find-the-point") == Set(["pt-001"]))
+        #expect(decoded.seenIDs(for: "fix-this-mess") == Set(["pt-002"]))
+    }
+}
+
+// MARK: - SeenTextsStore Tests
+
+@Suite("SeenTextsStore")
+struct SeenTextsStoreTests {
+
+    @Test func createWithEmptyState() async {
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        try? FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let store = SeenTextsStore(directory: tmpDir)
+        let record = await store.current
+        #expect(record.entries.isEmpty)
+    }
+
+    @Test func markSeenPersists() async throws {
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let store1 = SeenTextsStore(directory: tmpDir)
+        try await store1.markSeen(textID: "pt-001", sessionType: "find-the-point")
+
+        // Reload from disk
+        let store2 = SeenTextsStore(directory: tmpDir)
+        let seen = await store2.seenIDs(for: "find-the-point")
+        #expect(seen.contains("pt-001"))
+    }
+
+    @Test func resetClearsAllData() async throws {
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let store = SeenTextsStore(directory: tmpDir)
+        try await store.markSeen(textID: "pt-001", sessionType: "find-the-point")
+        try await store.reset()
+
+        let record = await store.current
+        #expect(record.entries.isEmpty)
+    }
+
+    @Test func selectUnseenTextReturnsText() async throws {
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let texts = [
+            makeText(id: "pt-001", level: 1),
+            makeText(id: "pt-002", level: 1),
+        ]
+        let library = makeLibrary(texts)
+
+        let store = SeenTextsStore(directory: tmpDir)
+        try await store.markSeen(textID: "pt-001", sessionType: "find-the-point")
+
+        let result = try await store.selectUnseenText(
+            sessionType: "find-the-point",
+            level: 1,
+            language: "en",
+            library: library
+        )
+        #expect(result != nil)
+        #expect(result!.text.id == "pt-002")
+        #expect(result!.didReset == false)
+    }
+
+    @Test func selectUnseenTextResetsWhenExhausted() async throws {
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let texts = [
+            makeText(id: "pt-001", level: 1),
+            makeText(id: "pt-002", level: 1),
+        ]
+        let library = makeLibrary(texts)
+
+        let store = SeenTextsStore(directory: tmpDir)
+        try await store.markSeen(textID: "pt-001", sessionType: "find-the-point")
+        try await store.markSeen(textID: "pt-002", sessionType: "find-the-point")
+
+        let result = try await store.selectUnseenText(
+            sessionType: "find-the-point",
+            level: 1,
+            language: "en",
+            library: library
+        )
+        #expect(result != nil)
+        #expect(result!.didReset == true)
+        #expect(["pt-001", "pt-002"].contains(result!.text.id))
+
+        // After reset, seen IDs for level 1 should be cleared
+        let seen = await store.seenIDs(for: "find-the-point")
+        #expect(seen.isEmpty)
+    }
+
+    @Test func selectUnseenTextReturnsNilForEmptyLibrary() async throws {
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let library = makeLibrary([])
+        let store = SeenTextsStore(directory: tmpDir)
+
+        let result = try await store.selectUnseenText(
+            sessionType: "find-the-point",
+            level: 1,
+            language: "en",
+            library: library
+        )
+        #expect(result == nil)
+    }
+
+    @Test func exhaustionMessageEnglish() {
+        let msg = SeenTextsStore.exhaustionMessage(language: "en")
+        #expect(msg.contains("entire collection"))
+        #expect(msg.contains("revisit"))
+    }
+
+    @Test func exhaustionMessageGerman() {
+        let msg = SeenTextsStore.exhaustionMessage(language: "de")
+        #expect(msg.contains("gesamte Sammlung"))
+        #expect(msg.contains("nochmal"))
+    }
+
+    @Test func persistenceRoundTrip() async throws {
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let store1 = SeenTextsStore(directory: tmpDir)
+        try await store1.markSeen(textID: "pt-001", sessionType: "find-the-point")
+        try await store1.markSeen(textID: "pt-002", sessionType: "fix-this-mess")
+        try await store1.markSeen(textID: "pt-003", sessionType: "find-the-point")
+
+        // Verify JSON file exists
+        let fileURL = tmpDir.appendingPathComponent("seen-texts.json")
+        #expect(FileManager.default.fileExists(atPath: fileURL.path))
+
+        // Reload and verify
+        let store2 = SeenTextsStore(directory: tmpDir)
+        let findSeen = await store2.seenIDs(for: "find-the-point")
+        let fixSeen = await store2.seenIDs(for: "fix-this-mess")
+
+        #expect(findSeen == Set(["pt-001", "pt-003"]))
+        #expect(fixSeen == Set(["pt-002"]))
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `SeenTextsRecord` (data model) and `SeenTextsStore` (actor-based persistence) to track which practice texts the user has seen, per session type
- Tracks text ID and date seen to enable future cooldown logic
- When all texts at a difficulty level are exhausted for a session type, resets tracking for that level with a Barbara acknowledgment message
- Persists as `seen-texts.json` in Documents directory, following the same pattern as `LearnerProfileStore`
- A text seen in "Find the point" can still appear in "Fix this mess" (per-session-type tracking)

## Test plan
- [x] Unit tests for `SeenTextsRecord`: mark as seen, filter by session type, unseen text filtering, level-based reset, codable round-trip
- [x] Unit tests for `SeenTextsStore`: persistence round-trip, mark-and-reload, reset, select unseen text, exhaustion reset behavior, exhaustion messages in both languages
- [x] All 53 tests pass (including 20+ new tests)
- [x] macOS build succeeds

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)