### PR TITLE
feat: answer key comparison logic (SIR-044)

### DIFF
--- a/app/SayItRight/Intelligence/StructuralEvaluator/AnswerKeyComparer.swift
+++ b/app/SayItRight/Intelligence/StructuralEvaluator/AnswerKeyComparer.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+/// Compares a user's response against a practice text's answer key using Claude
+/// for semantic structural evaluation.
+///
+/// This is the evaluation engine behind all Break mode exercises. It sends the
+/// user's extraction/restructuring and the answer key to Claude, and returns a
+/// structured evaluation of how well the user captured the text's structure.
+///
+/// The comparison is STRUCTURAL, not textual — a differently-worded but
+/// structurally equivalent extraction is considered correct.
+actor AnswerKeyComparer {
+
+    private let anthropicService: AnthropicService
+    private let promptBuilder: ComparisonPromptBuilder
+    private let responseParser: ComparisonResponseParser
+
+    /// - Parameters:
+    ///   - anthropicService: The Anthropic API service for Claude calls.
+    ///   - promptBuilder: Builds comparison-specific prompts per session type.
+    ///   - responseParser: Parses Claude's structured comparison response.
+    init(
+        anthropicService: AnthropicService = .shared,
+        promptBuilder: ComparisonPromptBuilder = ComparisonPromptBuilder(),
+        responseParser: ComparisonResponseParser = ComparisonResponseParser()
+    ) {
+        self.anthropicService = anthropicService
+        self.promptBuilder = promptBuilder
+        self.responseParser = responseParser
+    }
+
+    /// Compare a user's response against the practice text's answer key.
+    ///
+    /// Sends both the user response and the answer key to Claude with a
+    /// session-type-specific rubric. Claude evaluates semantic structural
+    /// similarity and returns a `AnswerKeyComparisonResult`.
+    ///
+    /// - Parameter input: All inputs for the comparison (user response,
+    ///   practice text with answer key, session type, language, level).
+    /// - Returns: A structured `AnswerKeyComparisonResult` with match quality,
+    ///   dimension scores, feedback, and hidden metadata.
+    /// - Throws: `AnswerKeyComparerError` if the API call fails or
+    ///   the response cannot be parsed.
+    func compare(_ input: ComparisonInput) async throws -> AnswerKeyComparisonResult {
+        let systemPrompt = promptBuilder.systemPrompt(for: input)
+        let userMessage = promptBuilder.userMessage(for: input)
+
+        let messages = [APIMessage(role: "user", content: userMessage)]
+
+        // Collect the full streamed response
+        let stream = await anthropicService.sendMessage(
+            systemPrompt: systemPrompt,
+            messages: messages
+        )
+
+        var fullResponse = ""
+        for try await chunk in stream {
+            fullResponse += chunk
+        }
+
+        // Parse the structured comparison response
+        guard let result = responseParser.parse(fullResponse: fullResponse) else {
+            throw AnswerKeyComparerError.parsingFailed(response: fullResponse)
+        }
+
+        return result
+    }
+}
+
+// MARK: - Errors
+
+/// Errors specific to answer key comparison.
+enum AnswerKeyComparerError: Error, LocalizedError, Sendable {
+    case parsingFailed(response: String)
+
+    var errorDescription: String? {
+        switch self {
+        case .parsingFailed:
+            "Failed to parse the comparison response from Claude."
+        }
+    }
+}

--- a/app/SayItRight/Intelligence/StructuralEvaluator/AnswerKeyComparison.swift
+++ b/app/SayItRight/Intelligence/StructuralEvaluator/AnswerKeyComparison.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+// MARK: - Comparison Session Types
+
+/// Break-mode session types that require answer key comparison.
+enum ComparisonSessionType: String, Sendable {
+    case findThePoint = "find_the_point"
+    case fixThisMess = "fix_this_mess"
+    case spotTheGap = "spot_the_gap"
+}
+
+// MARK: - Match Quality
+
+/// How closely the user's response matches the answer key structurally.
+enum MatchQuality: String, Codable, Sendable {
+    case high
+    case partial
+    case low
+}
+
+// MARK: - Comparison Result
+
+/// Structured result from comparing a user's response against an answer key.
+struct AnswerKeyComparisonResult: Codable, Sendable, Equatable {
+    /// Overall structural match quality.
+    let matchQuality: MatchQuality
+    /// Barbara's visible feedback text for the user.
+    let feedback: String
+    /// Per-dimension scores specific to the session type.
+    let dimensionScores: [String: Int]
+    /// Hidden metadata for learner profile and session tracking.
+    let metadata: ComparisonMetadata
+}
+
+/// Hidden metadata attached to every comparison result.
+struct ComparisonMetadata: Codable, Sendable, Equatable {
+    let mood: String
+    let progressionSignal: String
+    let sessionPhase: String
+    let feedbackFocus: String
+    let language: String
+}
+
+// MARK: - Comparison Input
+
+/// All inputs needed for an answer key comparison request.
+struct ComparisonInput: Sendable {
+    let userResponse: String
+    let practiceText: PracticeText
+    let sessionType: ComparisonSessionType
+    let language: String
+    let learnerLevel: Int
+}

