### PR TITLE
feat: add Analyse My Text user-submitted text analysis (SIR-040)

### DIFF
--- a/app/SayItRight/App/SayItRightApp.swift
+++ b/app/SayItRight/App/SayItRightApp.swift
@@ -52,6 +52,7 @@ struct ContentView: View {
     @State private var showSayItClearly = false
     @State private var showFindThePoint = false
     @State private var showElevatorPitch = false
+    @State private var showAnalyseMyText = false
 
     private var language: String { settings.language }
 
@@ -77,6 +78,8 @@ struct ContentView: View {
                     showFindThePoint = true
                 case .elevatorPitch:
                     showElevatorPitch = true
+                case .analyseMyText:
+                    showAnalyseMyText = true
                 }
             }
             .navigationDestination(isPresented: $showSayItClearly) {
@@ -107,6 +110,15 @@ struct ContentView: View {
                     language: language
                 ) {
                     showElevatorPitch = false
+                }
+            }
+            .navigationDestination(isPresented: $showAnalyseMyText) {
+                AnalyseMyTextView(
+                    sessionManager: sessionManager,
+                    profile: profile,
+                    language: language
+                ) {
+                    showAnalyseMyText = false
                 }
             }
         }

--- a/app/SayItRight/Content/PracticeTexts/TextDifficultyCalibrator.swift
+++ b/app/SayItRight/Content/PracticeTexts/TextDifficultyCalibrator.swift
@@ -143,7 +143,7 @@ struct TextDifficultyCalibrator: Sendable {
         case .findThePoint:
             // "Find the point" works with all allowed quality levels
             return texts
-        case .sayItClearly, .elevatorPitch:
+        case .sayItClearly, .elevatorPitch, .analyseMyText:
             // Build mode — no text selection needed, but if called, return all
             return texts
         }

--- a/app/SayItRight/Intelligence/ConversationManager/AnalyseMyTextSession.swift
+++ b/app/SayItRight/Intelligence/ConversationManager/AnalyseMyTextSession.swift
@@ -1,0 +1,113 @@
+import Foundation
+
+/// Tracks the state of an "Analyse my text" session.
+///
+/// The user pastes their own text (essay, email, article draft) and Barbara
+/// provides structural feedback. Supports a revision loop — the user can
+/// revise their text based on feedback.
+struct AnalyseMyTextSession: Sendable {
+
+    /// When the session was started.
+    let startedAt: Date
+
+    /// All text submissions, in order. Index 0 is the original text.
+    private(set) var submissions: [Submission] = []
+
+    /// Maximum number of revisions allowed.
+    let maxRevisions: Int
+
+    /// Whether a content flag was raised for the submitted text.
+    private(set) var contentFlagged: Bool = false
+
+    /// The session type identifier.
+    let sessionTypeID: String = "analyse-my-text"
+
+    /// Minimum sentence count for analysis.
+    static let minimumSentences = 2
+
+    /// Maximum word count for analysis.
+    static let maximumWords = 2000
+
+    init(startedAt: Date = .now, maxRevisions: Int = 2) {
+        self.startedAt = startedAt
+        self.maxRevisions = maxRevisions
+    }
+
+    /// A single text submission.
+    struct Submission: Sendable, Equatable {
+        let text: String
+        let submittedAt: Date
+        let wordCount: Int
+    }
+
+    /// Record a text submission.
+    mutating func recordSubmission(_ text: String, at date: Date = .now) {
+        let wordCount = text.components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }.count
+        submissions.append(Submission(text: text, submittedAt: date, wordCount: wordCount))
+    }
+
+    /// Mark that content was flagged.
+    mutating func markContentFlagged() {
+        contentFlagged = true
+    }
+
+    /// The original submitted text.
+    var originalText: String? {
+        submissions.first?.text
+    }
+
+    /// The latest submitted text.
+    var latestText: String? {
+        submissions.last?.text
+    }
+
+    /// Whether the user has submitted text.
+    var hasSubmission: Bool {
+        !submissions.isEmpty
+    }
+
+    /// Current revision round (0 = first submission).
+    var currentRevisionRound: Int {
+        max(0, submissions.count - 1)
+    }
+
+    /// Whether more revisions are allowed.
+    var canRevise: Bool {
+        hasSubmission && currentRevisionRound < maxRevisions
+    }
+
+    /// Validate text length before submission.
+    static func validate(_ text: String) -> TextValidationResult {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if trimmed.isEmpty {
+            return .empty
+        }
+
+        // Count sentences (rough: split by .!?)
+        let sentenceCount = trimmed.components(separatedBy: CharacterSet(charactersIn: ".!?"))
+            .filter { !$0.trimmingCharacters(in: .whitespaces).isEmpty }
+            .count
+        if sentenceCount < minimumSentences {
+            return .tooShort
+        }
+
+        // Count words
+        let wordCount = trimmed.components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }.count
+        if wordCount > maximumWords {
+            return .tooLong(wordCount: wordCount)
+        }
+
+        return .valid
+    }
+
+    /// Text validation result.
+    enum TextValidationResult: Equatable {
+        case valid
+        case empty
+        case tooShort
+        case tooLong(wordCount: Int)
+    }
+}

