### PR TITLE
feat: add revision loop for Say It Clearly sessions (SIR-031)

### DIFF
--- a/app/SayItRight/Intelligence/ConversationManager/SayItClearlySession.swift
+++ b/app/SayItRight/Intelligence/ConversationManager/SayItClearlySession.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Tracks the state of a "Say it clearly" session.
 ///
-/// Captures the selected topic, the learner's response text, and timestamps
-/// for the session lifecycle. This struct is the session-specific data model
-/// that sits alongside the general `SessionManager` conversation state.
+/// Captures the selected topic, the learner's response attempts, and timestamps
+/// for the session lifecycle. Supports a revision loop where the learner
+/// revises their response after Barbara's structural feedback.
 struct SayItClearlySession: Sendable {
 
     /// The topic Barbara selected for this session.
@@ -13,28 +13,97 @@ struct SayItClearlySession: Sendable {
     /// When the session was started (topic presented).
     let startedAt: Date
 
-    /// The learner's submitted response text, if any.
-    private(set) var responseText: String?
+    /// All response attempts, in order. Index 0 is the first draft.
+    private(set) var attempts: [Attempt] = []
 
-    /// When the learner submitted their response.
-    private(set) var respondedAt: Date?
+    /// Maximum number of revisions allowed (not counting the first draft).
+    let maxRevisions: Int
+
+    /// Whether the session summary has been requested.
+    private(set) var summaryRequested: Bool = false
 
     /// The session type identifier for downstream processing.
     let sessionTypeID: String = "say-it-clearly"
 
-    init(topic: Topic, startedAt: Date = .now) {
+    init(topic: Topic, startedAt: Date = .now, maxRevisions: Int = 2) {
         self.topic = topic
         self.startedAt = startedAt
+        self.maxRevisions = maxRevisions
     }
 
-    /// Record the learner's response.
-    mutating func recordResponse(_ text: String, at date: Date = .now) {
-        responseText = text
-        respondedAt = date
+    /// A single learner attempt (first draft or revision).
+    struct Attempt: Sendable, Equatable {
+        let text: String
+        let submittedAt: Date
     }
 
-    /// Whether the learner has submitted a response.
+    /// Record a learner response attempt.
+    mutating func recordAttempt(_ text: String, at date: Date = .now) {
+        attempts.append(Attempt(text: text, submittedAt: date))
+    }
+
+    /// The learner's first submitted response text, if any.
+    var responseText: String? {
+        attempts.first?.text
+    }
+
+    /// When the learner submitted their first response.
+    var respondedAt: Date? {
+        attempts.first?.submittedAt
+    }
+
+    /// Whether the learner has submitted at least one response.
     var hasResponse: Bool {
-        responseText != nil
+        !attempts.isEmpty
+    }
+
+    /// The current revision round (0 = first draft, 1 = first revision, etc.).
+    var currentRevisionRound: Int {
+        max(0, attempts.count - 1)
+    }
+
+    /// Whether more revisions are allowed.
+    var canRevise: Bool {
+        hasResponse && currentRevisionRound < maxRevisions
+    }
+
+    /// Whether the revision loop is complete (max revisions reached).
+    var isRevisionComplete: Bool {
+        currentRevisionRound >= maxRevisions
+    }
+
+    /// The most recent attempt text.
+    var latestAttemptText: String? {
+        attempts.last?.text
+    }
+
+    /// Whether the latest attempt is unchanged from the previous one
+    /// (whitespace-normalised comparison).
+    var isLatestAttemptUnchanged: Bool {
+        guard attempts.count >= 2 else { return false }
+        let prev = normalise(attempts[attempts.count - 2].text)
+        let curr = normalise(attempts[attempts.count - 1].text)
+        return prev == curr
+    }
+
+    /// Mark that the session summary has been requested.
+    mutating func markSummaryRequested() {
+        summaryRequested = true
+    }
+
+    // MARK: - Backward Compatibility
+
+    /// Record the learner's response (delegates to recordAttempt).
+    mutating func recordResponse(_ text: String, at date: Date = .now) {
+        recordAttempt(text, at: date)
+    }
+
+    // MARK: - Private
+
+    private func normalise(_ text: String) -> String {
+        text.trimmingCharacters(in: .whitespacesAndNewlines)
+            .components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
     }
 }

--- a/app/SayItRight/Intelligence/ConversationManager/SessionManager.swift
+++ b/app/SayItRight/Intelligence/ConversationManager/SessionManager.swift
@@ -254,9 +254,14 @@ final class SessionManager {
         let learnerMessage = ChatMessage(role: .learner, text: trimmed)
         messages.append(learnerMessage)
 
-        // Track first response in "Say it clearly" session
-        if sayItClearlySession != nil && !sayItClearlySession!.hasResponse {
-            sayItClearlySession?.recordResponse(trimmed)
+        // Track response attempts in "Say it clearly" session
+        if sayItClearlySession != nil {
+            sayItClearlySession?.recordAttempt(trimmed)
+
+            // Inject revision context if this is a revision
+            if sayItClearlySession!.currentRevisionRound > 0 {
+                injectRevisionContext()
+            }
         }
 
         // Track extraction attempts in "Find the point" session
@@ -270,6 +275,34 @@ final class SessionManager {
         }
 
         // Stream Barbara's response
+        await streamBarbaraResponse()
+    }
+
+    /// Whether the learner's input should be pre-loaded with their previous
+    /// response for revision editing.
+    var revisionPreloadText: String? {
+        guard let session = sayItClearlySession else { return nil }
+        // Only pre-load after feedback has been given (we have a response and
+        // the last message is from Barbara with scores) and revisions remain.
+        guard session.hasResponse, session.canRevise else { return nil }
+        guard let lastBarbaraMsg = messages.last(where: { $0.role == .barbara }),
+              lastBarbaraMsg.metadata != nil,
+              !lastBarbaraMsg.metadata!.scores.isEmpty else { return nil }
+        // Only pre-load if the learner hasn't already typed something new
+        return session.latestAttemptText
+    }
+
+    /// Request the session summary after the revision loop completes.
+    func requestSessionSummary() async {
+        guard var session = sayItClearlySession, !session.summaryRequested else { return }
+        session.markSummaryRequested()
+        sayItClearlySession = session
+
+        // Inject a summary directive as a system-level user message
+        let summaryDirective = buildSummaryDirective()
+        let directiveMessage = ChatMessage(role: .learner, text: summaryDirective)
+        messages.append(directiveMessage)
+
         await streamBarbaraResponse()
     }
 
@@ -299,6 +332,89 @@ final class SessionManager {
     /// The number of evaluation calls made in this session.
     var evaluationCallCount: Int {
         get async { await structuralEvaluator.callCount }
+    }
+
+    // MARK: - Private: Revision Loop
+
+    /// Inject a hidden system message with revision context so Barbara can
+    /// compare the original and revised responses.
+    private func injectRevisionContext() {
+        guard let session = sayItClearlySession, session.attempts.count >= 2 else { return }
+
+        let originalText = session.attempts[0].text
+        let revisedText = session.attempts.last!.text
+
+        // Check if unchanged
+        if session.isLatestAttemptUnchanged {
+            // Barbara will see the flag and call it out
+            let context = """
+            [SYSTEM: The learner has resubmitted their response WITHOUT changes. \
+            The text is identical to their previous attempt. Call this out — \
+            ask them to read your feedback and make specific changes.]
+            """
+            let contextMsg = ChatMessage(role: .learner, text: context)
+            // Insert before the learner's latest message
+            let insertIndex = max(0, messages.count - 1)
+            messages.insert(contextMsg, at: insertIndex)
+            return
+        }
+
+        let revisionRound = session.currentRevisionRound
+        let maxRevisions = session.maxRevisions
+        let isLastRevision = revisionRound >= maxRevisions
+
+        var context = """
+        [SYSTEM: This is revision \(revisionRound) of \(maxRevisions). \
+        Compare the revised response against the original and note what \
+        improved, what stayed the same, and what regressed. \
+        Focus on structural changes, not content changes.
+
+        ORIGINAL RESPONSE:
+        \(originalText)
+
+        REVISED RESPONSE:
+        \(revisedText)
+        """
+
+        if isLastRevision {
+            context += """
+
+            This is the FINAL revision. After your evaluation, provide a brief \
+            session summary: what was practiced, what improved across revisions, \
+            and one key structural takeaway. Set sessionPhase to "summary".]
+            """
+        } else {
+            context += """
+
+            After evaluation, prompt the learner to revise again if there is \
+            room for structural improvement. Even strong revisions should get \
+            a push for tighter structure.]
+            """
+        }
+
+        let contextMsg = ChatMessage(role: .learner, text: context)
+        // Insert before the learner's latest message
+        let insertIndex = max(0, messages.count - 1)
+        messages.insert(contextMsg, at: insertIndex)
+    }
+
+    /// Build a directive for Barbara to summarise the session.
+    private func buildSummaryDirective() -> String {
+        guard let session = sayItClearlySession else { return "" }
+
+        var parts = ["[SYSTEM: The revision loop is complete. Summarise this session:"]
+        for (index, attempt) in session.attempts.enumerated() {
+            let label = index == 0 ? "FIRST DRAFT" : "REVISION \(index)"
+            parts.append("\(label):\n\(attempt.text)")
+        }
+        parts.append("""
+        Provide a brief session summary covering:
+        1. What structural skill was practiced
+        2. What improved across revisions
+        3. One key takeaway for the learner
+        Set sessionPhase to "summary" and mood to "teaching".]
+        """)
+        return parts.joined(separator: "\n\n")
     }
 
     // MARK: - Private: Streaming

--- a/app/SayItRight/Presentation/Chat/ChatViewModel.swift
+++ b/app/SayItRight/Presentation/Chat/ChatViewModel.swift
@@ -68,6 +68,21 @@ final class ChatViewModel {
         sessionManager?.sessionState == .active || sessionManager?.sessionState == .loading
     }
 
+    /// Whether the revision loop is complete and a summary should be shown.
+    var isRevisionComplete: Bool {
+        sessionManager?.sayItClearlySession?.isRevisionComplete ?? false
+    }
+
+    /// Whether the session summary has already been requested.
+    var isSummaryRequested: Bool {
+        sessionManager?.sayItClearlySession?.summaryRequested ?? false
+    }
+
+    /// The current revision round (0 = first draft awaiting, 1+ = revision N).
+    var currentRevisionRound: Int {
+        sessionManager?.sayItClearlySession?.currentRevisionRound ?? 0
+    }
+
     // MARK: - Private State (standalone mode)
 
     private var _localMessages: [ChatMessage] = []
@@ -142,6 +157,8 @@ final class ChatViewModel {
         if let sm = sessionManager {
             Task {
                 await sm.sendMessage(text: text)
+                // After Barbara responds, pre-load revision text if applicable
+                preloadRevisionTextIfNeeded()
             }
         } else {
             // Standalone mode: direct API call
@@ -193,6 +210,25 @@ final class ChatViewModel {
         pendingInputText = nil
         countdownTask?.cancel()
         countdownTask = nil
+    }
+
+    /// Request the session summary after the revision loop completes.
+    func requestSummary() {
+        guard let sm = sessionManager else { return }
+        Task {
+            await sm.requestSessionSummary()
+        }
+    }
+
+    /// Pre-load the learner's last response into the input field for revision editing.
+    private func preloadRevisionTextIfNeeded() {
+        guard let sm = sessionManager,
+              let preloadText = sm.revisionPreloadText,
+              sm.sayItClearlySession?.canRevise == true else { return }
+        // Only pre-load if input is currently empty
+        if inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            inputText = preloadText
+        }
     }
 
     // MARK: - Private: Standalone streaming (no SessionManager)

--- a/app/SayItRight/Presentation/Session/SayItClearlyView.swift
+++ b/app/SayItRight/Presentation/Session/SayItClearlyView.swift
@@ -41,7 +41,13 @@ struct SayItClearlyView: View {
             if noTopicsAvailable {
                 noTopicsView
             } else {
-                ChatView(viewModel: viewModel)
+                VStack(spacing: 0) {
+                    ChatView(viewModel: viewModel)
+
+                    if viewModel.isRevisionComplete && !viewModel.isSummaryRequested {
+                        summaryPromptBar
+                    }
+                }
             }
         }
         .navigationTitle(SessionType.sayItClearly.displayName(language: language))
@@ -70,6 +76,30 @@ struct SayItClearlyView: View {
                 noTopicsAvailable = true
             }
         }
+    }
+
+    // MARK: - Summary Prompt
+
+    private var summaryPromptBar: some View {
+        VStack(spacing: 8) {
+            Divider()
+            Text(language == "de"
+                 ? "Revision abgeschlossen"
+                 : "Revision complete")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Button(action: { viewModel.requestSummary() }) {
+                Label(
+                    language == "de" ? "Zusammenfassung anzeigen" : "Show Session Summary",
+                    systemImage: "doc.text"
+                )
+            }
+            .buttonStyle(.borderedProminent)
+            .padding(.bottom, 8)
+        }
+        .padding(.horizontal, 16)
+        .transition(.move(edge: .bottom).combined(with: .opacity))
     }
 
     // MARK: - No Topics Available

--- a/app/SayItRight/Tests/SayItClearlySessionTests.swift
+++ b/app/SayItRight/Tests/SayItClearlySessionTests.swift
@@ -30,6 +30,10 @@ struct SayItClearlySessionTests {
         #expect(!session.hasResponse)
         #expect(session.responseText == nil)
         #expect(session.respondedAt == nil)
+        #expect(session.currentRevisionRound == 0)
+        #expect(!session.isRevisionComplete)
+        #expect(session.canRevise == false)
+        #expect(session.maxRevisions == 2)
     }
 
     @Test("recordResponse captures text and timestamp")
@@ -46,17 +50,99 @@ struct SayItClearlySessionTests {
         #expect(session.respondedAt! >= before)
     }
 
-    @Test("recordResponse only records once — first response wins")
-    func firstResponseWins() {
+    @Test("recordAttempt tracks multiple attempts")
+    func multipleAttempts() {
+        let topic = Self.makeTopic()
+        var session = SayItClearlySession(topic: topic)
+
+        session.recordAttempt("First draft")
+        #expect(session.attempts.count == 1)
+        #expect(session.currentRevisionRound == 0)
+        #expect(session.responseText == "First draft")
+        #expect(session.canRevise == true)
+
+        session.recordAttempt("Revision 1")
+        #expect(session.attempts.count == 2)
+        #expect(session.currentRevisionRound == 1)
+        #expect(session.responseText == "First draft") // first draft preserved
+        #expect(session.latestAttemptText == "Revision 1")
+        #expect(session.canRevise == true)
+
+        session.recordAttempt("Revision 2")
+        #expect(session.attempts.count == 3)
+        #expect(session.currentRevisionRound == 2)
+        #expect(session.isRevisionComplete == true)
+        #expect(session.canRevise == false)
+    }
+
+    @Test("isLatestAttemptUnchanged detects identical text")
+    func unchangedDetection() {
+        let topic = Self.makeTopic()
+        var session = SayItClearlySession(topic: topic)
+
+        session.recordAttempt("My argument is clear.")
+        // Only one attempt — can't be unchanged
+        #expect(!session.isLatestAttemptUnchanged)
+
+        // Submit identical text
+        session.recordAttempt("My argument is clear.")
+        #expect(session.isLatestAttemptUnchanged)
+    }
+
+    @Test("isLatestAttemptUnchanged normalises whitespace")
+    func unchangedWithWhitespace() {
+        let topic = Self.makeTopic()
+        var session = SayItClearlySession(topic: topic)
+
+        session.recordAttempt("My argument  is   clear.")
+        session.recordAttempt("  My argument is clear.  ")
+        #expect(session.isLatestAttemptUnchanged)
+    }
+
+    @Test("isLatestAttemptUnchanged detects real changes")
+    func changedText() {
+        let topic = Self.makeTopic()
+        var session = SayItClearlySession(topic: topic)
+
+        session.recordAttempt("Schools should switch.")
+        session.recordAttempt("Schools should switch to a four-day week.")
+        #expect(!session.isLatestAttemptUnchanged)
+    }
+
+    @Test("custom maxRevisions is respected")
+    func customMaxRevisions() {
+        let topic = Self.makeTopic()
+        var session = SayItClearlySession(topic: topic, maxRevisions: 1)
+
+        session.recordAttempt("Draft")
+        #expect(session.canRevise == true)
+
+        session.recordAttempt("Revision 1")
+        #expect(session.isRevisionComplete == true)
+        #expect(session.canRevise == false)
+    }
+
+    @Test("summaryRequested starts false and can be set")
+    func summaryTracking() {
+        let topic = Self.makeTopic()
+        var session = SayItClearlySession(topic: topic)
+
+        #expect(!session.summaryRequested)
+        session.markSummaryRequested()
+        #expect(session.summaryRequested)
+    }
+
+    @Test("recordResponse delegates to recordAttempt for backward compatibility")
+    func backwardCompatibility() {
         let topic = Self.makeTopic()
         var session = SayItClearlySession(topic: topic)
 
         session.recordResponse("First answer")
         session.recordResponse("Second answer")
 
-        // SayItClearlySession.recordResponse sets unconditionally,
-        // but SessionManager guards with hasResponse check
-        #expect(session.responseText == "Second answer")
+        #expect(session.attempts.count == 2)
+        #expect(session.responseText == "First answer")
+        #expect(session.latestAttemptText == "Second answer")
     }
 }
 


### PR DESCRIPTION
## Summary
- Revision loop: after Barbara's feedback, learner's text is pre-loaded for editing and resubmission
- Barbara re-evaluates revisions with comparison context (original vs revised)
- Unchanged text detection — Barbara calls out identical resubmissions
- Max 2 revisions per session, then session summary
- 8 new tests for revision tracking logic

## Acceptance Criteria
- [x] After feedback, original text pre-loaded in input for editing
- [x] User can edit and resubmit revised response
- [x] Barbara re-evaluates with comparison context
- [x] Hidden metadata includes revision round tracking
- [x] Max 2 revision rounds (configurable)
- [x] Session summary after final revision
- [x] Unchanged text detection

## Test plan
- [x] Build succeeds (macOS)
- [x] All 479 tests pass with 0 failures
- [x] New tests cover: multiple attempts, unchanged detection, whitespace normalisation, custom max revisions, summary tracking, backward compatibility

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)