--- a/app/SayItRight/Intelligence/StructuralEvaluator/ComparisonPromptBuilder.swift
+++ b/app/SayItRight/Intelligence/StructuralEvaluator/ComparisonPromptBuilder.swift
@@ -1,0 +1,268 @@
+import Foundation
+
+/// Builds the system prompt and user message for answer key comparison requests.
+///
+/// Each session type gets a tailored comparison rubric that instructs Claude
+/// to evaluate structural similarity rather than exact textual match.
+struct ComparisonPromptBuilder: Sendable {
+
+    // MARK: - Public API
+
+    /// Build the system prompt for a comparison request.
+    func systemPrompt(for input: ComparisonInput) -> String {
+        let identity = identityBlock(language: input.language)
+        let rubric = rubricBlock(for: input.sessionType, language: input.language)
+        let outputFormat = outputFormatBlock(for: input.sessionType, language: input.language)
+        return [identity, rubric, outputFormat].joined(separator: "\n\n")
+    }
+
+    /// Build the user message containing the practice text, answer key, and user response.
+    func userMessage(for input: ComparisonInput) -> String {
+        let answerKey = input.practiceText.answerKey
+        var parts: [String] = []
+
+        parts.append("## Practice Text\n\n\(input.practiceText.text)")
+        parts.append("## Answer Key\n\n\(formatAnswerKey(answerKey))")
+        parts.append("## User's Response\n\n\(input.userResponse)")
+
+        return parts.joined(separator: "\n\n")
+    }
+
+    // MARK: - Identity Block
+
+    private func identityBlock(language: String) -> String {
+        if language == "de" {
+            return """
+            # Rolle
+
+            Du bist Barbara, eine strenge aber wohlwollende Lehrerin für strukturiertes Denken. \
+            Du bewertest die STRUKTUR des Denkens, nicht den Inhalt der Meinungen. \
+            Du akzeptierst mehrere gültige Interpretationen — der Lösungsschlüssel ist eine Referenz, \
+            nicht die einzig richtige Antwort.
+            """
+        }
+        return """
+        # Role
+
+        You are Barbara, a strict but good-natured teacher of structured thinking. \
+        You evaluate the STRUCTURE of thinking, not the content of opinions. \
+        You accept multiple valid interpretations — the answer key is a reference, \
+        not the only correct answer.
+        """
+    }
+
+    // MARK: - Rubric Blocks
+
+    private func rubricBlock(for sessionType: ComparisonSessionType, language: String) -> String {
+        switch sessionType {
+        case .findThePoint:
+            return findThePointRubric(language: language)
+        case .fixThisMess:
+            return fixThisMessRubric(language: language)
+        case .spotTheGap:
+            return spotTheGapRubric(language: language)
+        }
+    }
+
+    private func findThePointRubric(language: String) -> String {
+        if language == "de" {
+            return """
+            # Bewertungskriterien: Finde den Punkt
+
+            Bewerte, wie gut der Lernende den Kerngedanken (Governing Thought) des Textes identifiziert hat.
+
+            ## Dimensionen (jeweils 0–3)
+            - **governingThoughtAccuracy**: Hat der Lernende den zentralen Punkt erfasst? \
+            Eine andere Formulierung ist akzeptabel, solange der strukturelle Kern stimmt.
+            - **specificity**: Ist die Identifikation konkret oder vage? \
+            "Es geht um Technologie" ist vage; "Der Autor argumentiert, dass KI die Bildung revolutioniert" ist spezifisch.
+            - **supportAwareness**: Zeigt der Lernende Bewusstsein für die Stützpfeiler unter dem Kerngedanken?
+
+            ## Bewertungsmaßstab
+            - **high**: Kerngedanke korrekt erfasst (auch wenn anders formuliert), mit Bewusstsein für Stützstruktur.
+            - **partial**: Richtiges Thema, aber Kerngedanke unscharf oder zu breit/eng gefasst.
+            - **low**: Falsches Thema, oder Detail statt Kerngedanke identifiziert.
+            """
+        }
+        return """
+        # Evaluation Criteria: Find the Point
+
+        Evaluate how well the learner identified the governing thought of the text.
+
+        ## Dimensions (0–3 each)
+        - **governingThoughtAccuracy**: Did the learner capture the central point? \
+        Different wording is acceptable if the structural core is correct.
+        - **specificity**: Is the identification concrete or vague? \
+        "It's about technology" is vague; "The author argues AI will revolutionise education" is specific.
+        - **supportAwareness**: Does the learner show awareness of the support pillars beneath the governing thought?
+
+        ## Match Quality Scale
+        - **high**: Governing thought correctly captured (even if differently worded), with awareness of support structure.
+        - **partial**: Right topic but governing thought is fuzzy or too broad/narrow.
+        - **low**: Wrong topic, or identified a detail instead of the governing thought.
+        """
+    }
+
+    private func fixThisMessRubric(language: String) -> String {
+        if language == "de" {
+            return """
+            # Bewertungskriterien: Räum das auf
+
+            Bewerte die Qualität der Umstrukturierung des Lernenden. Der Lösungsschlüssel zeigt EINE \
+            gültige Pyramide — der Lernende kann eine andere, ebenso gültige Struktur vorschlagen.
+
+            ## Dimensionen (jeweils 0–3)
+            - **pyramidValidity**: Bildet die Umstrukturierung eine gültige Pyramide? \
+            Klarer Kerngedanke oben, logische Gruppierung darunter.
+            - **groupingQuality**: Sind die Stützpfeiler sinnvoll gruppiert? MECE-Prinzip beachtet?
+            - **orderingLogic**: Ist die Reihenfolge der Argumente logisch? \
+            (Chronologisch, nach Wichtigkeit, oder strukturell begründet.)
+            - **completeness**: Wurden alle wesentlichen Punkte des Originaltexts erfasst? \
+            Nichts Wichtiges weggelassen, nichts Neues erfunden.
+
+            ## Bewertungsmaßstab
+            - **high**: Gültige Pyramide mit klarer Gruppierung, auch wenn sie vom Lösungsschlüssel abweicht.
+            - **partial**: Ansätze einer Struktur, aber Gruppierung oder Kerngedanke schwach.
+            - **low**: Keine erkennbare Pyramidenstruktur, oder wesentliche Inhalte fehlen/erfunden.
+            """
+        }
+        return """
+        # Evaluation Criteria: Fix This Mess
+
+        Evaluate the quality of the learner's restructuring. The answer key shows ONE valid \
+        pyramid — the learner may propose a different but equally valid structure.
+
+        ## Dimensions (0–3 each)
+        - **pyramidValidity**: Does the restructuring form a valid pyramid? \
+        Clear governing thought on top, logical grouping beneath.
+        - **groupingQuality**: Are support pillars meaningfully grouped? MECE principle respected?
+        - **orderingLogic**: Is the argument ordering logical? \
+        (Chronological, by importance, or structurally justified.)
+        - **completeness**: Were all essential points from the original text captured? \
+        Nothing important omitted, nothing new invented.
+
+        ## Match Quality Scale
+        - **high**: Valid pyramid with clear grouping, even if it differs from the answer key.
+        - **partial**: Some structural effort but grouping or governing thought is weak.
+        - **low**: No recognisable pyramid structure, or essential content missing/invented.
+        """
+    }
+
+    private func spotTheGapRubric(language: String) -> String {
+        if language == "de" {
+            return """
+            # Bewertungskriterien: Finde die Lücke
+
+            Bewerte, ob der Lernende den strukturellen Fehler im Text korrekt identifiziert hat. \
+            Der Fehlertyp ist wichtiger als die exakte Formulierung.
+
+            ## Dimensionen (jeweils 0–3)
+            - **flawIdentification**: Hat der Lernende den richtigen Fehlertyp erkannt? \
+            (z.B. Zirkelschluss, falsches Dilemma, Non Sequitur, fehlende Stütze)
+            - **locationAccuracy**: Hat der Lernende den Fehler an der richtigen Stelle im Text lokalisiert?
+            - **explanationClarity**: Ist die Erklärung des Fehlers klar und nachvollziehbar?
+
+            ## Bewertungsmaßstab
+            - **high**: Richtiger Fehlertyp, richtige Stelle, klare Erklärung.
+            - **partial**: Richtiger Fehlertyp aber falsche Stelle, oder richtige Stelle aber falsche Erklärung.
+            - **low**: Falscher Fehlertyp, oder kein struktureller Fehler identifiziert.
+            """
+        }
+        return """
+        # Evaluation Criteria: Spot the Gap
+
+        Evaluate whether the learner correctly identified the structural flaw in the text. \
+        The flaw type matters more than the exact wording of the identification.
+
+        ## Dimensions (0–3 each)
+        - **flawIdentification**: Did the learner identify the correct flaw type? \
+        (e.g. circular reasoning, false dichotomy, non sequitur, missing support)
+        - **locationAccuracy**: Did the learner locate the flaw in the right part of the text?
+        - **explanationClarity**: Is the explanation of the flaw clear and understandable?
+
+        ## Match Quality Scale
+        - **high**: Correct flaw type, correct location, clear explanation.
+        - **partial**: Correct flaw type but wrong location, or correct location but wrong explanation.
+        - **low**: Wrong flaw type, or no structural flaw identified.
+        """
+    }
+
+    // MARK: - Output Format
+
+    private func outputFormatBlock(for sessionType: ComparisonSessionType, language: String) -> String {
+        let dimensions = dimensionNames(for: sessionType)
+        let dimensionJSON = dimensions.map { "\"\($0)\": <0-3>" }.joined(separator: ", ")
+
+        if language == "de" {
+            return """
+            # Ausgabeformat
+
+            Antworte mit genau zwei Teilen:
+
+            1. **Sichtbares Feedback**: Barbaras Antwort an den Lernenden. Direkt, strukturfokussiert, \
+            in Barbaras Stimme. Maximal 3-4 Sätze.
+
+            2. **Versteckte Metadaten**: Ein einzelner HTML-Kommentar am Ende:
+
+            ```
+            <!-- COMPARISON_META: {"matchQuality":"high|partial|low","dimensionScores":{\(dimensionJSON)},"mood":"<mood>","progressionSignal":"<signal>","sessionPhase":"evaluation","feedbackFocus":"<focus>","language":"de"} -->
+            ```
+
+            Gültige Stimmungen: attentive, skeptical, approving, waiting, proud, evaluating, teaching, disappointed
+            Gültige Signale: none, improving, struggling, ready_for_level_up, regression
+            """
+        }
+        return """
+        # Output Format
+
+        Respond with exactly two parts:
+
+        1. **Visible feedback**: Barbara's response to the learner. Direct, structure-focused, \
+        in Barbara's voice. Maximum 3-4 sentences.
+
+        2. **Hidden metadata**: A single HTML comment at the end:
+
+        ```
+        <!-- COMPARISON_META: {"matchQuality":"high|partial|low","dimensionScores":{\(dimensionJSON)},"mood":"<mood>","progressionSignal":"<signal>","sessionPhase":"evaluation","feedbackFocus":"<focus>","language":"en"} -->
+        ```
+
+        Valid moods: attentive, skeptical, approving, waiting, proud, evaluating, teaching, disappointed
+        Valid signals: none, improving, struggling, ready_for_level_up, regression
+        """
+    }
+
+    private func dimensionNames(for sessionType: ComparisonSessionType) -> [String] {
+        switch sessionType {
+        case .findThePoint:
+            return ["governingThoughtAccuracy", "specificity", "supportAwareness"]
+        case .fixThisMess:
+            return ["pyramidValidity", "groupingQuality", "orderingLogic", "completeness"]
+        case .spotTheGap:
+            return ["flawIdentification", "locationAccuracy", "explanationClarity"]
+        }
+    }
+
+    // MARK: - Answer Key Formatting
+
+    private func formatAnswerKey(_ key: AnswerKey) -> String {
+        var parts: [String] = []
+        parts.append("**Governing Thought**: \(key.governingThought)")
+
+        for (index, group) in key.supports.enumerated() {
+            let evidence = group.evidence.map { "  - \($0)" }.joined(separator: "\n")
+            parts.append("**Support \(index + 1): \(group.label)**\n\(evidence)")
+        }
+
+        parts.append("**Structural Assessment**: \(key.structuralAssessment)")
+
+        if let flaw = key.structuralFlaw {
+            parts.append("**Structural Flaw**: [\(flaw.type)] \(flaw.description) (at \(flaw.location))")
+        }
+
+        if let restructure = key.proposedRestructure {
+            parts.append("**Proposed Restructure**: \(restructure)")
+        }
+
+        return parts.joined(separator: "\n\n")
+    }
+}

