### PR TITLE
feat: add Elevator Pitch timed session type (SIR-032)

### DIFF
--- a/app/SayItRight/App/SayItRightApp.swift
+++ b/app/SayItRight/App/SayItRightApp.swift
@@ -48,8 +48,10 @@ struct ContentView: View {
     @State private var sessionManager = SessionManager()
     @State private var coordinator = SayItClearlyCoordinator()
     @State private var findThePointCoordinator = FindThePointCoordinator()
+    @State private var elevatorPitchCoordinator = ElevatorPitchCoordinator()
     @State private var showSayItClearly = false
     @State private var showFindThePoint = false
+    @State private var showElevatorPitch = false
 
     private var language: String { settings.language }
 
@@ -73,6 +75,8 @@ struct ContentView: View {
                     showSayItClearly = true
                 case .findThePoint:
                     showFindThePoint = true
+                case .elevatorPitch:
+                    showElevatorPitch = true
                 }
             }
             .navigationDestination(isPresented: $showSayItClearly) {
@@ -93,6 +97,16 @@ struct ContentView: View {
                     language: language
                 ) {
                     showFindThePoint = false
+                }
+            }
+            .navigationDestination(isPresented: $showElevatorPitch) {
+                ElevatorPitchView(
+                    sessionManager: sessionManager,
+                    coordinator: elevatorPitchCoordinator,
+                    profile: profile,
+                    language: language
+                ) {
+                    showElevatorPitch = false
                 }
             }
         }

--- a/app/SayItRight/Content/PracticeTexts/TextDifficultyCalibrator.swift
+++ b/app/SayItRight/Content/PracticeTexts/TextDifficultyCalibrator.swift
@@ -143,7 +143,7 @@ struct TextDifficultyCalibrator: Sendable {
         case .findThePoint:
             // "Find the point" works with all allowed quality levels
             return texts
-        case .sayItClearly:
+        case .sayItClearly, .elevatorPitch:
             // Build mode — no text selection needed, but if called, return all
             return texts
         }

--- a/app/SayItRight/Intelligence/ConversationManager/ElevatorPitchCoordinator.swift
+++ b/app/SayItRight/Intelligence/ConversationManager/ElevatorPitchCoordinator.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+/// Orchestrates the "Elevator pitch" session flow.
+///
+/// Selects a topic from the topic bank and starts a timed session
+/// on the SessionManager. Reuses the same TopicBank as Say It Clearly
+/// since the topic format is identical.
+@MainActor
+@Observable
+final class ElevatorPitchCoordinator {
+
+    /// Topics the learner has seen recently.
+    var recentTopicIDs: Set<String> = []
+
+    /// The topic bank used for selection.
+    private let topicBank: TopicBank
+
+    /// Maximum recent topics before reset.
+    private let maxRecentTopics = 20
+
+    init(topicBank: TopicBank = TopicBank.loadFromBundle()) {
+        self.topicBank = topicBank
+    }
+
+    /// Convenience initialiser for testing.
+    init(topics: [Topic]) {
+        self.topicBank = TopicBank(topics: topics)
+    }
+
+    /// Start an elevator pitch session.
+    ///
+    /// - Returns: The selected topic, or `nil` if none available.
+    @discardableResult
+    func startSession(
+        sessionManager: SessionManager,
+        profile: LearnerProfile,
+        language: String
+    ) async -> Topic? {
+        guard let topic = selectTopic(for: profile.currentLevel, language: language) else {
+            return nil
+        }
+
+        trackSeen(topic)
+        await sessionManager.startElevatorPitchSession(
+            topic: topic,
+            profile: profile,
+            language: language
+        )
+        return topic
+    }
+
+    /// Select a topic appropriate for the learner's level.
+    func selectTopic(for level: Int, language: String) -> Topic? {
+        if let topic = topicBank.randomTopic(for: level, excluding: recentTopicIDs) {
+            return topic
+        }
+        recentTopicIDs.removeAll()
+        return topicBank.randomTopic(for: level, excluding: recentTopicIDs)
+    }
+
+    private func trackSeen(_ topic: Topic) {
+        recentTopicIDs.insert(topic.id)
+        if recentTopicIDs.count > maxRecentTopics {
+            recentTopicIDs.removeAll()
+            recentTopicIDs.insert(topic.id)
+        }
+    }
+
+    func clearRecentTopics() {
+        recentTopicIDs.removeAll()
+    }
+}