--- a/app/SayItRight/Intelligence/ConversationManager/SessionManager.swift
+++ b/app/SayItRight/Intelligence/ConversationManager/SessionManager.swift
@@ -37,6 +37,9 @@ final class SessionManager {
     /// The active "Elevator pitch" session state, if any.
     private(set) var elevatorPitchSession: ElevatorPitchSession?
 
+    /// The active "Analyse my text" session state, if any.
+    private(set) var analyseMyTextSession: AnalyseMyTextSession?
+
     /// The latest evaluation result from the structural evaluator.
     private(set) var lastEvaluationResult: EvaluationResult?
 
@@ -94,6 +97,7 @@ final class SessionManager {
         sayItClearlySession = nil
         findThePointSession = nil
         elevatorPitchSession = nil
+        analyseMyTextSession = nil
 
         lastEvaluationResult = nil
         sessionState = .loading
@@ -135,6 +139,7 @@ final class SessionManager {
         sayItClearlySession = SayItClearlySession(topic: topic)
         findThePointSession = nil
         elevatorPitchSession = nil
+        analyseMyTextSession = nil
 
         lastEvaluationResult = nil
         sessionState = .loading
@@ -183,6 +188,7 @@ final class SessionManager {
         sayItClearlySession = nil
         findThePointSession = FindThePointSession(practiceText: practiceText)
         elevatorPitchSession = nil
+        analyseMyTextSession = nil
 
         sessionState = .loading
 
@@ -336,6 +342,78 @@ final class SessionManager {
         await streamBarbaraResponse()
     }
 
+    /// Start an "Analyse my text" session.
+    ///
+    /// No topic selection — the user provides their own text. Barbara greets
+    /// the learner and asks them to paste their text.
+    func startAnalyseMyTextSession(profile: LearnerProfile, language: String) async {
+        messages = []
+        sessionMetadata = []
+        activeSessionType = .analyseMyText
+        sayItClearlySession = nil
+        findThePointSession = nil
+        elevatorPitchSession = nil
+        analyseMyTextSession = AnalyseMyTextSession()
+
+        lastEvaluationResult = nil
+        sessionState = .loading
+
+        let basePrompt = systemPromptAssembler.assemble(
+            level: profile.currentLevel,
+            sessionType: SessionType.analyseMyText.rawValue,
+            language: language,
+            profileJSON: profile.toPromptJSON()
+        )
+
+        let directive = analyseMyTextDirectiveBlock(language: language)
+        systemPrompt = basePrompt + "\n\n" + directive
+
+        await structuralEvaluator.prepareSession(
+            level: profile.currentLevel,
+            sessionType: SessionType.analyseMyText.rawValue,
+            language: language,
+            profile: profile
+        )
+
+        await streamBarbaraResponse()
+    }
+
+    /// Build the directive block for "Analyse my text" sessions.
+    private func analyseMyTextDirectiveBlock(language: String) -> String {
+        """
+        # Analyse My Text Session
+
+        The learner will paste their own text (essay, email, article draft) for \
+        structural analysis. Greet them and ask them to paste or type their text.
+
+        When evaluating:
+        - Analyse the STRUCTURE of the text, never the content correctness.
+        - Identify the governing thought (or note its absence).
+        - Evaluate grouping, MECE compliance, and logical flow.
+        - Reference specific sentences from the text in your feedback.
+        - Be exploratory: "What's your main point here? I can see several \
+        candidates — which one did you intend?"
+        - Acknowledge real-world context: "If this is for a school essay, your \
+        teacher will appreciate a clearer lead."
+        - After evaluation, encourage revision: "Now revise with my feedback in \
+        mind. Lead with your key point."
+
+        If the text is too short (less than 2 sentences), ask for more: \
+        "That's not enough to evaluate. Give me at least a paragraph."
+
+        If the text is very long, focus on the overall structure and the first \
+        few paragraphs in detail.
+
+        IMPORTANT: If the text contains distressing, violent, or inappropriate \
+        content, still provide structural feedback but include a content_flag \
+        field in the BARBARA_META block set to true.
+
+        Set sessionPhase to "evaluation" when providing feedback.
+        After revisions are complete, provide a session summary with \
+        sessionPhase "summary".
+        """
+    }
+
     /// Send a learner message and stream Barbara's response.
     ///
     /// - Parameter text: The learner's message text.
@@ -361,6 +439,11 @@ final class SessionManager {
         // Track extraction attempts in "Find the point" session
         if findThePointSession != nil && !findThePointSession!.hasUsedRetry {
             findThePointSession?.recordAttempt(trimmed)
+        }
+
+        // Track submissions in "Analyse my text" session
+        if analyseMyTextSession != nil {
+            analyseMyTextSession?.recordSubmission(trimmed)
         }
 
         // Check context window limits
@@ -423,6 +506,7 @@ final class SessionManager {
 
         findThePointSession = nil
         elevatorPitchSession = nil
+        analyseMyTextSession = nil
 
         lastEvaluationResult = nil
         sessionState = .idle

--- a/app/SayItRight/Intelligence/ConversationManager/SessionType.swift
+++ b/app/SayItRight/Intelligence/ConversationManager/SessionType.swift
@@ -8,6 +8,7 @@ enum SessionType: String, CaseIterable, Identifiable, Sendable {
     case sayItClearly = "say-it-clearly"
     case findThePoint = "find-the-point"
     case elevatorPitch = "elevator-pitch"
+    case analyseMyText = "analyse-my-text"
 
     var id: String { rawValue }
 
@@ -20,6 +21,8 @@ enum SessionType: String, CaseIterable, Identifiable, Sendable {
             language == "de" ? "Finde den Punkt" : "Find the point"
         case .elevatorPitch:
             language == "de" ? "30 Sekunden" : "The elevator pitch"
+        case .analyseMyText:
+            language == "de" ? "Analysiere meinen Text" : "Analyse my text"
         }
     }
 
@@ -38,6 +41,10 @@ enum SessionType: String, CaseIterable, Identifiable, Sendable {
             language == "de"
                 ? "Schreib unter Zeitdruck. Barbara bewertet, ob du priorisieren kannst."
                 : "Write under time pressure. Barbara evaluates your ability to prioritise."
+        case .analyseMyText:
+            language == "de"
+                ? "F\u{00FC}g deinen eigenen Text ein. Barbara bewertet die Struktur."
+                : "Paste your own text. Barbara evaluates the structure."
         }
     }
 
@@ -47,6 +54,7 @@ enum SessionType: String, CaseIterable, Identifiable, Sendable {
         case .sayItClearly: "text.bubble"
         case .findThePoint: "magnifyingglass"
         case .elevatorPitch: "timer"
+        case .analyseMyText: "doc.text"
         }
     }
 }

--- a/app/SayItRight/Presentation/Session/AnalyseMyTextView.swift
+++ b/app/SayItRight/Presentation/Session/AnalyseMyTextView.swift
@@ -1,0 +1,99 @@
+import SwiftUI
+
+/// Full-screen view for an "Analyse my text" session.
+///
+/// The learner pastes or types their own text for structural analysis.
+/// No topic selection — the text IS the input. Barbara evaluates the
+/// structure and the learner can revise based on feedback.
+///
+/// Platform behavior:
+/// - **iPhone**: Full-width chat, text input area.
+/// - **iPad/Mac**: Centered layout with generous text input area.
+struct AnalyseMyTextView: View {
+    let sessionManager: SessionManager
+    let profile: LearnerProfile
+    let language: String
+    var onDismiss: (() -> Void)?
+
+    @State private var viewModel: ChatViewModel
+    @State private var sessionStarted = false
+
+    init(
+        sessionManager: SessionManager,
+        profile: LearnerProfile,
+        language: String,
+        onDismiss: (() -> Void)? = nil
+    ) {
+        self.sessionManager = sessionManager
+        self.profile = profile
+        self.language = language
+        self.onDismiss = onDismiss
+        self._viewModel = State(initialValue: ChatViewModel(sessionManager: sessionManager))
+    }
+
+    var body: some View {
+        ChatView(viewModel: viewModel)
+            .navigationTitle(SessionType.analyseMyText.displayName(language: language))
+            #if !os(macOS)
+            .navigationBarTitleDisplayMode(.inline)
+            #endif
+            .toolbar {
+                ToolbarItem(placement: .automatic) {
+                    Button(action: endSessionAndDismiss) {
+                        Label(
+                            language == "de" ? "Beenden" : "End Session",
+                            systemImage: "xmark.circle"
+                        )
+                    }
+                }
+            }
+            .task {
+                guard !sessionStarted else { return }
+                sessionStarted = true
+                await sessionManager.startAnalyseMyTextSession(
+                    profile: profile,
+                    language: language
+                )
+            }
+    }
+
+    // MARK: - Actions
+
+    private func endSessionAndDismiss() {
+        sessionManager.endSession()
+        onDismiss?()
+    }
+}
+
+// MARK: - Previews
+
+#Preview("Analyse My Text — Loading") {
+    NavigationStack {
+        AnalyseMyTextView(
+            sessionManager: SessionManager(),
+            profile: .createDefault(displayName: "Alex"),
+            language: "en"
+        )
+    }
+}
+
+#Preview("German") {
+    NavigationStack {
+        AnalyseMyTextView(
+            sessionManager: SessionManager(),
+            profile: .createDefault(displayName: "Maxi", language: "de"),
+            language: "de"
+        )
+    }
+}
+
+#Preview("iPad") {
+    NavigationStack {
+        AnalyseMyTextView(
+            sessionManager: SessionManager(),
+            profile: .createDefault(displayName: "Alex"),
+            language: "en"
+        )
+    }
+    .environment(\.horizontalSizeClass, .regular)
+}