--- a/app/SayItRight/Intelligence/StructuralEvaluator/ComparisonResponseParser.swift
+++ b/app/SayItRight/Intelligence/StructuralEvaluator/ComparisonResponseParser.swift
@@ -1,0 +1,79 @@
+import Foundation
+
+/// Parses Claude's comparison response into visible feedback and structured metadata.
+///
+/// Comparison responses use `<!-- COMPARISON_META: {...} -->` to embed structured
+/// evaluation data, similar to the `BARBARA_META` pattern used in coaching sessions.
+struct ComparisonResponseParser: Sendable {
+
+    /// Raw decoded JSON from the COMPARISON_META block.
+    private struct RawComparisonMeta: Decodable {
+        let matchQuality: String
+        let dimensionScores: [String: Int]
+        let mood: String
+        let progressionSignal: String
+        let sessionPhase: String
+        let feedbackFocus: String
+        let language: String
+    }
+
+    /// Parse a full comparison response from Claude.
+    ///
+    /// - Parameter fullResponse: The raw text containing visible feedback
+    ///   and a `COMPARISON_META` HTML comment block.
+    /// - Returns: A `AnswerKeyComparisonResult` if metadata was found and valid, nil otherwise.
+    func parse(fullResponse: String) -> AnswerKeyComparisonResult? {
+        let pattern = #"<!--\s*COMPARISON_META:\s*(.*?)\s*-->"#
+
+        guard let regex = try? NSRegularExpression(
+            pattern: pattern,
+            options: [.dotMatchesLineSeparators]
+        ) else {
+            return nil
+        }
+
+        let nsString = fullResponse as NSString
+        let matches = regex.matches(
+            in: fullResponse,
+            range: NSRange(location: 0, length: nsString.length)
+        )
+
+        guard let lastMatch = matches.last else {
+            return nil
+        }
+
+        // Extract JSON from the last metadata block.
+        let jsonRange = lastMatch.range(at: 1)
+        let jsonString = nsString.substring(with: jsonRange)
+
+        // Remove all metadata blocks from visible text.
+        var visibleText = fullResponse
+        for match in matches.reversed() {
+            guard let fullRange = Range(match.range, in: fullResponse) else { continue }
+            visibleText.removeSubrange(fullRange)
+        }
+        visibleText = visibleText.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        // Decode JSON payload.
+        guard let data = jsonString.data(using: .utf8),
+              let raw = try? JSONDecoder().decode(RawComparisonMeta.self, from: data),
+              let matchQuality = MatchQuality(rawValue: raw.matchQuality) else {
+            return nil
+        }
+
+        let metadata = ComparisonMetadata(
+            mood: raw.mood,
+            progressionSignal: raw.progressionSignal,
+            sessionPhase: raw.sessionPhase,
+            feedbackFocus: raw.feedbackFocus,
+            language: raw.language
+        )
+
+        return AnswerKeyComparisonResult(
+            matchQuality: matchQuality,
+            feedback: visibleText,
+            dimensionScores: raw.dimensionScores,
+            metadata: metadata
+        )
+    }
+}

--- a/app/SayItRight/SayItRight.xcodeproj/project.pbxproj
+++ b/app/SayItRight/SayItRight.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		09099979FE939EB2AF863CF9 /* SpeechRecognitionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD87491EB57716C7181C506 /* SpeechRecognitionService.swift */; };
 		0993F28FAFD79202B101068F /* MacChatInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C051275C85D1D1ED1778AC59 /* MacChatInputView.swift */; };
 		0A34DEDADFDCDA5E7ADE5A1C /* AnthropicService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C28CC98EB4FCDC9137D15433 /* AnthropicService.swift */; };