--- a/app/SayItRight/Intelligence/ConversationManager/ElevatorPitchSession.swift
+++ b/app/SayItRight/Intelligence/ConversationManager/ElevatorPitchSession.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+/// Tracks the state of an "Elevator pitch" / "30 Sekunden" session.
+///
+/// The learner writes a structured response under time pressure. No revision
+/// loop — one shot, then Barbara's evaluation and summary.
+struct ElevatorPitchSession: Sendable {
+
+    /// The topic for this session.
+    let topic: Topic
+
+    /// When the session was started (topic presented).
+    let startedAt: Date
+
+    /// Duration allowed in seconds (30 or 60 based on level).
+    let durationSeconds: Int
+
+    /// The learner's submitted response, if any.
+    private(set) var responseText: String?
+
+    /// When the learner submitted (or time expired).
+    private(set) var submittedAt: Date?
+
+    /// Whether the timer expired before the learner submitted.
+    private(set) var timedOut: Bool = false
+
+    /// The session type identifier for downstream processing.
+    let sessionTypeID: String = "elevator-pitch"
+
+    init(topic: Topic, durationSeconds: Int = 60, startedAt: Date = .now) {
+        self.topic = topic
+        self.durationSeconds = durationSeconds
+        self.startedAt = startedAt
+    }
+
+    /// Record the learner's response.
+    mutating func recordResponse(_ text: String, timedOut: Bool = false, at date: Date = .now) {
+        responseText = text
+        submittedAt = date
+        self.timedOut = timedOut
+    }
+
+    /// Whether the learner has submitted a response.
+    var hasResponse: Bool {
+        responseText != nil
+    }
+
+    /// Duration appropriate for the learner's level.
+    static func duration(for level: Int) -> Int {
+        level >= 2 ? 30 : 60
+    }
+}

