### PR TITLE
feat: add learner profile update from session metadata (SIR-034)

### DIFF
--- a/app/SayItRight/Intelligence/ConversationManager/SessionManager.swift
+++ b/app/SayItRight/Intelligence/ConversationManager/SessionManager.swift
@@ -46,6 +46,10 @@ final class SessionManager {
     private let systemPromptAssembler: SystemPromptAssembler
     private let responseParser: ResponseParser
     let structuralEvaluator: StructuralEvaluator
+    private let profileUpdater: ProfileUpdater
+
+    /// Optional profile store for persisting session results.
+    var profileStore: LearnerProfileStore?
 
     // MARK: - Configuration
 
@@ -61,12 +65,14 @@ final class SessionManager {
         anthropicService: AnthropicService = .shared,
         systemPromptAssembler: SystemPromptAssembler = SystemPromptAssembler(),
         responseParser: ResponseParser = ResponseParser(),
-        structuralEvaluator: StructuralEvaluator = StructuralEvaluator()
+        structuralEvaluator: StructuralEvaluator = StructuralEvaluator(),
+        profileUpdater: ProfileUpdater = ProfileUpdater()
     ) {
         self.anthropicService = anthropicService
         self.systemPromptAssembler = systemPromptAssembler
         self.responseParser = responseParser
         self.structuralEvaluator = structuralEvaluator
+        self.profileUpdater = profileUpdater
     }
 
     // MARK: - Public API
@@ -399,6 +405,19 @@ final class SessionManager {
     /// Clears conversation state and returns to idle. The session summary
     /// (last metadata) remains accessible until a new session starts.
     func endSession() {
+        // Apply profile updates from this session's metadata before clearing
+        let metadata = sessionMetadata
+        let sessionType = activeSessionType?.rawValue ?? ""
+        if let store = profileStore, !metadata.isEmpty {
+            Task {
+                try? await profileUpdater.applySessionResults(
+                    store: store,
+                    metadataList: metadata,
+                    sessionType: sessionType
+                )
+            }
+        }
+
         activeSessionType = nil
         sayItClearlySession = nil
 

--- a/app/SayItRight/State/LearnerProfile/ProfileUpdater.swift
+++ b/app/SayItRight/State/LearnerProfile/ProfileUpdater.swift
@@ -1,0 +1,111 @@
+import Foundation
+
+/// Updates the learner profile from session evaluation metadata.
+///
+/// Bridges individual session results to long-term skill tracking by
+/// extracting dimension scores from Barbara's hidden metadata, computing
+/// rolling averages, and identifying structural strengths and development areas.
+struct ProfileUpdater: Sendable {
+
+    // MARK: - Thresholds
+
+    /// Rolling average above this marks a dimension as a strength.
+    static let strengthThreshold: Double = 0.8
+
+    /// Rolling average below this marks a dimension as a development area.
+    static let developmentThreshold: Double = 0.5
+
+    /// Maximum scores per dimension (L1 rubric).
+    static let maxScores: [String: Int] = [
+        "governingThought": 3,
+        "supportGrouping": 2,
+        "redundancy": 2,
+        "clarity": 3,
+        "l1Gate": 3,
+        "meceQuality": 3,
+        "orderingLogic": 3,
+        "scqApplication": 2,
+        "horizontalLogic": 2
+    ]
+
+    // MARK: - Public API
+
+    /// Update a profile with scores from session metadata.
+    ///
+    /// - Parameters:
+    ///   - profile: The profile to update (mutated in place).
+    ///   - metadataList: All metadata blocks from the session.
+    ///   - sessionType: The type of session completed.
+    func updateProfile(
+        _ profile: inout LearnerProfile,
+        from metadataList: [BarbaraMetadata],
+        sessionType: String
+    ) {
+        // Extract the last evaluation metadata with scores
+        let scoredMetadata = metadataList.filter { !$0.scores.isEmpty }
+        guard !scoredMetadata.isEmpty else { return }
+
+        // Record dimension scores from each evaluation
+        for metadata in scoredMetadata {
+            for (dimension, score) in metadata.scores {
+                profile.recordScore(score, for: dimension)
+            }
+        }
+
+        // Update session count
+        profile.sessionCount += 1
+
+        // Update streak
+        profile.updateStreak()
+
+        // Recalculate strengths and development areas
+        updateStrengthsAndWeaknesses(&profile)
+    }
+
+    /// Update a profile from a single metadata block (convenience).
+    func updateProfile(
+        _ profile: inout LearnerProfile,
+        from metadata: BarbaraMetadata,
+        sessionType: String
+    ) {
+        updateProfile(&profile, from: [metadata], sessionType: sessionType)
+    }
+
+    /// Apply profile update via the store (async, saves to disk).
+    func applySessionResults(
+        store: LearnerProfileStore,
+        metadataList: [BarbaraMetadata],
+        sessionType: String
+    ) async throws {
+        let scoredMetadata = metadataList.filter { !$0.scores.isEmpty }
+        guard !scoredMetadata.isEmpty else { return }
+
+        try await store.update { profile in
+            self.updateProfile(&profile, from: scoredMetadata, sessionType: sessionType)
+        }
+    }
+
+    // MARK: - Private
+
+    /// Recalculate structural strengths and development areas from rolling averages.
+    private func updateStrengthsAndWeaknesses(_ profile: inout LearnerProfile) {
+        var strengths: [String] = []
+        var weaknesses: [String] = []
+
+        for (dimension, scores) in profile.dimensionScores where !scores.isEmpty {
+            guard let maxScore = Self.maxScores[dimension], maxScore > 0 else { continue }
+
+            let avg = profile.rollingAverage(for: dimension) ?? 0
+            let normalised = avg / Double(maxScore)
+
+            if normalised >= Self.strengthThreshold {
+                strengths.append(dimension)
+            } else if normalised < Self.developmentThreshold {
+                weaknesses.append(dimension)
+            }
+        }
+
+        profile.structuralStrengths = strengths.sorted()
+        profile.developmentAreas = weaknesses.sorted()
+    }
+}

--- a/app/SayItRight/Tests/ProfileUpdaterTests.swift
+++ b/app/SayItRight/Tests/ProfileUpdaterTests.swift
@@ -1,0 +1,178 @@
+import Testing
+import Foundation
+@testable import SayItRight
+
+@Suite("ProfileUpdater")
+struct ProfileUpdaterTests {
+
+    private static func makeMetadata(
+        scores: [String: Int] = ["governingThought": 2, "clarity": 2, "supportGrouping": 1, "redundancy": 1],
+        totalScore: Int = 6,
+        mood: BarbaraMood = .evaluating,
+        progressionSignal: ProgressionSignal = .none,
+        revisionRound: Int = 0,
+        sessionPhase: SessionPhase = .evaluation
+    ) -> BarbaraMetadata {
+        BarbaraMetadata(
+            scores: scores,
+            totalScore: totalScore,
+            mood: mood,
+            progressionSignal: progressionSignal,
+            revisionRound: revisionRound,
+            sessionPhase: sessionPhase,
+            feedbackFocus: "clarity",
+            language: "en"
+        )
+    }
+
+    @Test("Updates dimension scores from metadata")
+    func recordsScores() {
+        let updater = ProfileUpdater()
+        var profile = LearnerProfile.createDefault()
+        let metadata = Self.makeMetadata()
+
+        updater.updateProfile(&profile, from: metadata, sessionType: "say-it-clearly")
+
+        #expect(profile.dimensionScores["governingThought"] == [2])
+        #expect(profile.dimensionScores["clarity"] == [2])
+        #expect(profile.dimensionScores["supportGrouping"] == [1])
+        #expect(profile.dimensionScores["redundancy"] == [1])
+    }
+
+    @Test("Increments session count")
+    func incrementsSessionCount() {
+        let updater = ProfileUpdater()
+        var profile = LearnerProfile.createDefault()
+
+        updater.updateProfile(&profile, from: Self.makeMetadata(), sessionType: "say-it-clearly")
+
+        #expect(profile.sessionCount == 1)
+    }
+
+    @Test("Updates streak")
+    func updatesStreak() {
+        let updater = ProfileUpdater()
+        var profile = LearnerProfile.createDefault()
+
+        updater.updateProfile(&profile, from: Self.makeMetadata(), sessionType: "say-it-clearly")
+
+        #expect(profile.currentStreak == 1)
+        #expect(profile.lastSessionDate != nil)
+    }
+
+    @Test("Identifies strengths from high rolling averages")
+    func identifiesStrengths() {
+        let updater = ProfileUpdater()
+        var profile = LearnerProfile.createDefault()
+
+        // Record high scores for governingThought (max 3) — need ≥ 0.8 * 3 = 2.4
+        let highMetadata = Self.makeMetadata(scores: ["governingThought": 3, "clarity": 3])
+        for _ in 0..<5 {
+            updater.updateProfile(&profile, from: highMetadata, sessionType: "say-it-clearly")
+        }
+
+        #expect(profile.structuralStrengths.contains("governingThought"))
+        #expect(profile.structuralStrengths.contains("clarity"))
+    }
+
+    @Test("Identifies development areas from low rolling averages")
+    func identifiesDevelopmentAreas() {
+        let updater = ProfileUpdater()
+        var profile = LearnerProfile.createDefault()
+
+        // Record low scores for supportGrouping (max 2) — need < 0.5 * 2 = 1.0
+        let lowMetadata = Self.makeMetadata(scores: ["supportGrouping": 0, "redundancy": 0])
+        for _ in 0..<3 {
+            updater.updateProfile(&profile, from: lowMetadata, sessionType: "say-it-clearly")
+        }
+
+        #expect(profile.developmentAreas.contains("supportGrouping"))
+        #expect(profile.developmentAreas.contains("redundancy"))
+    }
+
+    @Test("Does not corrupt profile when metadata has no scores")
+    func noScoresNoCorruption() {
+        let updater = ProfileUpdater()
+        var profile = LearnerProfile.createDefault()
+        profile.sessionCount = 5
+
+        let emptyMetadata = Self.makeMetadata(scores: [:], totalScore: 0)
+        updater.updateProfile(&profile, from: [emptyMetadata], sessionType: "say-it-clearly")
+
+        // Should not change since metadata is filtered
+        #expect(profile.sessionCount == 5)
+    }
+
+    @Test("Multiple metadata blocks from same session all contribute scores")
+    func multipleMetadataBlocks() {
+        let updater = ProfileUpdater()
+        var profile = LearnerProfile.createDefault()
+
+        let meta1 = Self.makeMetadata(scores: ["governingThought": 1, "clarity": 1])
+        let meta2 = Self.makeMetadata(scores: ["governingThought": 3, "clarity": 3])
+
+        updater.updateProfile(&profile, from: [meta1, meta2], sessionType: "say-it-clearly")
+
+        // Both scores recorded
+        #expect(profile.dimensionScores["governingThought"] == [1, 3])
+        #expect(profile.dimensionScores["clarity"] == [1, 3])
+        // Session count only incremented once
+        #expect(profile.sessionCount == 1)
+    }
+
+    @Test("Rolling average correctly determines threshold membership")
+    func rollingAverageThresholds() {
+        let updater = ProfileUpdater()
+        var profile = LearnerProfile.createDefault()
+
+        // governingThought: max 3, threshold 0.8 → needs avg ≥ 2.4
+        // Give score of 2 (avg = 2/3 = 0.67) — should be neither strength nor weakness
+        let midMetadata = Self.makeMetadata(scores: ["governingThought": 2])
+        updater.updateProfile(&profile, from: midMetadata, sessionType: "say-it-clearly")
+
+        #expect(!profile.structuralStrengths.contains("governingThought"))
+        #expect(!profile.developmentAreas.contains("governingThought"))
+    }
+
+    @Test("Revision improvement tracked via multiple metadata blocks")
+    func revisionImprovement() {
+        let updater = ProfileUpdater()
+        var profile = LearnerProfile.createDefault()
+
+        let firstDraft = Self.makeMetadata(
+            scores: ["governingThought": 1, "clarity": 1],
+            revisionRound: 0
+        )
+        let revision = Self.makeMetadata(
+            scores: ["governingThought": 3, "clarity": 2],
+            revisionRound: 1
+        )
+
+        updater.updateProfile(&profile, from: [firstDraft, revision], sessionType: "say-it-clearly")
+
+        // Both scores recorded — profile shows improvement trajectory
+        #expect(profile.dimensionScores["governingThought"] == [1, 3])
+        #expect(profile.dimensionScores["clarity"] == [1, 2])
+    }
+
+    @Test("applySessionResults saves to store")
+    func appliesViaStore() async throws {
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let store = await LearnerProfileStore(directory: tmpDir)
+        let updater = ProfileUpdater()
+
+        try await updater.applySessionResults(
+            store: store,
+            metadataList: [Self.makeMetadata()],
+            sessionType: "say-it-clearly"
+        )
+
+        let profile = await store.current
+        #expect(profile.sessionCount == 1)
+        #expect(profile.dimensionScores["governingThought"] == [2])
+    }
+}


### PR DESCRIPTION
## Summary
- ProfileUpdater bridges session results to long-term skill tracking
- Records dimension scores, updates rolling averages, recalculates strengths/weaknesses
- SessionManager applies updates on session end when profileStore is set
- Safe: no corruption when metadata missing

## Test plan
- [x] Build succeeds
- [x] 503 tests pass (10 new)

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)