+		0DDC5480C5521B99A77E02A0 /* ComparisonResponseParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC11499E66D1CCC6F0EDB5EE /* ComparisonResponseParser.swift */; };
 		0EB7A9CA948A196FA81EBD88 /* TTSPlaybackService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4F296F432E8A069994E5167 /* TTSPlaybackService.swift */; };
 		0F0F6EFEABD224BE50436E3C /* DropZone.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28E6F9B9D6818D8BCF742BCC /* DropZone.swift */; };
 		0FBDF4EC860A70831CBBB2F0 /* SessionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8EF7D134A239EF29A060F8C /* SessionType.swift */; };
@@ -54,6 +55,7 @@
 		2F52829C24DE0D1E7D980EB2 /* FirstLaunchSetupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E493E1B347AC7D15C639949F /* FirstLaunchSetupView.swift */; };
 		32D5314255E68AE513C355B9 /* StreamingTTSCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DF0427FCB8E6843FA1E136B /* StreamingTTSCoordinatorTests.swift */; };
 		33274CD62BE5B41D80760AC0 /* SystemPromptAssemblerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65A78B634A6D6F9D4CD57BC7 /* SystemPromptAssemblerTests.swift */; };
+		33D64B1F80E3DC6DAB7F372D /* AnswerKeyComparison.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1910976EBE55B2D0A2B347CA /* AnswerKeyComparison.swift */; };
 		33D97DD448F0E5566052D4BC /* SpeechRecognitionServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D57221714F45B9C00201617 /* SpeechRecognitionServiceTests.swift */; };
 		3663C29466AF276F1C5289C7 /* SystemPromptAssembler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4096FB5122C41B3F25CCFB2 /* SystemPromptAssembler.swift */; };
 		37C28646E0EEDAC5D185ADC7 /* SessionManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57ACC716C56B7F8E16DBDFB3 /* SessionManagerTests.swift */; };
@@ -76,6 +78,7 @@
 		56E59D06B02418F6D1057A03 /* ChatViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40319D5211156AC1671570F5 /* ChatViewTests.swift */; };
 		57BFD8048F458724D5220EE4 /* SidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F227EDAC8833CE0EA075111 /* SidebarView.swift */; };
 		58C18276239608ABD6F07EBB /* AudioSessionManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D5A7EA09817CE62F1FE9796 /* AudioSessionManagerTests.swift */; };
+		5B4147D9159DD55A0A8875B4 /* ComparisonResponseParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC11499E66D1CCC6F0EDB5EE /* ComparisonResponseParser.swift */; };
 		5DA2F76EA751F3EF0CB55386 /* StreamingTTSCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DF0427FCB8E6843FA1E136B /* StreamingTTSCoordinatorTests.swift */; };
 		5E86220B69F94E1D80BE6E21 /* PracticeTextLibrary_en.json in Resources */ = {isa = PBXBuildFile; fileRef = E021EB6D73273983DB9E14F6 /* PracticeTextLibrary_en.json */; };
 		5F51449B08403989803DD749 /* ResponseParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 192E20839A759A3AF4CC7D51 /* ResponseParser.swift */; };
@@ -104,6 +107,7 @@
 		803EEA750EBA59009E814F7C /* SayItClearlyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47BCCF7B7169BFF3B4722C58 /* SayItClearlyView.swift */; };
 		81160A48F23B0693F8B6BE38 /* VoiceInputViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FFAF667809AFED071F2163 /* VoiceInputViewModel.swift */; };
 		812AC213EB49FEC705555E09 /* ResponseParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8D179C236AD14B5C8076627 /* ResponseParserTests.swift */; };
+		81A961AB926731C065A38556 /* ComparisonPromptBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69C98EBC60AB392AA8868374 /* ComparisonPromptBuilder.swift */; };
 		81E23FA9C56B29B66E3ECD13 /* SeenTextsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC1974647876CBDFA39B8A71 /* SeenTextsStore.swift */; };
 		8253B0ABF87DA1DEF424AB4E /* MicrophoneButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8309BF4EE774FABE588555F4 /* MicrophoneButton.swift */; };
 		868CC677F0EF47C03E66115E /* BarbaraAvatarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36C6BF2F47F0B8EFFC2DF98B /* BarbaraAvatarView.swift */; };
@@ -119,10 +123,13 @@
 		940C00B95F727301E44CC7BC /* MicrophoneButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8309BF4EE774FABE588555F4 /* MicrophoneButton.swift */; };
 		945C5AB0AE1C1A1164802CF7 /* PracticeText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48A1CF3D22441AE55554B302 /* PracticeText.swift */; };
 		94BD55EA2659D676E06DEAAE /* MacChatInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C051275C85D1D1ED1778AC59 /* MacChatInputView.swift */; };
+		9B75A691D0F56293D7AF2B2B /* ComparisonPromptBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69C98EBC60AB392AA8868374 /* ComparisonPromptBuilder.swift */; };
 		9C6C847EC9BCCD14AE067A8A /* TTSPlaybackServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1964D965458CCC6A3A747B0 /* TTSPlaybackServiceTests.swift */; };
+		9D641BA106661D4AD460D3A1 /* AnswerKeyComparison.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1910976EBE55B2D0A2B347CA /* AnswerKeyComparison.swift */; };
 		9E229F94708A12673A30600F /* PINEntryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0B8EDE7E53601DCAC1DB42 /* PINEntryView.swift */; };
 		9E94F43764B254F793A66465 /* PINEntryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0B8EDE7E53601DCAC1DB42 /* PINEntryView.swift */; };
 		A21F3D22008E858CE7D1DE45 /* PracticeTextLibrary_de.json in Resources */ = {isa = PBXBuildFile; fileRef = BEE1CAA3817E82AA6D53AF15 /* PracticeTextLibrary_de.json */; };
+		A4A5E4A6E927A6FF4AE200B1 /* AnswerKeyComparer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AEAE8216CAB132332EE8012 /* AnswerKeyComparer.swift */; };
 		A6AC757407E2F30AB816970C /* MECEValidationEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D07B7B9E84CD6DF8BC6ACCF /* MECEValidationEngineTests.swift */; };
 		A8CD8951B7D4294936CBB7B7 /* ConnectionLinesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3915AE540EBA11321FA76BB /* ConnectionLinesView.swift */; };
 		A9313E9BDF1BFC6F4549F9ED /* MECEValidationEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64BCF114772DA58597F6EC7A /* MECEValidationEngine.swift */; };
@@ -184,11 +191,13 @@
 		E55D26181C652FF34FB5B162 /* PracticeText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48A1CF3D22441AE55554B302 /* PracticeText.swift */; };
 		E82E1F599E93664105775B47 /* LearnerProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49EB5CEF2D12A478BB1EA7AF /* LearnerProfile.swift */; };
 		E964ABEE2D1CD7095C2F2CFE /* BarbaraAvatarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36C6BF2F47F0B8EFFC2DF98B /* BarbaraAvatarView.swift */; };