--- a/app/SayItRight/Intelligence/ConversationManager/SessionManager.swift
+++ b/app/SayItRight/Intelligence/ConversationManager/SessionManager.swift
@@ -34,6 +34,9 @@ final class SessionManager {
     /// The active "Find the point" session state, if any.
     private(set) var findThePointSession: FindThePointSession?
 
+    /// The active "Elevator pitch" session state, if any.
+    private(set) var elevatorPitchSession: ElevatorPitchSession?
+
     /// The latest evaluation result from the structural evaluator.
     private(set) var lastEvaluationResult: EvaluationResult?
 
@@ -84,6 +87,7 @@ final class SessionManager {
         activeSessionType = type
         sayItClearlySession = nil
         findThePointSession = nil
+        elevatorPitchSession = nil
 
         lastEvaluationResult = nil
         sessionState = .loading
@@ -124,6 +128,7 @@ final class SessionManager {
         activeSessionType = .sayItClearly
         sayItClearlySession = SayItClearlySession(topic: topic)
         findThePointSession = nil
+        elevatorPitchSession = nil
 
         lastEvaluationResult = nil
         sessionState = .loading
@@ -171,6 +176,7 @@ final class SessionManager {
         activeSessionType = .findThePoint
         sayItClearlySession = nil
         findThePointSession = FindThePointSession(practiceText: practiceText)
+        elevatorPitchSession = nil
 
         sessionState = .loading
 
@@ -240,6 +246,88 @@ final class SessionManager {
         Governing Thought: \(practiceText.answerKey.governingThought)
         Structural Assessment: \(practiceText.answerKey.structuralAssessment)
         """
+    }
+
+    /// Start an "Elevator pitch" session with a specific topic.
+    ///
+    /// - Parameters:
+    ///   - topic: The topic selected from the topic bank.
+    ///   - profile: The learner's current profile.
+    ///   - language: Language code ("en" or "de").
+    func startElevatorPitchSession(topic: Topic, profile: LearnerProfile, language: String) async {
+        messages = []
+        sessionMetadata = []
+        activeSessionType = .elevatorPitch
+        sayItClearlySession = nil
+        findThePointSession = nil
+
+        let duration = ElevatorPitchSession.duration(for: profile.currentLevel)
+        elevatorPitchSession = ElevatorPitchSession(topic: topic, durationSeconds: duration)
+
+        lastEvaluationResult = nil
+        sessionState = .loading
+
+        let basePrompt = systemPromptAssembler.assemble(
+            level: profile.currentLevel,
+            sessionType: SessionType.elevatorPitch.rawValue,
+            language: language,
+            profileJSON: profile.toPromptJSON()
+        )
+
+        let directive = elevatorPitchDirectiveBlock(topic: topic, duration: duration, language: language)
+        systemPrompt = basePrompt + "\n\n" + directive
+
+        await structuralEvaluator.prepareSession(
+            level: profile.currentLevel,
+            sessionType: SessionType.elevatorPitch.rawValue,
+            language: language,
+            profile: profile
+        )
+
+        await streamBarbaraResponse()
+    }
+
+    /// Build the directive block for elevator pitch sessions.
+    private func elevatorPitchDirectiveBlock(topic: Topic, duration: Int, language: String) -> String {
+        let title = topic.title(for: language)
+        let prompt = topic.prompt(for: language)
+        return """
+        # Elevator Pitch Session
+
+        Present this topic to the learner. They have \(duration) seconds to write \
+        a structured response under time pressure.
+
+        **Topic:** \(title)
+        **Prompt:** \(prompt)
+        **Time limit:** \(duration) seconds
+
+        After presenting the topic, wait for the learner's response. When evaluating:
+        - This response was written under time pressure. Evaluate structural \
+        prioritisation above all else.
+        - Did the conclusion come FIRST? Under time pressure, this is the #1 skill.
+        - Value brevity-with-structure over completeness: "You only made one point, \
+        but it was crystal clear. Better than three muddled points."
+        - Acknowledge the constraint: "In \(duration) seconds you got the key point \
+        across. That's the skill."
+        - No revision loop — give final feedback and a session summary.
+        - Set sessionPhase to "summary" after evaluation.
+        """
+    }
+
+    /// Submit the learner's elevator pitch response (called by timer or early submit).
+    func submitElevatorPitch(text: String, timedOut: Bool) async {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty || timedOut else { return }
+        guard sessionState == .active else { return }
+
+        let responseText = trimmed.isEmpty ? "[No response — time expired]" : trimmed
+        elevatorPitchSession?.recordResponse(responseText, timedOut: timedOut)
+
+        let prefix = timedOut ? "[SYSTEM: Time expired. The learner's response below was auto-submitted.]\n\n" : ""
+        let learnerMessage = ChatMessage(role: .learner, text: prefix + responseText)
+        messages.append(learnerMessage)
+
+        await streamBarbaraResponse()
     }
 
     /// Send a learner message and stream Barbara's response.
@@ -315,7 +403,8 @@ final class SessionManager {
         sayItClearlySession = nil
 
         findThePointSession = nil
- 
+        elevatorPitchSession = nil
+
         lastEvaluationResult = nil
         sessionState = .idle
         messages = []

--- a/app/SayItRight/Intelligence/ConversationManager/SessionType.swift
+++ b/app/SayItRight/Intelligence/ConversationManager/SessionType.swift
@@ -7,6 +7,7 @@ import Foundation
 enum SessionType: String, CaseIterable, Identifiable, Sendable {
     case sayItClearly = "say-it-clearly"
     case findThePoint = "find-the-point"
+    case elevatorPitch = "elevator-pitch"
 
     var id: String { rawValue }
 
@@ -17,6 +18,8 @@ enum SessionType: String, CaseIterable, Identifiable, Sendable {
             language == "de" ? "Sag's klar" : "Say it clearly"
         case .findThePoint:
             language == "de" ? "Finde den Punkt" : "Find the point"
+        case .elevatorPitch:
+            language == "de" ? "30 Sekunden" : "The elevator pitch"
         }
     }
 
@@ -31,6 +34,10 @@ enum SessionType: String, CaseIterable, Identifiable, Sendable {
             language == "de"
                 ? "Finde den Kerngedanken in einem Text. Barbara pr\u{00FC}ft dein Verst\u{00E4}ndnis."
                 : "Extract the governing thought from a text. Barbara checks your understanding."
+        case .elevatorPitch:
+            language == "de"
+                ? "Schreib unter Zeitdruck. Barbara bewertet, ob du priorisieren kannst."
+                : "Write under time pressure. Barbara evaluates your ability to prioritise."
         }
     }
 
@@ -39,6 +46,7 @@ enum SessionType: String, CaseIterable, Identifiable, Sendable {
         switch self {
         case .sayItClearly: "text.bubble"
         case .findThePoint: "magnifyingglass"
+        case .elevatorPitch: "timer"
         }
     }
 }

--- a/app/SayItRight/Presentation/Session/ElevatorPitchView.swift
+++ b/app/SayItRight/Presentation/Session/ElevatorPitchView.swift
@@ -1,0 +1,307 @@
+import SwiftUI
+
+/// Full-screen view for an "Elevator pitch" / "30 Sekunden" session.
+///
+/// Presents a topic with a countdown timer. The learner writes under time
+/// pressure; auto-submits when the timer expires. No revision loop.
+///
+/// Platform behavior:
+/// - **iPhone**: Full-width, compact timer above input.
+/// - **iPad/Mac**: Centered layout with prominent timer.
+struct ElevatorPitchView: View {
+    let sessionManager: SessionManager
+    let coordinator: ElevatorPitchCoordinator
+    let profile: LearnerProfile
+    let language: String
+    var onDismiss: (() -> Void)?
+
+    @State private var viewModel: ChatViewModel
+    @State private var sessionStarted = false
+    @State private var noTopicsAvailable = false
+    @State private var timerState = TimerState()
+
+    init(
+        sessionManager: SessionManager,
+        coordinator: ElevatorPitchCoordinator,
+        profile: LearnerProfile,
+        language: String,
+        onDismiss: (() -> Void)? = nil
+    ) {
+        self.sessionManager = sessionManager
+        self.coordinator = coordinator
+        self.profile = profile
+        self.language = language
+        self.onDismiss = onDismiss
+        self._viewModel = State(initialValue: ChatViewModel(sessionManager: sessionManager))
+    }
+
+    var body: some View {
+        Group {
+            if noTopicsAvailable {
+                noTopicsView
+            } else {
+                VStack(spacing: 0) {
+                    if timerState.isRunning {
+                        timerBar
+                    }
+                    ChatView(viewModel: viewModel)
+                }
+            }
+        }
+        .navigationTitle(SessionType.elevatorPitch.displayName(language: language))
+        #if !os(macOS)
+        .navigationBarTitleDisplayMode(.inline)
+        #endif
+        .toolbar {
+            ToolbarItem(placement: .automatic) {
+                Button(action: endSessionAndDismiss) {
+                    Label(
+                        language == "de" ? "Beenden" : "End Session",
+                        systemImage: "xmark.circle"
+                    )
+                }
+            }
+        }
+        .task {
+            guard !sessionStarted else { return }
+            sessionStarted = true
+            let topic = await coordinator.startSession(
+                sessionManager: sessionManager,
+                profile: profile,
+                language: language
+            )
+            if topic == nil {
+                noTopicsAvailable = true
+            }
+        }
+        .onChange(of: sessionManager.sessionState) { _, newState in
+            // Start timer when Barbara's greeting completes (session becomes active)
+            if case .active = newState,
+               !timerState.hasStarted,
+               let session = sessionManager.elevatorPitchSession {
+                startTimer(duration: session.durationSeconds)
+            }
+        }
+    }
+
+    // MARK: - Timer Bar
+
+    private var timerBar: some View {
+        VStack(spacing: 4) {
+            HStack {
+                Image(systemName: "timer")
+                    .font(.caption)
+                Text(timerText)
+                    .font(.system(.title3, design: .monospaced).bold())
+                Spacer()
+                if timerState.isRunning && !viewModel.inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    Button(action: submitEarly) {
+                        Label(
+                            language == "de" ? "Abgeben" : "Submit",
+                            systemImage: "arrow.up.circle.fill"
+                        )
+                        .font(.caption.bold())
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.small)
+                }
+            }
+
+            // Progress bar
+            GeometryReader { geo in
+                ZStack(alignment: .leading) {
+                    RoundedRectangle(cornerRadius: 3)
+                        .fill(Color.gray.opacity(0.2))
+                        .frame(height: 4)
+
+                    RoundedRectangle(cornerRadius: 3)
+                        .fill(timerColor)
+                        .frame(width: geo.size.width * timerProgress, height: 4)
+                        .animation(.linear(duration: 1), value: timerState.remainingSeconds)
+                }
+            }
+            .frame(height: 4)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 8)
+        .background(timerColor.opacity(0.08))
+    }
+
+    private var timerText: String {
+        let minutes = timerState.remainingSeconds / 60
+        let seconds = timerState.remainingSeconds % 60
+        if minutes > 0 {
+            return String(format: "%d:%02d", minutes, seconds)
+        }
+        return "\(seconds)s"
+    }
+
+    private var timerProgress: CGFloat {
+        guard timerState.totalSeconds > 0 else { return 0 }
+        return CGFloat(timerState.remainingSeconds) / CGFloat(timerState.totalSeconds)
+    }
+
+    private var timerColor: Color {
+        let ratio = timerProgress
+        if ratio > 0.5 { return .green }
+        if ratio > 0.17 { return .orange }
+        return .red
+    }
+
+    // MARK: - Timer Logic
+
+    private func startTimer(duration: Int) {
+        timerState.totalSeconds = duration
+        timerState.remainingSeconds = duration
+        timerState.isRunning = true
+        timerState.hasStarted = true
+
+        timerState.timerTask = Task { @MainActor in
+            while timerState.remainingSeconds > 0 && !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(1))
+                guard !Task.isCancelled else { return }
+                timerState.remainingSeconds -= 1
+
+                #if os(iOS)
+                // Haptic feedback at 10 and 5 seconds
+                if timerState.remainingSeconds == 10 || timerState.remainingSeconds == 5 {
+                    let generator = UIImpactFeedbackGenerator(style: .medium)
+                    generator.impactOccurred()
+                }
+                #endif
+            }
+
+            if !Task.isCancelled && timerState.remainingSeconds <= 0 {
+                timerState.isRunning = false
+                await autoSubmit()
+            }
+        }
+    }
+
+    private func autoSubmit() async {
+        let text = viewModel.inputText
+        viewModel.inputText = ""
+        timerState.isRunning = false
+        timerState.timerTask?.cancel()
+        await sessionManager.submitElevatorPitch(text: text, timedOut: true)
+    }
+
+    private func submitEarly() {
+        let text = viewModel.inputText
+        viewModel.inputText = ""
+        timerState.isRunning = false
+        timerState.timerTask?.cancel()
+        Task {
+            await sessionManager.submitElevatorPitch(text: text, timedOut: false)
+        }
+    }
+
+    // MARK: - No Topics
+
+    private var noTopicsView: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "tray")
+                .font(.system(size: 48))
+                .foregroundStyle(.secondary)
+
+            Text(language == "de"
+                 ? "Keine Themen verf\u{00FC}gbar"
+                 : "No topics available")
+                .font(.title3)
+                .fontWeight(.semibold)
+
+            Text(language == "de"
+                 ? "Es gibt aktuell keine passenden Themen f\u{00FC}r dein Level."
+                 : "There are no matching topics for your current level.")
+                .font(.body)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+
+            if let onDismiss {
+                Button(language == "de" ? "Zur\u{00FC}ck" : "Go Back") {
+                    onDismiss()
+                }
+                .buttonStyle(.borderedProminent)
+                .padding(.top, 8)
+            }
+        }
+        .padding(32)
+    }
+
+    // MARK: - Actions
+
+    private func endSessionAndDismiss() {
+        timerState.timerTask?.cancel()
+        sessionManager.endSession()
+        onDismiss?()
+    }
+}
+
+// MARK: - Timer State
+
+/// Mutable timer state for the elevator pitch countdown.
+@MainActor
+private struct TimerState {
+    var totalSeconds: Int = 0
+    var remainingSeconds: Int = 0
+    var isRunning: Bool = false
+    var hasStarted: Bool = false
+    var timerTask: Task<Void, Never>?
+}
+
+// MARK: - Previews
+
+#Preview("Elevator Pitch — Loading") {
+    NavigationStack {
+        ElevatorPitchView(
+            sessionManager: SessionManager(),
+            coordinator: ElevatorPitchCoordinator(topics: [
+                Topic(
+                    id: "preview-ep",
+                    titleEN: "School uniforms",
+                    titleDE: "Schuluniformen",
+                    promptEN: "Should schools require uniforms? You have 60 seconds.",
+                    promptDE: "Sollten Schulen Uniformen vorschreiben? Du hast 60 Sekunden.",
+                    domain: .school,
+                    level: 1,
+                    barbaraFavorite: true
+                )
+            ]),
+            profile: .createDefault(displayName: "Alex"),
+            language: "en"
+        )
+    }
+}
+
+#Preview("No Topics") {
+    NavigationStack {
+        ElevatorPitchView(
+            sessionManager: SessionManager(),
+            coordinator: ElevatorPitchCoordinator(topics: []),
+            profile: .createDefault(displayName: "Alex"),
+            language: "en"
+        )
+    }
+}
+
+#Preview("German") {
+    NavigationStack {
+        ElevatorPitchView(
+            sessionManager: SessionManager(),
+            coordinator: ElevatorPitchCoordinator(topics: [
+                Topic(
+                    id: "preview-ep-de",
+                    titleEN: "Homework",
+                    titleDE: "Hausaufgaben",
+                    promptEN: "Should homework be abolished?",
+                    promptDE: "Sollten Hausaufgaben abgeschafft werden? Du hast 60 Sekunden.",
+                    domain: .school,
+                    level: 1,
+                    barbaraFavorite: false
+                )
+            ]),
+            profile: .createDefault(displayName: "Maxi", language: "de"),
+            language: "de"
+        )
+    }
+}

--- a/app/SayItRight/Presentation/Session/SessionPickerView.swift
+++ b/app/SayItRight/Presentation/Session/SessionPickerView.swift
@@ -57,12 +57,7 @@ struct SessionPickerView: View {
     }
 
     private func handleSessionSelection(_ sessionType: SessionType) {
-        switch sessionType {
-        case .sayItClearly:
-            onSessionStarted?(.sayItClearly)
-        case .findThePoint:
-            onSessionStarted?(.findThePoint)
-        }
+        onSessionStarted?(sessionType)
     }
 
     // MARK: - Layout

--- a/app/SayItRight/Tests/ElevatorPitchSessionTests.swift
+++ b/app/SayItRight/Tests/ElevatorPitchSessionTests.swift
@@ -1,0 +1,175 @@
+import Foundation
+import Testing
+@testable import SayItRight
+
+// MARK: - ElevatorPitchSession Tests
+
+@Suite("ElevatorPitchSession")
+struct ElevatorPitchSessionTests {
+
+    private static func makeTopic(id: String = "ep-topic") -> Topic {
+        Topic(
+            id: id,
+            titleEN: "Test Topic",
+            titleDE: "Testthema",
+            promptEN: "What do you think? Conclusion first.",
+            promptDE: "Was denkst du? Fazit zuerst.",
+            domain: .school,
+            level: 1,
+            barbaraFavorite: false
+        )
+    }
+
+    @Test("Session initialises with topic and duration")
+    func initialisation() {
+        let topic = Self.makeTopic()
+        let session = ElevatorPitchSession(topic: topic, durationSeconds: 60)
+
+        #expect(session.topic.id == "ep-topic")
+        #expect(session.durationSeconds == 60)
+        #expect(session.sessionTypeID == "elevator-pitch")
+        #expect(!session.hasResponse)
+        #expect(session.responseText == nil)
+        #expect(session.timedOut == false)
+    }
+
+    @Test("recordResponse captures text and timeout status")
+    func recordResponse() {
+        let topic = Self.makeTopic()
+        var session = ElevatorPitchSession(topic: topic)
+        let before = Date.now
+
+        session.recordResponse("Schools should have uniforms because...")
+
+        #expect(session.hasResponse)
+        #expect(session.responseText == "Schools should have uniforms because...")
+        #expect(session.submittedAt != nil)
+        #expect(session.submittedAt! >= before)
+        #expect(!session.timedOut)
+    }
+
+    @Test("recordResponse with timeout flag")
+    func recordResponseTimedOut() {
+        let topic = Self.makeTopic()
+        var session = ElevatorPitchSession(topic: topic)
+
+        session.recordResponse("Partial response...", timedOut: true)
+
+        #expect(session.hasResponse)
+        #expect(session.timedOut)
+    }
+
+    @Test("duration for level 1 is 60 seconds")
+    func durationLevel1() {
+        #expect(ElevatorPitchSession.duration(for: 1) == 60)
+    }
+
+    @Test("duration for level 2+ is 30 seconds")
+    func durationLevel2() {
+        #expect(ElevatorPitchSession.duration(for: 2) == 30)
+        #expect(ElevatorPitchSession.duration(for: 3) == 30)
+        #expect(ElevatorPitchSession.duration(for: 4) == 30)
+    }
+}
+
+// MARK: - ElevatorPitchCoordinator Tests
+
+@Suite("ElevatorPitchCoordinator")
+struct ElevatorPitchCoordinatorTests {
+
+    private static let testTopics: [Topic] = [
+        Topic(
+            id: "ep-1",
+            titleEN: "Topic 1",
+            titleDE: "Thema 1",
+            promptEN: "Prompt 1",
+            promptDE: "Aufgabe 1",
+            domain: .school,
+            level: 1,
+            barbaraFavorite: false
+        ),
+        Topic(
+            id: "ep-2",
+            titleEN: "Topic 2",
+            titleDE: "Thema 2",
+            promptEN: "Prompt 2",
+            promptDE: "Aufgabe 2",
+            domain: .everyday,
+            level: 1,
+            barbaraFavorite: true
+        ),
+    ]
+
+    @Test("selectTopic returns a topic for matching level")
+    @MainActor
+    func selectTopicForLevel() {
+        let coordinator = ElevatorPitchCoordinator(topics: Self.testTopics)
+        let topic = coordinator.selectTopic(for: 1, language: "en")
+        #expect(topic != nil)
+        #expect(topic!.level <= 1)
+    }
+
+    @Test("selectTopic returns nil when no topics match")
+    @MainActor
+    func noMatchingTopics() {
+        let coordinator = ElevatorPitchCoordinator(topics: [])
+        let topic = coordinator.selectTopic(for: 1, language: "en")
+        #expect(topic == nil)
+    }
+
+    @Test("selectTopic avoids recently seen topics")
+    @MainActor
+    func avoidsRecentTopics() {
+        let coordinator = ElevatorPitchCoordinator(topics: Self.testTopics)
+
+        let first = coordinator.selectTopic(for: 1, language: "en")
+        #expect(first != nil)
+
+        coordinator.recentTopicIDs.insert(first!.id)
+
+        let second = coordinator.selectTopic(for: 1, language: "en")
+        #expect(second != nil)
+        #expect(second!.id != first!.id)
+    }
+
+    @Test("clearRecentTopics empties the set")
+    @MainActor
+    func clearRecentTopics() {
+        let coordinator = ElevatorPitchCoordinator(topics: Self.testTopics)
+        coordinator.recentTopicIDs.insert("x")
+        coordinator.clearRecentTopics()
+        #expect(coordinator.recentTopicIDs.isEmpty)
+    }
+}
+
+// MARK: - SessionType Elevator Pitch Tests
+
+@Suite("SessionType — Elevator Pitch")
+struct SessionTypeElevatorPitchTests {
+
+    @Test("elevatorPitch has correct raw value")
+    func rawValue() {
+        #expect(SessionType.elevatorPitch.rawValue == "elevator-pitch")
+    }
+
+    @Test("elevatorPitch English display name")
+    func displayNameEN() {
+        #expect(SessionType.elevatorPitch.displayName(language: "en") == "The elevator pitch")
+    }
+
+    @Test("elevatorPitch German display name")
+    func displayNameDE() {
+        #expect(SessionType.elevatorPitch.displayName(language: "de") == "30 Sekunden")
+    }
+
+    @Test("elevatorPitch icon is timer")
+    func iconName() {
+        #expect(SessionType.elevatorPitch.iconName == "timer")
+    }
+
+    @Test("CaseIterable includes elevatorPitch")
+    func allCases() {
+        #expect(SessionType.allCases.contains(.elevatorPitch))
+        #expect(SessionType.allCases.count == 3)
+    }
+}


### PR DESCRIPTION
## Summary
- New "Elevator Pitch" / "30 Sekunden" timed session type
- Countdown timer (60s L1, 30s L2+) with color transitions and auto-submit
- Barbara evaluates structural prioritisation under time pressure
- One-shot format: no revision loop

## Test plan
- [x] Build succeeds (macOS)
- [x] All 493 tests pass
- [x] New tests: session state, duration, coordinator, SessionType enum

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)