### PR TITLE
feat: structural evaluation integration (SIR-029)

### DIFF
--- a/app/SayItRight/Intelligence/ConversationManager/SessionManager.swift
+++ b/app/SayItRight/Intelligence/ConversationManager/SessionManager.swift
@@ -30,14 +30,19 @@ final class SessionManager {
     /// The active "Say it clearly" session state, if any.
     private(set) var sayItClearlySession: SayItClearlySession?
 
+
     /// The active "Find the point" session state, if any.
     private(set) var findThePointSession: FindThePointSession?
+ 
+    /// The latest evaluation result from the structural evaluator.
+    private(set) var lastEvaluationResult: EvaluationResult?
 
     // MARK: - Dependencies
 
     private let anthropicService: AnthropicService
     private let systemPromptAssembler: SystemPromptAssembler
     private let responseParser: ResponseParser
+    let structuralEvaluator: StructuralEvaluator
 
     // MARK: - Configuration
 
@@ -52,11 +57,13 @@ final class SessionManager {
     init(
         anthropicService: AnthropicService = .shared,
         systemPromptAssembler: SystemPromptAssembler = SystemPromptAssembler(),
-        responseParser: ResponseParser = ResponseParser()
+        responseParser: ResponseParser = ResponseParser(),
+        structuralEvaluator: StructuralEvaluator = StructuralEvaluator()
     ) {
         self.anthropicService = anthropicService
         self.systemPromptAssembler = systemPromptAssembler
         self.responseParser = responseParser
+        self.structuralEvaluator = structuralEvaluator
     }
 
     // MARK: - Public API
@@ -76,7 +83,10 @@ final class SessionManager {
         sessionMetadata = []
         activeSessionType = type
         sayItClearlySession = nil
+
         findThePointSession = nil
+ 
+        lastEvaluationResult = nil
         sessionState = .loading
 
         // Assemble system prompt
@@ -85,6 +95,14 @@ final class SessionManager {
             sessionType: type.rawValue,
             language: language,
             profileJSON: profile.toPromptJSON()
+        )
+
+        // Prepare the structural evaluator with cached prompt for this session
+        await structuralEvaluator.prepareSession(
+            level: profile.currentLevel,
+            sessionType: type.rawValue,
+            language: language,
+            profile: profile
         )
 
         // Request Barbara's greeting
@@ -106,7 +124,10 @@ final class SessionManager {
         sessionMetadata = []
         activeSessionType = .sayItClearly
         sayItClearlySession = SayItClearlySession(topic: topic)
+
         findThePointSession = nil
+ 
+        lastEvaluationResult = nil
         sessionState = .loading
 
         // Assemble system prompt with topic directive appended
@@ -119,6 +140,14 @@ final class SessionManager {
 
         let topicDirective = topicDirectiveBlock(topic: topic, language: language)
         systemPrompt = basePrompt + "\n\n" + topicDirective
+
+        // Prepare the structural evaluator for this session
+        await structuralEvaluator.prepareSession(
+            level: profile.currentLevel,
+            sessionType: SessionType.sayItClearly.rawValue,
+            language: language,
+            profile: profile
+        )
 
         // Request Barbara's greeting (she will present the topic)
         await streamBarbaraResponse()
@@ -252,11 +281,25 @@ final class SessionManager {
     func endSession() {
         activeSessionType = nil
         sayItClearlySession = nil
+
         findThePointSession = nil
+ 
+        lastEvaluationResult = nil
         sessionState = .idle
         messages = []
         systemPrompt = ""
         // sessionMetadata is preserved until next startSession
+        Task { await structuralEvaluator.reset() }
+    }
+
+    /// The number of remaining evaluation calls in this session.
+    var remainingEvaluations: Int {
+        get async { await structuralEvaluator.remainingCalls }
+    }
+
+    /// The number of evaluation calls made in this session.
+    var evaluationCallCount: Int {
+        get async { await structuralEvaluator.callCount }
     }
 
     // MARK: - Private: Streaming
@@ -304,6 +347,14 @@ final class SessionManager {
             if let metadata = parsed.metadata {
                 messages[streamingIndex].metadata = metadata
                 sessionMetadata.append(metadata)
+
+                // Capture evaluation result when the response contains scores
+                if !metadata.scores.isEmpty {
+                    lastEvaluationResult = EvaluationResult(
+                        feedbackText: parsed.visibleText,
+                        metadata: metadata
+                    )
+                }
             }
 
             sessionState = .active

--- a/app/SayItRight/Intelligence/StructuralEvaluator/EvaluationResult.swift
+++ b/app/SayItRight/Intelligence/StructuralEvaluator/EvaluationResult.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// The result of a structural evaluation of the learner's response.
+///
+/// Contains Barbara's visible feedback text and the parsed scoring data
+/// extracted from the hidden `BARBARA_META` block. The scoring data maps
+/// to the L1/L2 rubric dimensions defined in the prompt blocks.
+struct EvaluationResult: Sendable {
+
+    /// Barbara's visible feedback text (metadata stripped).
+    let feedbackText: String
+
+    /// Parsed hidden metadata with scores and progression signals.
+    let metadata: BarbaraMetadata?
+
+    /// Dimension-level scores extracted from metadata for convenience.
+    var dimensionScores: [String: Int] {
+        metadata?.scores ?? [:]
+    }
+
+    /// The total score across all rubric dimensions.
+    var totalScore: Int {
+        metadata?.totalScore ?? 0
+    }
+
+    /// Whether the evaluation contains valid scoring data.
+    var hasScores: Bool {
+        metadata != nil && !(metadata!.scores.isEmpty)
+    }
+
+    /// The progression signal from this evaluation.
+    var progressionSignal: ProgressionSignal {
+        metadata?.progressionSignal ?? .none
+    }
+
+    /// Barbara's mood based on the evaluation.
+    var mood: BarbaraMood {
+        metadata?.mood ?? .evaluating
+    }
+
+    /// Which structural element Barbara is focusing feedback on.
+    var feedbackFocus: String {
+        metadata?.feedbackFocus ?? ""
+    }
+}

--- a/app/SayItRight/Intelligence/StructuralEvaluator/StructuralEvaluator.swift
+++ b/app/SayItRight/Intelligence/StructuralEvaluator/StructuralEvaluator.swift
@@ -1,0 +1,88 @@
+import Foundation
+
+enum EvaluationError: Error, LocalizedError, Sendable, Equatable {
+    case missingMetadata
+    case rateLimitExceeded(limit: Int)
+    case evaluationTimeout
+    case promptAssemblyFailed
+
+    var errorDescription: String? {
+        switch self {
+        case .missingMetadata:
+            "Barbara's evaluation was incomplete — no scoring data received."
+        case .rateLimitExceeded(let limit):
+            "Session limit reached (\(limit) evaluations). Start a new session to continue."
+        case .evaluationTimeout:
+            "Evaluation took too long. Try again."
+        case .promptAssemblyFailed:
+            "Could not assemble the evaluation prompt. Check that prompt blocks are available."
+        }
+    }
+}
+
+actor StructuralEvaluator {
+    private let anthropicService: AnthropicService
+    private let systemPromptAssembler: SystemPromptAssembler
+    private let responseParser: ResponseParser
+    private let maxCallsPerSession: Int
+    private(set) var callCount: Int = 0
+    private var cachedSystemPrompt: String?
+
+    init(
+        anthropicService: AnthropicService = .shared,
+        systemPromptAssembler: SystemPromptAssembler = SystemPromptAssembler(),
+        responseParser: ResponseParser = ResponseParser(),
+        maxCallsPerSession: Int = 10
+    ) {
+        self.anthropicService = anthropicService
+        self.systemPromptAssembler = systemPromptAssembler
+        self.responseParser = responseParser
+        self.maxCallsPerSession = maxCallsPerSession
+    }
+
+    func prepareSession(level: Int, sessionType: String, language: String, profile: LearnerProfile) {
+        callCount = 0
+        cachedSystemPrompt = systemPromptAssembler.assemble(
+            level: level, sessionType: sessionType, language: language, profileJSON: profile.toPromptJSON()
+        )
+    }
+
+    func evaluate(
+        conversationMessages: [APIMessage],
+        systemPromptOverride: String? = nil
+    ) async throws -> StreamingEvaluation {
+        guard callCount < maxCallsPerSession else {
+            throw EvaluationError.rateLimitExceeded(limit: maxCallsPerSession)
+        }
+        let prompt = systemPromptOverride ?? cachedSystemPrompt
+        guard let systemPrompt = prompt, !systemPrompt.isEmpty else {
+            throw EvaluationError.promptAssemblyFailed
+        }
+        callCount += 1
+        let stream = await anthropicService.sendMessage(systemPrompt: systemPrompt, messages: conversationMessages)
+        return StreamingEvaluation(textStream: stream, responseParser: responseParser)
+    }
+
+    func reset() { callCount = 0; cachedSystemPrompt = nil }
+    var remainingCalls: Int { max(0, maxCallsPerSession - callCount) }
+}
+
+struct StreamingEvaluation: Sendable {
+    let textStream: AsyncThrowingStream<String, Error>
+    private let responseParser: ResponseParser
+
+    init(textStream: AsyncThrowingStream<String, Error>, responseParser: ResponseParser) {
+        self.textStream = textStream
+        self.responseParser = responseParser
+    }
+
+    func collect(onChunk: @Sendable (String) -> Void = { _ in }) async throws -> EvaluationResult {
+        var fullText = ""
+        for try await chunk in textStream {
+            fullText += chunk
+            onChunk(chunk)
+        }
+        let parsed = responseParser.parse(fullResponse: fullText)
+        return EvaluationResult(feedbackText: parsed.visibleText, metadata: parsed.metadata)
+    }
+}

--- a/app/SayItRight/Tests/StructuralEvaluatorTests.swift
+++ b/app/SayItRight/Tests/StructuralEvaluatorTests.swift
@@ -1,0 +1,398 @@
+import Testing
+@testable import SayItRight
+
+// MARK: - EvaluationResult Tests
+
+@Suite("EvaluationResult")
+struct EvaluationResultTests {
+
+    private static func sampleMetadata(
+        scores: [String: Int] = ["governingThought": 3, "supportGrouping": 2, "redundancy": 1, "clarity": 3],
+        totalScore: Int = 9,
+        mood: BarbaraMood = .evaluating,
+        progressionSignal: ProgressionSignal = .improving
+    ) -> BarbaraMetadata {
+        BarbaraMetadata(
+            scores: scores,
+            totalScore: totalScore,
+            mood: mood,
+            progressionSignal: progressionSignal,
+            revisionRound: 1,
+            sessionPhase: .evaluation,
+            feedbackFocus: "Your conclusion is strong but buried.",
+            language: "en"
+        )
+    }
+
+    @Test("dimensionScores returns scores from metadata")
+    func dimensionScores() {
+        let result = EvaluationResult(
+            feedbackText: "Good work.",
+            metadata: Self.sampleMetadata()
+        )
+        #expect(result.dimensionScores["governingThought"] == 3)
+        #expect(result.dimensionScores["supportGrouping"] == 2)
+        #expect(result.dimensionScores["redundancy"] == 1)
+        #expect(result.dimensionScores["clarity"] == 3)
+    }
+
+    @Test("dimensionScores returns empty dict when metadata is nil")
+    func dimensionScoresNilMetadata() {
+        let result = EvaluationResult(feedbackText: "No scores.", metadata: nil)
+        #expect(result.dimensionScores.isEmpty)
+    }
+
+    @Test("totalScore returns value from metadata")
+    func totalScore() {
+        let result = EvaluationResult(
+            feedbackText: "Feedback",
+            metadata: Self.sampleMetadata(totalScore: 9)
+        )
+        #expect(result.totalScore == 9)
+    }
+
+    @Test("totalScore returns 0 when metadata is nil")
+    func totalScoreNilMetadata() {
+        let result = EvaluationResult(feedbackText: "No meta.", metadata: nil)
+        #expect(result.totalScore == 0)
+    }
+
+    @Test("hasScores is true when metadata has scores")
+    func hasScoresTrue() {
+        let result = EvaluationResult(
+            feedbackText: "Feedback",
+            metadata: Self.sampleMetadata()
+        )
+        #expect(result.hasScores)
+    }
+
+    @Test("hasScores is false when metadata is nil")
+    func hasScoresFalseNil() {
+        let result = EvaluationResult(feedbackText: "No meta.", metadata: nil)
+        #expect(!result.hasScores)
+    }
+
+    @Test("hasScores is false when scores dict is empty")
+    func hasScoresFalseEmpty() {
+        let result = EvaluationResult(
+            feedbackText: "Feedback",
+            metadata: Self.sampleMetadata(scores: [:], totalScore: 0)
+        )
+        #expect(!result.hasScores)
+    }
+
+    @Test("progressionSignal returns value from metadata")
+    func progressionSignal() {
+        let result = EvaluationResult(
+            feedbackText: "Good progress.",
+            metadata: Self.sampleMetadata(progressionSignal: .readyForLevelUp)
+        )
+        #expect(result.progressionSignal == .readyForLevelUp)
+    }
+
+    @Test("progressionSignal defaults to .none when metadata is nil")
+    func progressionSignalDefault() {
+        let result = EvaluationResult(feedbackText: "No meta.", metadata: nil)
+        #expect(result.progressionSignal == .none)
+    }
+
+    @Test("mood returns value from metadata")
+    func mood() {
+        let result = EvaluationResult(
+            feedbackText: "Nice!",
+            metadata: Self.sampleMetadata(mood: .proud)
+        )
+        #expect(result.mood == .proud)
+    }
+
+    @Test("mood defaults to .evaluating when metadata is nil")
+    func moodDefault() {
+        let result = EvaluationResult(feedbackText: "No meta.", metadata: nil)
+        #expect(result.mood == .evaluating)
+    }
+
+    @Test("feedbackFocus returns value from metadata")
+    func feedbackFocus() {
+        let result = EvaluationResult(
+            feedbackText: "Feedback",
+            metadata: Self.sampleMetadata()
+        )
+        #expect(result.feedbackFocus == "Your conclusion is strong but buried.")
+    }
+
+    @Test("feedbackFocus returns empty string when metadata is nil")
+    func feedbackFocusDefault() {
+        let result = EvaluationResult(feedbackText: "No meta.", metadata: nil)
+        #expect(result.feedbackFocus.isEmpty)
+    }
+}
+
+// MARK: - StructuralEvaluator Tests
+
+@Suite("StructuralEvaluator")
+struct StructuralEvaluatorTests {
+
+    private static func makeProfile() -> LearnerProfile {
+        LearnerProfile.createDefault(displayName: "Test Learner", language: "en")
+    }
+
+    @Test("prepareSession resets call count and caches prompt")
+    func prepareSessionResets() async {
+        let evaluator = StructuralEvaluator(maxCallsPerSession: 5)
+        await evaluator.prepareSession(
+            level: 1,
+            sessionType: "say-it-clearly",
+            language: "en",
+            profile: Self.makeProfile()
+        )
+
+        let count = await evaluator.callCount
+        #expect(count == 0)
+
+        let remaining = await evaluator.remainingCalls
+        #expect(remaining == 5)
+    }
+
+    @Test("remainingCalls is bounded by maxCallsPerSession")
+    func remainingCallsBounded() async {
+        let evaluator = StructuralEvaluator(maxCallsPerSession: 3)
+        let remaining = await evaluator.remainingCalls
+        #expect(remaining == 3)
+    }
+
+    @Test("reset clears call count")
+    func resetClearsState() async {
+        let evaluator = StructuralEvaluator(maxCallsPerSession: 10)
+        await evaluator.prepareSession(
+            level: 1,
+            sessionType: "say-it-clearly",
+            language: "en",
+            profile: Self.makeProfile()
+        )
+        await evaluator.reset()
+
+        let count = await evaluator.callCount
+        #expect(count == 0)
+    }
+
+    @Test("evaluate throws promptAssemblyFailed without preparation")
+    func evaluateWithoutPreparation() async {
+        let evaluator = StructuralEvaluator()
+        do {
+            _ = try await evaluator.evaluate(conversationMessages: [])
+            Issue.record("Expected promptAssemblyFailed error")
+        } catch let error as EvaluationError {
+            #expect(error == .promptAssemblyFailed)
+        } catch {
+            Issue.record("Unexpected error type: \(error)")
+        }
+    }
+
+    @Test("evaluate throws rateLimitExceeded when limit reached")
+    func evaluateRateLimited() async {
+        let evaluator = StructuralEvaluator(maxCallsPerSession: 0)
+        await evaluator.prepareSession(
+            level: 1,
+            sessionType: "say-it-clearly",
+            language: "en",
+            profile: Self.makeProfile()
+        )
+
+        do {
+            _ = try await evaluator.evaluate(conversationMessages: [])
+            Issue.record("Expected rateLimitExceeded error")
+        } catch let error as EvaluationError {
+            if case .rateLimitExceeded(let limit) = error {
+                #expect(limit == 0)
+            } else {
+                Issue.record("Expected rateLimitExceeded, got \(error)")
+            }
+        } catch {
+            Issue.record("Unexpected error type: \(error)")
+        }
+    }
+
+    @Test("evaluate accepts systemPromptOverride without preparation")
+    func evaluateWithOverride() async throws {
+        let evaluator = StructuralEvaluator(maxCallsPerSession: 5)
+        let streaming = try await evaluator.evaluate(
+            conversationMessages: [],
+            systemPromptOverride: "Test system prompt"
+        )
+
+        // Verify call count was incremented
+        let count = await evaluator.callCount
+        #expect(count == 1)
+
+        // StreamingEvaluation was returned
+        _ = streaming.textStream
+    }
+}
+
+// MARK: - EvaluationError Tests
+
+@Suite("EvaluationError")
+struct EvaluationErrorTests {
+
+    @Test("missingMetadata has descriptive message")
+    func missingMetadataDescription() {
+        let error = EvaluationError.missingMetadata
+        #expect(error.errorDescription?.contains("incomplete") == true)
+    }
+
+    @Test("rateLimitExceeded includes limit in message")
+    func rateLimitDescription() {
+        let error = EvaluationError.rateLimitExceeded(limit: 10)
+        #expect(error.errorDescription?.contains("10") == true)
+    }
+
+    @Test("evaluationTimeout has descriptive message")
+    func timeoutDescription() {
+        let error = EvaluationError.evaluationTimeout
+        #expect(error.errorDescription?.contains("long") == true)
+    }
+
+    @Test("promptAssemblyFailed has descriptive message")
+    func promptAssemblyDescription() {
+        let error = EvaluationError.promptAssemblyFailed
+        #expect(error.errorDescription?.contains("prompt") == true)
+    }
+
+    @Test("EvaluationError equatable")
+    func equatable() {
+        #expect(EvaluationError.missingMetadata == .missingMetadata)
+        #expect(EvaluationError.evaluationTimeout == .evaluationTimeout)
+        #expect(EvaluationError.promptAssemblyFailed == .promptAssemblyFailed)
+        #expect(EvaluationError.rateLimitExceeded(limit: 5) == .rateLimitExceeded(limit: 5))
+        #expect(EvaluationError.rateLimitExceeded(limit: 5) != .rateLimitExceeded(limit: 10))
+    }
+}
+
+// MARK: - StreamingEvaluation Tests
+
+@Suite("StreamingEvaluation - collect")
+struct StreamingEvaluationTests {
+
+    @Test("collect parses response with metadata into EvaluationResult")
+    func collectWithMetadata() async throws {
+        let visibleText = "Your conclusion leads clearly. Good structure!"
+        let metaJSON = """
+        {"scores":{"governingThought":3,"clarity":2},"totalScore":5,"mood":"approving","progressionSignal":"improving","revisionRound":1,"sessionPhase":"evaluation","feedbackFocus":"Lead with answer","language":"en"}
+        """
+        let fullResponse = "\(visibleText)\n\n<!-- BARBARA_META: \(metaJSON) -->"
+
+        let stream = AsyncThrowingStream<String, Error> { continuation in
+            continuation.yield(fullResponse)
+            continuation.finish()
+        }
+
+        let evaluation = StreamingEvaluation(
+            textStream: stream,
+            responseParser: ResponseParser()
+        )
+
+        let result = try await evaluation.collect()
+
+        #expect(result.feedbackText == visibleText)
+        #expect(result.hasScores)
+        #expect(result.dimensionScores["governingThought"] == 3)
+        #expect(result.dimensionScores["clarity"] == 2)
+        #expect(result.totalScore == 5)
+        #expect(result.mood == .approving)
+        #expect(result.progressionSignal == .improving)
+    }
+
+    @Test("collect handles response without metadata gracefully")
+    func collectWithoutMetadata() async throws {
+        let plainText = "That's not a conclusion, that's a preamble."
+
+        let stream = AsyncThrowingStream<String, Error> { continuation in
+            continuation.yield(plainText)
+            continuation.finish()
+        }
+
+        let evaluation = StreamingEvaluation(
+            textStream: stream,
+            responseParser: ResponseParser()
+        )
+
+        let result = try await evaluation.collect()
+        #expect(result.feedbackText == plainText)
+        #expect(!result.hasScores)
+        #expect(result.metadata == nil)
+    }
+
+    @Test("collect assembles multiple chunks into complete response")
+    func collectMultipleChunks() async throws {
+        let metaJSON = """
+        {"scores":{"clarity":3},"totalScore":3,"mood":"teaching","progressionSignal":"none","revisionRound":0,"sessionPhase":"evaluation","feedbackFocus":"Structure","language":"en"}
+        """
+
+        let stream = AsyncThrowingStream<String, Error> { continuation in
+            continuation.yield("Part one. ")
+            continuation.yield("Part two.")
+            continuation.yield("\n\n<!-- BARBARA_META: \(metaJSON) -->")
+            continuation.finish()
+        }
+
+        let evaluation = StreamingEvaluation(
+            textStream: stream,
+            responseParser: ResponseParser()
+        )
+
+        let result = try await evaluation.collect()
+
+        #expect(result.feedbackText == "Part one. Part two.")
+        #expect(result.hasScores)
+        #expect(result.totalScore == 3)
+    }
+
+    @Test("collect propagates stream errors")
+    func collectPropagatesError() async {
+        let stream = AsyncThrowingStream<String, Error> { continuation in
+            continuation.yield("Partial text")
+            continuation.finish(throwing: AnthropicServiceError.networkTimeout)
+        }
+
+        let evaluation = StreamingEvaluation(
+            textStream: stream,
+            responseParser: ResponseParser()
+        )
+
+        do {
+            _ = try await evaluation.collect()
+            Issue.record("Expected error to propagate")
+        } catch {
+            #expect(error is AnthropicServiceError)
+        }
+    }
+}
+
+// MARK: - SessionManager Evaluation Integration Tests
+
+@Suite("SessionManager - evaluation integration")
+struct SessionManagerEvaluationTests {
+
+    @Test("SessionManager initialises with structural evaluator")
+    @MainActor
+    func hasEvaluator() {
+        let manager = SessionManager()
+        #expect(manager.lastEvaluationResult == nil)
+    }
+
+    @Test("endSession clears lastEvaluationResult")
+    @MainActor
+    func endSessionClearsEvaluation() {
+        let manager = SessionManager()
+        manager.endSession()
+        #expect(manager.lastEvaluationResult == nil)
+    }
+
+    @Test("SessionManager accepts custom evaluator")
+    @MainActor
+    func customEvaluator() {
+        let evaluator = StructuralEvaluator(maxCallsPerSession: 3)
+        let manager = SessionManager(structuralEvaluator: evaluator)
+        #expect(manager.lastEvaluationResult == nil)
+    }
+}


### PR DESCRIPTION
## Summary
- Add `StructuralEvaluator` actor that sends learner responses to Claude with the appropriate rubric (L1/L2) and parses the evaluation into visible feedback + hidden scores
- Add `EvaluationResult` struct wrapping feedback text, dimension scores, progression signals, and mood
- Add `StreamingEvaluation` for progressive response display with `collect()` to produce final results
- Add `EvaluationError` enum for evaluation-specific error handling (rate limit, timeout, missing metadata, prompt assembly failure)
- Integrate evaluator into `SessionManager` lifecycle: prepares on session start, captures scores from responses, resets on session end
- Rate limiting: max 10 API calls per session (configurable), exposed via `remainingEvaluations`
- System prompt cached per session (rubric doesn't change mid-session)

## Files changed
- `app/SayItRight/Intelligence/StructuralEvaluator/EvaluationResult.swift` — new
- `app/SayItRight/Intelligence/StructuralEvaluator/StructuralEvaluator.swift` — new
- `app/SayItRight/Intelligence/ConversationManager/SessionManager.swift` — modified
- `app/SayItRight/Tests/StructuralEvaluatorTests.swift` — new (30+ tests)

## Test plan
- [x] EvaluationResult correctly extracts scores, mood, progression from metadata
- [x] EvaluationResult defaults gracefully when metadata is nil
- [x] StructuralEvaluator prepareSession resets state and caches prompt
- [x] StructuralEvaluator evaluate throws promptAssemblyFailed without preparation
- [x] StructuralEvaluator evaluate throws rateLimitExceeded at limit
- [x] StructuralEvaluator accepts systemPromptOverride
- [x] StreamingEvaluation.collect parses metadata from streamed response
- [x] StreamingEvaluation.collect handles missing metadata gracefully
- [x] StreamingEvaluation.collect assembles multiple chunks correctly
- [x] StreamingEvaluation.collect propagates stream errors
- [x] EvaluationError has descriptive messages and equatable conformance
- [x] SessionManager accepts custom evaluator via DI
- [x] SessionManager clears evaluation state on endSession

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)