+		E97996275531EAC63277B021 /* AnswerKeyComparisonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2A6B03C9A74B0140D2B2BE7 /* AnswerKeyComparisonTests.swift */; };
 		EA56A67113CF8CEB37FE4066 /* SessionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = C02627D1A73370A9B58BE9CC /* SessionState.swift */; };
 		EBE97AEDAD50F2E4A8AF50A3 /* PracticeTextLibraryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C70ADBF790944D3353F4FA32 /* PracticeTextLibraryTests.swift */; };
 		EC2B4036D1202B37FDCFF1B7 /* ParentGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B22653B114F07E9EA40C7C62 /* ParentGate.swift */; };
 		EC8D5C128F51D0CCF602CE9D /* SeenTextsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E399297963E1A59A4C958BFA /* SeenTextsTests.swift */; };
 		EE7B786DFC8E07B8C334D925 /* SpeechRecognitionServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D57221714F45B9C00201617 /* SpeechRecognitionServiceTests.swift */; };
+		F00F932F2105F4C2E508109B /* AnswerKeyComparer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AEAE8216CAB132332EE8012 /* AnswerKeyComparer.swift */; };
 		F0CC71F3229103F04C025A33 /* PracticeTextLibrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BFD6B8D5C586B0C9ADEEBA5 /* PracticeTextLibrary.swift */; };
 		F138325B5D79C1F7D86FD19F /* ErrorBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E27CEE853747DCC27BA168 /* ErrorBannerView.swift */; };
 		F1F057BADCA87A05AF322BC6 /* LearnerProfileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A1C0B31006940A2DBFE5E41 /* LearnerProfileTests.swift */; };
@@ -200,6 +209,7 @@
 		F9F35AAB16261DE9156AFA81 /* DraggableBlockView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4373E47CEF1B184CF62920CB /* DraggableBlockView.swift */; };
 		FB4A6CAC2211C3CE1456B0C4 /* ChatViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40319D5211156AC1671570F5 /* ChatViewTests.swift */; };
 		FC483FFC26C8467FF1807413 /* PyramidTreeState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72D83F01BEC457D843FA46B2 /* PyramidTreeState.swift */; };
+		FCDB2F855E3D272EABFC4626 /* AnswerKeyComparisonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2A6B03C9A74B0140D2B2BE7 /* AnswerKeyComparisonTests.swift */; };
 		FCFA826700749EA41FCB4FDC /* PyramidBlock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AC8B2C13C23B149624FD027 /* PyramidBlock.swift */; };
 		FEA6E6E26B1F513C393C1444 /* SessionPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A466760C86E7CBA8E140814 /* SessionPickerView.swift */; };
 		FF71C89423AE71ED46EE2B27 /* NetworkErrorHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91ECF5F1EF7623373F5BBD2C /* NetworkErrorHandler.swift */; };
@@ -227,12 +237,14 @@
 		02BB2E4C4988BEA73B0B9060 /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
 		0571FE24B4A26446F89C5096 /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
 		0756AEBC135E6923ED87C8A0 /* AdaptiveChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdaptiveChatView.swift; sourceTree = "<group>"; };
+		0AEAE8216CAB132332EE8012 /* AnswerKeyComparer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnswerKeyComparer.swift; sourceTree = "<group>"; };
 		0D5A7EA09817CE62F1FE9796 /* AudioSessionManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioSessionManagerTests.swift; sourceTree = "<group>"; };
 		0F511DE18C0C20C43553C36D /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
 		10F6CAB4EBA45B17A293C4C0 /* AnthropicModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnthropicModel.swift; sourceTree = "<group>"; };
 		1161CE00FACCF6715D7034A1 /* SidebarViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarViewTests.swift; sourceTree = "<group>"; };
 		1607A6E887C79A834F460459 /* AppLanguage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLanguage.swift; sourceTree = "<group>"; };
 		188F1F9BBC0111EE4F4EB660 /* Topic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Topic.swift; sourceTree = "<group>"; };
+		1910976EBE55B2D0A2B347CA /* AnswerKeyComparison.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnswerKeyComparison.swift; sourceTree = "<group>"; };
 		192E20839A759A3AF4CC7D51 /* ResponseParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResponseParser.swift; sourceTree = "<group>"; };
 		1B08B6C7C928249161C6C0AC /* ParentSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentSettingsView.swift; sourceTree = "<group>"; };
 		1BEBAE680A83F0277794FDFA /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
@@ -277,6 +289,7 @@
 		64BCF114772DA58597F6EC7A /* MECEValidationEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MECEValidationEngine.swift; sourceTree = "<group>"; };
 		65A78B634A6D6F9D4CD57BC7 /* SystemPromptAssemblerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemPromptAssemblerTests.swift; sourceTree = "<group>"; };
 		65D79D2FA2765B439235C94A /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
+		69C98EBC60AB392AA8868374 /* ComparisonPromptBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComparisonPromptBuilder.swift; sourceTree = "<group>"; };
 		6BCBA23B5D640E11325097D0 /* KeychainService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainService.swift; sourceTree = "<group>"; };
 		70A1CB45AEA63A237D7499E4 /* SessionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionManager.swift; sourceTree = "<group>"; };
 		72D83F01BEC457D843FA46B2 /* PyramidTreeState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PyramidTreeState.swift; sourceTree = "<group>"; };
@@ -328,6 +341,7 @@
 		D2F4D31053E77ACAC3D6E7D2 /* BarbaraVoiceProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarbaraVoiceProfile.swift; sourceTree = "<group>"; };
 		D6C50086B3A681AE4B706D0B /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
 		D7340051027E1031862796AD /* LearnerProfileStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearnerProfileStore.swift; sourceTree = "<group>"; };
+		DC11499E66D1CCC6F0EDB5EE /* ComparisonResponseParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComparisonResponseParser.swift; sourceTree = "<group>"; };
 		DC1974647876CBDFA39B8A71 /* SeenTextsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeenTextsStore.swift; sourceTree = "<group>"; };
 		DE9990EFFDBC213F3F1D0B19 /* SayItRightApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SayItRightApp.swift; sourceTree = "<group>"; };
 		E021EB6D73273983DB9E14F6 /* PracticeTextLibrary_en.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = PracticeTextLibrary_en.json; sourceTree = "<group>"; };
@@ -337,6 +351,7 @@
 		E4F296F432E8A069994E5167 /* TTSPlaybackService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TTSPlaybackService.swift; sourceTree = "<group>"; };
 		E53301B75E9027FAD04FAA44 /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
 		ED72B2F78895FD96D69C5698 /* AudioSessionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioSessionManager.swift; sourceTree = "<group>"; };
+		F2A6B03C9A74B0140D2B2BE7 /* AnswerKeyComparisonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnswerKeyComparisonTests.swift; sourceTree = "<group>"; };
 		F4096FB5122C41B3F25CCFB2 /* SystemPromptAssembler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemPromptAssembler.swift; sourceTree = "<group>"; };
 		F70F04FAE54C5FB6BC13D7E5 /* AppVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppVersion.swift; sourceTree = "<group>"; };
 		F75B735D96C774F30B95405C /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
@@ -503,6 +518,7 @@
 		9CA9825E2539A59A51BE06B7 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				F2A6B03C9A74B0140D2B2BE7 /* AnswerKeyComparisonTests.swift */,
 				F77568CC779F6818DEF9ADCC /* AnthropicServiceTests.swift */,
 				0D5A7EA09817CE62F1FE9796 /* AudioSessionManagerTests.swift */,
 				A553A59D04C7ABFA86CF117E /* BarbaraAvatarTests.swift */,