--- a/app/SayItRight/Tests/AnalyseMyTextSessionTests.swift
+++ b/app/SayItRight/Tests/AnalyseMyTextSessionTests.swift
@@ -1,0 +1,122 @@
+import Foundation
+import Testing
+@testable import SayItRight
+
+@Suite("AnalyseMyTextSession")
+struct AnalyseMyTextSessionTests {
+
+    @Test("Session initialises with defaults")
+    func initialisation() {
+        let session = AnalyseMyTextSession()
+
+        #expect(session.sessionTypeID == "analyse-my-text")
+        #expect(!session.hasSubmission)
+        #expect(session.originalText == nil)
+        #expect(session.latestText == nil)
+        #expect(session.currentRevisionRound == 0)
+        #expect(session.maxRevisions == 2)
+        #expect(!session.contentFlagged)
+    }
+
+    @Test("recordSubmission captures text and word count")
+    func recordSubmission() {
+        var session = AnalyseMyTextSession()
+
+        session.recordSubmission("Schools should require uniforms. This reduces social pressure among students.")
+
+        #expect(session.hasSubmission)
+        #expect(session.originalText?.contains("Schools should") == true)
+        #expect(session.submissions.count == 1)
+        #expect(session.submissions[0].wordCount == 10)
+    }
+
+    @Test("Multiple submissions tracked for revision loop")
+    func multipleSubmissions() {
+        var session = AnalyseMyTextSession()
+
+        session.recordSubmission("First draft of my essay. It has several points.")
+        #expect(session.canRevise == true)
+        #expect(session.currentRevisionRound == 0)
+
+        session.recordSubmission("Revised draft with clearer structure. The main point comes first.")
+        #expect(session.currentRevisionRound == 1)
+        #expect(session.canRevise == true)
+
+        session.recordSubmission("Final revision with tight structure. Lead with conclusion.")
+        #expect(session.currentRevisionRound == 2)
+        #expect(session.canRevise == false)
+        #expect(session.originalText?.contains("First draft") == true)
+        #expect(session.latestText?.contains("Final revision") == true)
+    }
+
+    @Test("Content flag can be set")
+    func contentFlag() {
+        var session = AnalyseMyTextSession()
+        #expect(!session.contentFlagged)
+        session.markContentFlagged()
+        #expect(session.contentFlagged)
+    }
+
+    // MARK: - Text Validation
+
+    @Test("Empty text is invalid")
+    func validateEmpty() {
+        #expect(AnalyseMyTextSession.validate("") == .empty)
+        #expect(AnalyseMyTextSession.validate("   ") == .empty)
+    }
+
+    @Test("Single sentence is too short")
+    func validateTooShort() {
+        #expect(AnalyseMyTextSession.validate("Just one sentence") == .tooShort)
+    }
+
+    @Test("Two sentences is valid")
+    func validateMinimum() {
+        let text = "This is the first sentence. This is the second sentence."
+        #expect(AnalyseMyTextSession.validate(text) == .valid)
+    }
+
+    @Test("Very long text is rejected")
+    func validateTooLong() {
+        let words = (0..<2100).map { "word\($0)" }.joined(separator: " ")
+        let text = words + ". Another sentence here."
+        let result = AnalyseMyTextSession.validate(text)
+        if case .tooLong(let count) = result {
+            #expect(count > 2000)
+        } else {
+            Issue.record("Expected .tooLong but got \(result)")
+        }
+    }
+}
+
+// MARK: - SessionType Tests
+
+@Suite("SessionType — Analyse My Text")
+struct SessionTypeAnalyseMyTextTests {
+
+    @Test("analyseMyText raw value")
+    func rawValue() {
+        #expect(SessionType.analyseMyText.rawValue == "analyse-my-text")
+    }
+
+    @Test("English display name")
+    func displayNameEN() {
+        #expect(SessionType.analyseMyText.displayName(language: "en") == "Analyse my text")
+    }
+
+    @Test("German display name")
+    func displayNameDE() {
+        #expect(SessionType.analyseMyText.displayName(language: "de") == "Analysiere meinen Text")
+    }
+
+    @Test("Icon is doc.text")
+    func iconName() {
+        #expect(SessionType.analyseMyText.iconName == "doc.text")
+    }
+
+    @Test("CaseIterable includes analyseMyText")
+    func allCases() {
+        #expect(SessionType.allCases.contains(.analyseMyText))
+        #expect(SessionType.allCases.count == 4)
+    }
+}

--- a/app/SayItRight/Tests/ElevatorPitchSessionTests.swift
+++ b/app/SayItRight/Tests/ElevatorPitchSessionTests.swift
@@ -170,6 +170,5 @@ struct SessionTypeElevatorPitchTests {
     @Test("CaseIterable includes elevatorPitch")
     func allCases() {
         #expect(SessionType.allCases.contains(.elevatorPitch))
-        #expect(SessionType.allCases.count == 3)
     }
 }


### PR DESCRIPTION
## Summary
- Add `AnalyseMyTextSession` with multi-submission revision tracking, content flagging, and text validation
- Add `AnalyseMyTextView` with chat-based interface for user-submitted text analysis
- Add `.analyseMyText` case to `SessionType` with bilingual display names
- Integrate into `SessionManager` and app routing

Closes #40

## Test plan
- [x] 13 unit tests for session state, validation, and revisions
- [x] Build passes on macOS
- [x] All 516 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)