@@ -563,6 +579,10 @@
 			isa = PBXGroup;
 			children = (
 				1BEBAE680A83F0277794FDFA /* .gitkeep */,
+				0AEAE8216CAB132332EE8012 /* AnswerKeyComparer.swift */,
+				1910976EBE55B2D0A2B347CA /* AnswerKeyComparison.swift */,
+				69C98EBC60AB392AA8868374 /* ComparisonPromptBuilder.swift */,
+				DC11499E66D1CCC6F0EDB5EE /* ComparisonResponseParser.swift */,
 				64BCF114772DA58597F6EC7A /* MECEValidationEngine.swift */,
 			);
 			path = StructuralEvaluator;
@@ -854,6 +874,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E97996275531EAC63277B021 /* AnswerKeyComparisonTests.swift in Sources */,
 				00D8301F3E74117DF9AA973B /* AnthropicServiceTests.swift in Sources */,
 				58C18276239608ABD6F07EBB /* AudioSessionManagerTests.swift in Sources */,
 				232A2240F8CDCBF5093977DA /* BarbaraAvatarTests.swift in Sources */,
@@ -887,6 +908,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FCDB2F855E3D272EABFC4626 /* AnswerKeyComparisonTests.swift in Sources */,
 				908ED70F336A90E3DBF4E198 /* AnthropicServiceTests.swift in Sources */,
 				60E3DD654D41C484DFD3281E /* AudioSessionManagerTests.swift in Sources */,
 				DE38095862958923B2416C42 /* BarbaraAvatarTests.swift in Sources */,
@@ -921,6 +943,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				49828FC1CE9DAC9540F13C29 /* AdaptiveChatView.swift in Sources */,
+				A4A5E4A6E927A6FF4AE200B1 /* AnswerKeyComparer.swift in Sources */,
+				33D64B1F80E3DC6DAB7F372D /* AnswerKeyComparison.swift in Sources */,
 				A9BA44DA0F1F2B687C7EB602 /* AnthropicModel.swift in Sources */,
 				2C1D8AB58512AA4B4605815E /* AnthropicService.swift in Sources */,
 				DDD2F11F3AD9916F6E39F996 /* AppLanguage.swift in Sources */,
@@ -933,6 +957,8 @@
 				CB11CF599D010F75FA77C233 /* ChatMessage.swift in Sources */,
 				042513332D5A484B14A5DE76 /* ChatView.swift in Sources */,
 				2A465A472C7B43AE1FCFDECE /* ChatViewModel.swift in Sources */,
+				9B75A691D0F56293D7AF2B2B /* ComparisonPromptBuilder.swift in Sources */,
+				0DDC5480C5521B99A77E02A0 /* ComparisonResponseParser.swift in Sources */,
 				B9A55A00D5E93D6AC049A85C /* ConfigProvider.swift in Sources */,
 				B9E64E1CAA8464301C3DC563 /* ConnectionLinesView.swift in Sources */,
 				F3EA6C9E62178099319F591E /* DebugLogView.swift in Sources */,
@@ -993,6 +1019,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				5F73FE131A1DB6BA939A2C5A /* AdaptiveChatView.swift in Sources */,
+				F00F932F2105F4C2E508109B /* AnswerKeyComparer.swift in Sources */,
+				9D641BA106661D4AD460D3A1 /* AnswerKeyComparison.swift in Sources */,
 				2B62856D49AD9FB989384F80 /* AnthropicModel.swift in Sources */,
 				0A34DEDADFDCDA5E7ADE5A1C /* AnthropicService.swift in Sources */,
 				08B73D82C6BB007D6B4AFE15 /* AppLanguage.swift in Sources */,
@@ -1005,6 +1033,8 @@
 				6C681A520B587FCEBFAE81B9 /* ChatMessage.swift in Sources */,
 				26F70AF1E1BDF322EBFDC2B8 /* ChatView.swift in Sources */,
 				78D4EC3D68AAF8BB663C0E46 /* ChatViewModel.swift in Sources */,
+				81A961AB926731C065A38556 /* ComparisonPromptBuilder.swift in Sources */,
+				5B4147D9159DD55A0A8875B4 /* ComparisonResponseParser.swift in Sources */,
 				1DA60359B8EB91B16DB3188F /* ConfigProvider.swift in Sources */,
 				A8CD8951B7D4294936CBB7B7 /* ConnectionLinesView.swift in Sources */,
 				3C009DF5A5015AB1595F05B2 /* DebugLogView.swift in Sources */,

--- a/app/SayItRight/Tests/AnswerKeyComparisonTests.swift
+++ b/app/SayItRight/Tests/AnswerKeyComparisonTests.swift
@@ -1,0 +1,350 @@
+import XCTest
+@testable import SayItRight
+
+final class AnswerKeyComparisonTests: XCTestCase {
+
+    // MARK: - Test Fixtures
+
+    private let samplePracticeText = PracticeText(
+        id: "pt-test-001",
+        text: "Remote work has transformed the modern workplace. Studies show productivity increases of 13% among remote workers. Companies save an average of $11,000 per remote employee annually. However, collaboration suffers without in-person interaction, and junior employees miss mentoring opportunities.",
+        answerKey: AnswerKey(
+            governingThought: "Remote work offers significant productivity and cost benefits but creates challenges for collaboration and professional development.",
+            supports: [
+                SupportGroup(
+                    label: "Productivity gains",
+                    evidence: ["13% productivity increase in studies"]
+                ),
+                SupportGroup(
+                    label: "Cost savings",
+                    evidence: ["$11,000 saved per remote employee annually"]
+                ),
+                SupportGroup(
+                    label: "Collaboration challenges",
+                    evidence: [
+                        "Collaboration suffers without in-person interaction",
+                        "Junior employees miss mentoring opportunities"
+                    ]
+                )
+            ],
+            structuralAssessment: "Well-structured argument with clear governing thought and three support pillars balancing benefits against drawbacks."
+        ),
+        metadata: PracticeTextMetadata(
+            qualityLevel: .wellStructured,
+            difficultyRating: 2,
+            topicDomain: "workplace",
+            language: "en",
+            wordCount: 48,
+            targetLevel: 1
+        )
+    )
+
+    private let adversarialPracticeText = PracticeText(
+        id: "pt-test-002",
+        text: "Electric cars are better because they are electric. They use electricity instead of gas, which makes them superior. Since they run on batteries, they are the future of transportation.",
+        answerKey: AnswerKey(
+            governingThought: "Electric cars are better than gas cars.",
+            supports: [
+                SupportGroup(
+                    label: "Electric power",
+                    evidence: ["They use electricity instead of gas"]
+                ),
+                SupportGroup(
+                    label: "Battery technology",
+                    evidence: ["They run on batteries"]
+                )
+            ],
+            structuralAssessment: "Circular reasoning — the conclusion restates the premise without independent evidence.",
+            structuralFlaw: StructuralFlaw(
+                type: "circular_reasoning",
+                description: "The argument that electric cars are better because they are electric is circular — it restates the premise as the conclusion.",
+                location: "paragraph 1, sentence 1"
+            )
+        ),
+        metadata: PracticeTextMetadata(
+            qualityLevel: .adversarial,
+            difficultyRating: 3,
+            topicDomain: "technology",
+            language: "en",
+            wordCount: 35,
+            targetLevel: 2
+        )
+    )
+
+    // MARK: - ComparisonResponseParser Tests
+
+    private let parser = ComparisonResponseParser()
+
+    func testParseHighMatchFindThePoint() {
+        let response = """
+        Excellent! You've identified the governing thought precisely. The text argues that remote work has trade-offs, and you captured both the benefits and the challenges.
+
+        <!-- COMPARISON_META: {"matchQuality":"high","dimensionScores":{"governingThoughtAccuracy":3,"specificity":3,"supportAwareness":2},"mood":"approving","progressionSignal":"improving","sessionPhase":"evaluation","feedbackFocus":"Strong extraction — now work on identifying all support pillars.","language":"en"} -->
+        """
+
+        let result = parser.parse(fullResponse: response)
+
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result!.matchQuality, .high)
+        XCTAssertEqual(result!.dimensionScores["governingThoughtAccuracy"], 3)
+        XCTAssertEqual(result!.dimensionScores["specificity"], 3)
+        XCTAssertEqual(result!.dimensionScores["supportAwareness"], 2)
+        XCTAssertEqual(result!.metadata.mood, "approving")
+        XCTAssertEqual(result!.metadata.progressionSignal, "improving")
+        XCTAssertFalse(result!.feedback.contains("COMPARISON_META"))
+        XCTAssertTrue(result!.feedback.contains("Excellent"))
+    }
+
+    func testParsePartialMatchFixThisMess() {
+        let response = """
+        You've found a governing thought, but your grouping needs work. The three support pillars aren't clearly separated — productivity and cost savings are lumped together.
+
+        <!-- COMPARISON_META: {"matchQuality":"partial","dimensionScores":{"pyramidValidity":2,"groupingQuality":1,"orderingLogic":2,"completeness":3},"mood":"teaching","progressionSignal":"none","sessionPhase":"evaluation","feedbackFocus":"Focus on MECE grouping.","language":"en"} -->
+        """
+
+        let result = parser.parse(fullResponse: response)
+
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result!.matchQuality, .partial)
+        XCTAssertEqual(result!.dimensionScores["pyramidValidity"], 2)
+        XCTAssertEqual(result!.dimensionScores["groupingQuality"], 1)
+        XCTAssertEqual(result!.dimensionScores["orderingLogic"], 2)
+        XCTAssertEqual(result!.dimensionScores["completeness"], 3)
+        XCTAssertEqual(result!.metadata.mood, "teaching")
+    }
+
+    func testParseLowMatchSpotTheGap() {
+        let response = """
+        That's not the structural flaw. You identified a content disagreement, not a reasoning error. Look again: the argument's conclusion restates its own premise.
+
+        <!-- COMPARISON_META: {"matchQuality":"low","dimensionScores":{"flawIdentification":0,"locationAccuracy":1,"explanationClarity":1},"mood":"disappointed","progressionSignal":"struggling","sessionPhase":"evaluation","feedbackFocus":"Distinguish content critique from structural critique.","language":"en"} -->
+        """
+
+        let result = parser.parse(fullResponse: response)
+
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result!.matchQuality, .low)
+        XCTAssertEqual(result!.dimensionScores["flawIdentification"], 0)
+        XCTAssertEqual(result!.metadata.mood, "disappointed")
+        XCTAssertEqual(result!.metadata.progressionSignal, "struggling")
+    }
+
+    func testParseGermanResponse() {
+        let response = """
+        Gut erkannt! Der Kerngedanke ist klar formuliert. Arbeite jetzt daran, die Stützpfeiler sauber zu benennen.
+
+        <!-- COMPARISON_META: {"matchQuality":"high","dimensionScores":{"governingThoughtAccuracy":3,"specificity":2,"supportAwareness":2},"mood":"approving","progressionSignal":"improving","sessionPhase":"evaluation","feedbackFocus":"Stützpfeiler benennen.","language":"de"} -->
+        """
+
+        let result = parser.parse(fullResponse: response)
+
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result!.matchQuality, .high)
+        XCTAssertEqual(result!.metadata.language, "de")
+        XCTAssertTrue(result!.feedback.contains("Gut erkannt"))
+    }
+
+    func testParseMissingMetadataReturnsNil() {
+        let response = "Just some plain text without metadata."
+        let result = parser.parse(fullResponse: response)
+        XCTAssertNil(result)
+    }
+
+    func testParseMalformedJSONReturnsNil() {
+        let response = """
+        Good work.
+
+        <!-- COMPARISON_META: {not valid json at all} -->
+        """
+        let result = parser.parse(fullResponse: response)
+        XCTAssertNil(result)
+    }
+
+    func testParseInvalidMatchQualityReturnsNil() {
+        let response = """
+        Good work.
+
+        <!-- COMPARISON_META: {"matchQuality":"excellent","dimensionScores":{"a":1},"mood":"approving","progressionSignal":"none","sessionPhase":"evaluation","feedbackFocus":"x","language":"en"} -->
+        """
+        let result = parser.parse(fullResponse: response)
+        XCTAssertNil(result)
+    }
+
+    func testParseMultipleMetaBlocksUsesLast() {
+        let response = """
+        First attempt feedback.
+
+        <!-- COMPARISON_META: {"matchQuality":"low","dimensionScores":{"governingThoughtAccuracy":1},"mood":"skeptical","progressionSignal":"none","sessionPhase":"evaluation","feedbackFocus":"x","language":"en"} -->
+
+        Revised feedback after reconsideration.
+
+        <!-- COMPARISON_META: {"matchQuality":"partial","dimensionScores":{"governingThoughtAccuracy":2},"mood":"teaching","progressionSignal":"improving","sessionPhase":"evaluation","feedbackFocus":"y","language":"en"} -->
+        """
+
+        let result = parser.parse(fullResponse: response)
+
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result!.matchQuality, .partial)
+        XCTAssertEqual(result!.dimensionScores["governingThoughtAccuracy"], 2)
+        XCTAssertEqual(result!.metadata.mood, "teaching")
+        XCTAssertFalse(result!.feedback.contains("COMPARISON_META"))
+    }
+
+    // MARK: - ComparisonPromptBuilder Tests
+
+    private let promptBuilder = ComparisonPromptBuilder()
+
+    func testFindThePointPromptContainsDimensions() {
+        let input = ComparisonInput(
+            userResponse: "The text argues remote work has trade-offs.",
+            practiceText: samplePracticeText,
+            sessionType: .findThePoint,
+            language: "en",
+            learnerLevel: 1
+        )
+
+        let systemPrompt = promptBuilder.systemPrompt(for: input)
+
+        XCTAssertTrue(systemPrompt.contains("governingThoughtAccuracy"))
+        XCTAssertTrue(systemPrompt.contains("specificity"))
+        XCTAssertTrue(systemPrompt.contains("supportAwareness"))
+        XCTAssertTrue(systemPrompt.contains("Find the Point"))
+        XCTAssertFalse(systemPrompt.contains("pyramidValidity"))
+    }
+
+    func testFixThisMessPromptContainsDimensions() {
+        let input = ComparisonInput(
+            userResponse: "Restructured version here.",
+            practiceText: samplePracticeText,
+            sessionType: .fixThisMess,
+            language: "en",
+            learnerLevel: 1
+        )
+
+        let systemPrompt = promptBuilder.systemPrompt(for: input)
+
+        XCTAssertTrue(systemPrompt.contains("pyramidValidity"))
+        XCTAssertTrue(systemPrompt.contains("groupingQuality"))
+        XCTAssertTrue(systemPrompt.contains("orderingLogic"))
+        XCTAssertTrue(systemPrompt.contains("completeness"))
+        XCTAssertTrue(systemPrompt.contains("Fix This Mess"))
+    }
+
+    func testSpotTheGapPromptContainsDimensions() {
+        let input = ComparisonInput(
+            userResponse: "The argument is circular.",
+            practiceText: adversarialPracticeText,
+            sessionType: .spotTheGap,
+            language: "en",
+            learnerLevel: 2
+        )
+
+        let systemPrompt = promptBuilder.systemPrompt(for: input)
+
+        XCTAssertTrue(systemPrompt.contains("flawIdentification"))
+        XCTAssertTrue(systemPrompt.contains("locationAccuracy"))
+        XCTAssertTrue(systemPrompt.contains("explanationClarity"))
+        XCTAssertTrue(systemPrompt.contains("Spot the Gap"))
+    }
+
+    func testGermanPromptUsesGerman() {
+        let input = ComparisonInput(
+            userResponse: "Der Kerngedanke ist...",
+            practiceText: samplePracticeText,
+            sessionType: .findThePoint,
+            language: "de",
+            learnerLevel: 1
+        )
+
+        let systemPrompt = promptBuilder.systemPrompt(for: input)
+
+        XCTAssertTrue(systemPrompt.contains("Bewertungskriterien"))
+        XCTAssertTrue(systemPrompt.contains("Finde den Punkt"))
+        XCTAssertTrue(systemPrompt.contains("Ausgabeformat"))
+    }
+
+    func testUserMessageContainsPracticeTextAndAnswerKey() {
+        let input = ComparisonInput(
+            userResponse: "My analysis of the text.",
+            practiceText: samplePracticeText,
+            sessionType: .findThePoint,
+            language: "en",
+            learnerLevel: 1
+        )
+
+        let userMessage = promptBuilder.userMessage(for: input)
+
+        XCTAssertTrue(userMessage.contains("## Practice Text"))
+        XCTAssertTrue(userMessage.contains("Remote work has transformed"))
+        XCTAssertTrue(userMessage.contains("## Answer Key"))
+        XCTAssertTrue(userMessage.contains("Governing Thought"))
+        XCTAssertTrue(userMessage.contains("## User's Response"))
+        XCTAssertTrue(userMessage.contains("My analysis of the text."))
+    }
+
+    func testUserMessageIncludesStructuralFlaw() {
+        let input = ComparisonInput(
+            userResponse: "The argument is circular.",
+            practiceText: adversarialPracticeText,
+            sessionType: .spotTheGap,
+            language: "en",
+            learnerLevel: 2
+        )
+
+        let userMessage = promptBuilder.userMessage(for: input)
+
+        XCTAssertTrue(userMessage.contains("Structural Flaw"))
+        XCTAssertTrue(userMessage.contains("circular_reasoning"))
+    }
+
+    // MARK: - ComparisonInput and Result model tests
+
+    func testMatchQualityRawValues() {
+        XCTAssertEqual(MatchQuality(rawValue: "high"), .high)
+        XCTAssertEqual(MatchQuality(rawValue: "partial"), .partial)
+        XCTAssertEqual(MatchQuality(rawValue: "low"), .low)
+        XCTAssertNil(MatchQuality(rawValue: "medium"))
+    }
+
+    func testComparisonSessionTypeRawValues() {
+        XCTAssertEqual(ComparisonSessionType(rawValue: "find_the_point"), .findThePoint)
+        XCTAssertEqual(ComparisonSessionType(rawValue: "fix_this_mess"), .fixThisMess)
+        XCTAssertEqual(ComparisonSessionType(rawValue: "spot_the_gap"), .spotTheGap)
+    }
+
+    func testAnswerKeyComparisonResultCodable() throws {
+        let result = AnswerKeyComparisonResult(
+            matchQuality: .high,
+            feedback: "Well done!",
+            dimensionScores: ["governingThoughtAccuracy": 3, "specificity": 2],
+            metadata: ComparisonMetadata(
+                mood: "approving",
+                progressionSignal: "improving",
+                sessionPhase: "evaluation",
+                feedbackFocus: "Keep it up.",
+                language: "en"
+            )
+        )
+
+        let data = try JSONEncoder().encode(result)
+        let decoded = try JSONDecoder().decode(AnswerKeyComparisonResult.self, from: data)
+
+        XCTAssertEqual(decoded, result)
+    }
+
+    // MARK: - Prompt builder: output format includes correct COMPARISON_META tag
+
+    func testOutputFormatSpecifiesComparisonMetaTag() {
+        let input = ComparisonInput(
+            userResponse: "test",
+            practiceText: samplePracticeText,
+            sessionType: .findThePoint,
+            language: "en",
+            learnerLevel: 1
+        )
+
+        let systemPrompt = promptBuilder.systemPrompt(for: input)
+        XCTAssertTrue(systemPrompt.contains("COMPARISON_META"))
+        XCTAssertTrue(systemPrompt.contains("matchQuality"))
+    }
+}


### PR DESCRIPTION
## Summary
- Implements semantic structural comparison between user responses and practice text answer keys via Claude API
- Supports three Break-mode session types: `find_the_point`, `fix_this_mess`, `spot_the_gap`, each with tailored evaluation rubrics
- Bilingual prompt generation (EN/DE) with session-type-specific dimensions and match quality scale (high/partial/low)
- Comparison is structural, not textual — differently-worded but structurally equivalent extractions are accepted
- Uses `COMPARISON_META` HTML comment pattern (analogous to `BARBARA_META`) for hidden metadata

## New Files
- `Intelligence/StructuralEvaluator/AnswerKeyComparison.swift` — Data types (ComparisonInput, AnswerKeyComparisonResult, MatchQuality, ComparisonMetadata)
- `Intelligence/StructuralEvaluator/ComparisonPromptBuilder.swift` — Builds system prompt and user message per session type
- `Intelligence/StructuralEvaluator/ComparisonResponseParser.swift` — Parses COMPARISON_META from Claude responses
- `Intelligence/StructuralEvaluator/AnswerKeyComparer.swift` — Orchestrates the comparison via AnthropicService
- `Tests/AnswerKeyComparisonTests.swift` — 18 unit tests covering parser, prompt builder, and data models

## Test plan
- [x] All 18 unit tests pass (`AnswerKeyComparisonTests`)
- [x] Build succeeds on macOS (arm64)
- [ ] Verify prompt quality with real Claude API call (manual)

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)