### PR TITLE
feat: add progress dashboard with level, streak, and dimension chart (SIR-035)

### DIFF
--- a/app/SayItRight/App/SayItRightApp.swift
+++ b/app/SayItRight/App/SayItRightApp.swift
@@ -53,6 +53,7 @@ struct ContentView: View {
     @State private var showFindThePoint = false
     @State private var showElevatorPitch = false
     @State private var showAnalyseMyText = false
+    @State private var showDashboard = false
 
     private var language: String { settings.language }
 
@@ -119,6 +120,24 @@ struct ContentView: View {
                     language: language
                 ) {
                     showAnalyseMyText = false
+                }
+            }
+            .navigationDestination(isPresented: $showDashboard) {
+                ProgressDashboardView(
+                    profile: profile,
+                    language: language
+                )
+            }
+            .toolbar {
+                ToolbarItem(placement: .automatic) {
+                    Button {
+                        showDashboard = true
+                    } label: {
+                        Label(
+                            language == "de" ? "Fortschritt" : "Progress",
+                            systemImage: "chart.bar.fill"
+                        )
+                    }
                 }
             }
         }

--- a/app/SayItRight/Presentation/Dashboard/DimensionBarChartView.swift
+++ b/app/SayItRight/Presentation/Dashboard/DimensionBarChartView.swift
@@ -1,0 +1,121 @@
+import SwiftUI
+
+/// Bar chart showing rolling average scores per structural dimension.
+///
+/// Each dimension is displayed as a horizontal bar with a user-friendly label.
+/// Bars are colour-coded: green for strengths, red for development areas, blue for normal.
+struct DimensionBarChartView: View {
+    let dimensionScores: [String: [Int]]
+    let language: String
+
+    private var sortedDimensions: [(key: String, average: Double, maxScore: Double)] {
+        dimensionScores.compactMap { key, scores in
+            guard !scores.isEmpty else { return nil }
+            let recent = scores.suffix(10)
+            let avg = Double(recent.reduce(0, +)) / Double(recent.count)
+            let maxScore = Double(Self.maxScoreFor(key))
+            return (key: key, average: avg, maxScore: maxScore)
+        }
+        .sorted { $0.key < $1.key }
+    }
+
+    var body: some View {
+        VStack(spacing: 10) {
+            ForEach(sortedDimensions, id: \.key) { dimension in
+                dimensionRow(dimension)
+            }
+        }
+    }
+
+    private func dimensionRow(_ dimension: (key: String, average: Double, maxScore: Double)) -> some View {
+        let normalised = dimension.maxScore > 0 ? dimension.average / dimension.maxScore : 0
+        let barColor = barColor(for: normalised)
+
+        return VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text(Self.displayName(for: dimension.key, language: language))
+                    .font(.caption)
+                    .foregroundStyle(.primary)
+                Spacer()
+                Text(String(format: "%.0f%%", normalised * 100))
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .monospacedDigit()
+            }
+
+            GeometryReader { geo in
+                ZStack(alignment: .leading) {
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(Color.secondary.opacity(0.15))
+                        .frame(height: 8)
+
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(barColor)
+                        .frame(width: max(4, geo.size.width * normalised), height: 8)
+                }
+            }
+            .frame(height: 8)
+        }
+    }
+
+    private func barColor(for normalised: Double) -> Color {
+        if normalised >= ProfileUpdater.strengthThreshold {
+            return .green
+        } else if normalised < ProfileUpdater.developmentThreshold {
+            return .red
+        }
+        return .blue
+    }
+
+    // MARK: - Dimension Display Names
+
+    static func displayName(for dimension: String, language: String) -> String {
+        let names: [String: (en: String, de: String)] = [
+            "governingThought": ("Leading with your point", "Mit dem Kerngedanken führen"),
+            "supportGrouping": ("Logical grouping", "Logische Gruppierung"),
+            "redundancy": ("Avoiding redundancy", "Redundanz vermeiden"),
+            "clarity": ("Clarity of expression", "Klarheit im Ausdruck"),
+            "l1Gate": ("Foundation mastery", "Grundlagen beherrschen"),
+            "meceQuality": ("MECE quality", "MECE-Qualität"),
+            "orderingLogic": ("Ordering logic", "Ordnungslogik"),
+            "scqApplication": ("SCQ framing", "SCQ-Rahmen"),
+            "horizontalLogic": ("Horizontal logic", "Horizontale Logik"),
+        ]
+
+        if let name = names[dimension] {
+            return language == "de" ? name.de : name.en
+        }
+        return dimension
+    }
+
+    static func maxScoreFor(_ dimension: String) -> Int {
+        ProfileUpdater.maxScores[dimension] ?? 3
+    }
+}
+
+// MARK: - Previews
+
+#Preview("Bar Chart") {
+    DimensionBarChartView(
+        dimensionScores: [
+            "governingThought": [2, 3, 2, 3, 3],
+            "supportGrouping": [1, 1, 2, 1, 1],
+            "clarity": [2, 2, 3, 2, 3],
+            "redundancy": [1, 1, 0, 1, 1],
+        ],
+        language: "en"
+    )
+    .padding()
+}
+
+#Preview("Bar Chart — DE") {
+    DimensionBarChartView(
+        dimensionScores: [
+            "governingThought": [2, 3, 3],
+            "clarity": [3, 3, 3],
+            "supportGrouping": [0, 1, 1],
+        ],
+        language: "de"
+    )
+    .padding()
+}

--- a/app/SayItRight/Presentation/Dashboard/ProgressDashboardView.swift
+++ b/app/SayItRight/Presentation/Dashboard/ProgressDashboardView.swift
@@ -1,0 +1,275 @@
+import SwiftUI
+
+/// Progress dashboard showing the learner's level, dimension scores, streak, and recent sessions.
+///
+/// Platform behavior:
+/// - **iPhone**: Scrolling list layout with compact cards.
+/// - **iPad/Mac**: Wider layout with side-by-side dimension chart and stats.
+struct ProgressDashboardView: View {
+    let profile: LearnerProfile
+    let language: String
+
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+
+    private var isWide: Bool {
+        #if os(macOS)
+        true
+        #else
+        horizontalSizeClass == .regular
+        #endif
+    }
+
+    var body: some View {
+        ScrollView {
+            if profile.sessionCount == 0 {
+                emptyState
+            } else if isWide {
+                wideLayout
+            } else {
+                compactLayout
+            }
+        }
+        .navigationTitle(language == "de" ? "Fortschritt" : "Progress")
+        #if !os(macOS)
+        .navigationBarTitleDisplayMode(.large)
+        #endif
+    }
+
+    // MARK: - Empty State
+
+    private var emptyState: some View {
+        VStack(spacing: 20) {
+            Spacer().frame(height: 60)
+            Image(systemName: "chart.bar.xaxis.ascending")
+                .font(.system(size: 48))
+                .foregroundStyle(.secondary)
+
+            Text(language == "de"
+                ? "Noch keine Sitzungen abgeschlossen"
+                : "No sessions completed yet")
+                .font(.title3)
+                .fontWeight(.semibold)
+
+            Text(language == "de"
+                ? "Starte deine erste Übung und dein Fortschritt erscheint hier."
+                : "Start your first exercise and your progress will appear here.")
+                .font(.body)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 40)
+
+            Spacer()
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    // MARK: - Compact Layout (iPhone)
+
+    private var compactLayout: some View {
+        VStack(spacing: 20) {
+            levelCard
+            streakCard
+            dimensionSection
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 20)
+    }
+
+    // MARK: - Wide Layout (iPad/Mac)
+
+    private var wideLayout: some View {
+        VStack(spacing: 24) {
+            HStack(alignment: .top, spacing: 20) {
+                levelCard
+                streakCard
+            }
+            dimensionSection
+        }
+        .padding(.horizontal, 24)
+        .padding(.vertical, 24)
+        .frame(maxWidth: 700)
+        .frame(maxWidth: .infinity)
+    }
+
+    // MARK: - Level Card
+
+    private var levelCard: some View {
+        VStack(spacing: 8) {
+            Text(language == "de" ? "Aktuelles Level" : "Current Level")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+
+            Text("\(profile.currentLevel)")
+                .font(.system(size: 42, weight: .bold, design: .rounded))
+                .foregroundStyle(Color.accentColor)
+
+            Text(levelName(for: profile.currentLevel))
+                .font(.headline)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(20)
+        .background(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .fill(.background)
+                .shadow(color: .black.opacity(0.06), radius: 6, y: 2)
+        )
+    }
+
+    // MARK: - Streak Card
+
+    private var streakCard: some View {
+        VStack(spacing: 12) {
+            HStack(spacing: 16) {
+                streakStat(
+                    title: language == "de" ? "Aktuell" : "Current",
+                    value: "\(profile.currentStreak)",
+                    icon: "flame.fill",
+                    color: profile.currentStreak > 0 ? .orange : .secondary
+                )
+                Divider().frame(height: 40)
+                streakStat(
+                    title: language == "de" ? "Längster" : "Longest",
+                    value: "\(profile.longestStreak)",
+                    icon: "trophy.fill",
+                    color: .yellow
+                )
+                Divider().frame(height: 40)
+                streakStat(
+                    title: language == "de" ? "Sitzungen" : "Sessions",
+                    value: "\(profile.sessionCount)",
+                    icon: "checkmark.circle.fill",
+                    color: .green
+                )
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .padding(20)
+        .background(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .fill(.background)
+                .shadow(color: .black.opacity(0.06), radius: 6, y: 2)
+        )
+    }
+
+    private func streakStat(title: String, value: String, icon: String, color: Color) -> some View {
+        VStack(spacing: 6) {
+            Image(systemName: icon)
+                .font(.title3)
+                .foregroundStyle(color)
+            Text(value)
+                .font(.title2)
+                .fontWeight(.bold)
+            Text(title)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    // MARK: - Dimension Section
+
+    private var dimensionSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(language == "de" ? "Strukturelle Fähigkeiten" : "Structural Skills")
+                .font(.headline)
+
+            if profile.dimensionScores.isEmpty {
+                Text(language == "de"
+                    ? "Deine Bewertungen erscheinen nach der ersten Sitzung."
+                    : "Your scores will appear after your first session.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            } else {
+                DimensionBarChartView(
+                    dimensionScores: profile.dimensionScores,
+                    language: language
+                )
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(20)
+        .background(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .fill(.background)
+                .shadow(color: .black.opacity(0.06), radius: 6, y: 2)
+        )
+    }
+
+    // MARK: - Helpers
+
+    private func levelName(for level: Int) -> String {
+        switch level {
+        case 1: language == "de" ? "Klartext" : "Plain Talk"
+        case 2: language == "de" ? "Ordnung" : "Order"
+        case 3: language == "de" ? "Architektur" : "Architecture"
+        case 4: language == "de" ? "Meisterschaft" : "Mastery"
+        default: ""
+        }
+    }
+}
+
+// MARK: - Previews
+
+#Preview("Populated — EN") {
+    NavigationStack {
+        ProgressDashboardView(
+            profile: .previewPopulated,
+            language: "en"
+        )
+    }
+}
+
+#Preview("Populated — DE") {
+    NavigationStack {
+        ProgressDashboardView(
+            profile: .previewPopulated,
+            language: "de"
+        )
+    }
+}
+
+#Preview("Empty State") {
+    NavigationStack {
+        ProgressDashboardView(
+            profile: .createDefault(displayName: "Alex"),
+            language: "en"
+        )
+    }
+}
+
+#Preview("iPad") {
+    NavigationStack {
+        ProgressDashboardView(
+            profile: .previewPopulated,
+            language: "en"
+        )
+    }
+    .environment(\.horizontalSizeClass, .regular)
+}
+
+// MARK: - Preview Helpers
+
+extension LearnerProfile {
+    static var previewPopulated: LearnerProfile {
+        var profile = LearnerProfile.createDefault(displayName: "Alex")
+        profile.currentLevel = 1
+        profile.sessionCount = 12
+        profile.currentStreak = 3
+        profile.longestStreak = 7
+
+        // Simulate some dimension scores
+        for _ in 0..<5 {
+            profile.recordScore(2, for: "governingThought")
+            profile.recordScore(1, for: "supportGrouping")
+            profile.recordScore(2, for: "clarity")
+            profile.recordScore(1, for: "redundancy")
+        }
+        profile.recordScore(3, for: "governingThought")
+        profile.recordScore(3, for: "clarity")
+
+        profile.structuralStrengths = ["governingThought", "clarity"]
+        profile.developmentAreas = ["supportGrouping"]
+
+        return profile
+    }
+}

--- a/app/SayItRight/SayItRight.xcodeproj/project.pbxproj
+++ b/app/SayItRight/SayItRight.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		009F14C7F7569D0991BD7BC8 /* AppVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = F70F04FAE54C5FB6BC13D7E5 /* AppVersion.swift */; };
 		00BD16B95665CCD3B7B58AAE /* FindThePointView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B466AA033E6F289710EDCFC8 /* FindThePointView.swift */; };
 		00D8301F3E74117DF9AA973B /* AnthropicServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F77568CC779F6818DEF9ADCC /* AnthropicServiceTests.swift */; };
+		01725E7CBADF98137BDC26AA /* ProgressDashboardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3C3798349D47FE3497CC587 /* ProgressDashboardTests.swift */; };
 		026C148F047C0BFD727A7A17 /* AppSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81A63E61EA4ABC850E93CB2E /* AppSettings.swift */; };
 		033B5DE1A4166D33D74334B9 /* ResponseParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 192E20839A759A3AF4CC7D51 /* ResponseParser.swift */; };
 		0346190953B25D320839884F /* Config.template.plist in Resources */ = {isa = PBXBuildFile; fileRef = E040537D24996C58EBA537D8 /* Config.template.plist */; };
@@ -71,10 +72,15 @@
 		3C009DF5A5015AB1595F05B2 /* DebugLogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D7F67899A791B97B42902B0 /* DebugLogView.swift */; };
 		3C3D496429C02F2A19997126 /* SeenTextsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E399297963E1A59A4C958BFA /* SeenTextsTests.swift */; };
 		3D30DF4F7A2D515EBD37FF5F /* SessionManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57ACC716C56B7F8E16DBDFB3 /* SessionManagerTests.swift */; };
+		404C385E99618BE1F1977825 /* ProgressDashboardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3C3798349D47FE3497CC587 /* ProgressDashboardTests.swift */; };
+		41A85E6A507F013D8D83DDA7 /* ProfileUpdaterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98CBB6A6B6FD6628BB30BA6D /* ProfileUpdaterTests.swift */; };
+		42C2A1A109BB746F35591B2E /* ElevatorPitchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCC9887FA1B8FA6F1AF29DAE /* ElevatorPitchView.swift */; };
 		4333A9801B4794A47C8D0EB7 /* MacOSAdaptationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2648E59B50498C1D83FD795F /* MacOSAdaptationTests.swift */; };
 		450B437F71624F37AA4EB50F /* FeedbackBubbleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A30E1A80DC1D1B71AF67390 /* FeedbackBubbleView.swift */; };
+		4656E3C4F8DBBB5DDD9355D5 /* ProfileUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30EED07035F76FC2168D236A /* ProfileUpdater.swift */; };
 		465D99D2F607EE3A29C71228 /* Topic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 188F1F9BBC0111EE4F4EB660 /* Topic.swift */; };
 		469976D5DF124503DE6E5F7C /* FindThePointSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5FB097A1FAE84E286F0F1F6 /* FindThePointSession.swift */; };
+		46A6335BD38DF3D1EEC54EE9 /* DimensionBarChartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64F1F5B0738E60E8163A2FDB /* DimensionBarChartView.swift */; };
 		4754932F6E5805C72ADB45E2 /* KeychainService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BCBA23B5D640E11325097D0 /* KeychainService.swift */; };
 		487820CDB3AB1F86C7D41CD1 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2679A39DC09E233E6C5FB8DC /* Assets.xcassets */; };
 		487E6CBCA4808690CB6B31C4 /* DebugLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1355D670E0F227DE429EAB9 /* DebugLogger.swift */; };
@@ -87,6 +93,7 @@
 		5673D8240DB6073E30B4EAF5 /* LearnerProfileStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7340051027E1031862796AD /* LearnerProfileStore.swift */; };
 		56E59D06B02418F6D1057A03 /* ChatViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40319D5211156AC1671570F5 /* ChatViewTests.swift */; };
 		57BFD8048F458724D5220EE4 /* SidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F227EDAC8833CE0EA075111 /* SidebarView.swift */; };
+		588D9CEDFC0028729E9822A4 /* AnalyseMyTextSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA73D30DCB7C56BAA6867CC2 /* AnalyseMyTextSession.swift */; };
 		58C18276239608ABD6F07EBB /* AudioSessionManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D5A7EA09817CE62F1FE9796 /* AudioSessionManagerTests.swift */; };
 		5A025527375F657258C7BFD6 /* FindThePointView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B466AA033E6F289710EDCFC8 /* FindThePointView.swift */; };
 		5B4147D9159DD55A0A8875B4 /* ComparisonResponseParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC11499E66D1CCC6F0EDB5EE /* ComparisonResponseParser.swift */; };
@@ -133,6 +140,7 @@
 		8253B0ABF87DA1DEF424AB4E /* MicrophoneButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8309BF4EE774FABE588555F4 /* MicrophoneButton.swift */; };
 		868CC677F0EF47C03E66115E /* BarbaraAvatarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36C6BF2F47F0B8EFFC2DF98B /* BarbaraAvatarView.swift */; };
 		86AC04612F354912B3989863 /* AppVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = F70F04FAE54C5FB6BC13D7E5 /* AppVersion.swift */; };
+		8728021A5019601223697286 /* ElevatorPitchCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76F67E39596D4AD4CCEAE6BB /* ElevatorPitchCoordinator.swift */; };
 		89CED9375747E4D03FCB8E66 /* PracticeTextGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 761B9E06D45D03688B09D463 /* PracticeTextGeneratorTests.swift */; };
 		8BED3E20F4C909B14BE520AA /* DropZoneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C05DDD40848A9E59E713026 /* DropZoneView.swift */; };
 		8CE2454D0869BE2E74B38474 /* FindThePointCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19168BF6E4820E37458DAA57 /* FindThePointCoordinator.swift */; };
@@ -145,14 +153,17 @@
 		940C00B95F727301E44CC7BC /* MicrophoneButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8309BF4EE774FABE588555F4 /* MicrophoneButton.swift */; };
 		945C5AB0AE1C1A1164802CF7 /* PracticeText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48A1CF3D22441AE55554B302 /* PracticeText.swift */; };
 		94BD55EA2659D676E06DEAAE /* MacChatInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C051275C85D1D1ED1778AC59 /* MacChatInputView.swift */; };
+		95A50EEDFAC1BC4B1996DF6D /* ProfileUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30EED07035F76FC2168D236A /* ProfileUpdater.swift */; };
 		9B75A691D0F56293D7AF2B2B /* ComparisonPromptBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69C98EBC60AB392AA8868374 /* ComparisonPromptBuilder.swift */; };
 		9C6C847EC9BCCD14AE067A8A /* TTSPlaybackServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1964D965458CCC6A3A747B0 /* TTSPlaybackServiceTests.swift */; };
 		9C781F5BC09396E0F44BBFCB /* StructuralEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11A375822F278D205A1F9090 /* StructuralEvaluator.swift */; };
+		9D25E26FB942070B61F6E54D /* ElevatorPitchCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76F67E39596D4AD4CCEAE6BB /* ElevatorPitchCoordinator.swift */; };
 		9D641BA106661D4AD460D3A1 /* AnswerKeyComparison.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1910976EBE55B2D0A2B347CA /* AnswerKeyComparison.swift */; };
 		9E229F94708A12673A30600F /* PINEntryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0B8EDE7E53601DCAC1DB42 /* PINEntryView.swift */; };
 		9E94F43764B254F793A66465 /* PINEntryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0B8EDE7E53601DCAC1DB42 /* PINEntryView.swift */; };
 		9FF735052B95F66DE636AF76 /* FindThePointSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5FB097A1FAE84E286F0F1F6 /* FindThePointSession.swift */; };
 		A21F3D22008E858CE7D1DE45 /* PracticeTextLibrary_de.json in Resources */ = {isa = PBXBuildFile; fileRef = BEE1CAA3817E82AA6D53AF15 /* PracticeTextLibrary_de.json */; };
+		A4A0DD5041F5926F318A2BB6 /* AnalyseMyTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9386A4C1CF530878ECC12755 /* AnalyseMyTextView.swift */; };
 		A4A5E4A6E927A6FF4AE200B1 /* AnswerKeyComparer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AEAE8216CAB132332EE8012 /* AnswerKeyComparer.swift */; };
 		A5F6092C5DBADDBDC55A732F /* FeedbackBubbleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A30E1A80DC1D1B71AF67390 /* FeedbackBubbleView.swift */; };
 		A6AC757407E2F30AB816970C /* MECEValidationEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D07B7B9E84CD6DF8BC6ACCF /* MECEValidationEngineTests.swift */; };
@@ -161,7 +172,9 @@
 		A97A27185FAD7A443CC81A23 /* PracticeTextLibrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BFD6B8D5C586B0C9ADEEBA5 /* PracticeTextLibrary.swift */; };
 		A9B7342D214CE45653F5BAB3 /* LearnerAvatar.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE528A4BB6F7C58BD0CC3708 /* LearnerAvatar.swift */; };
 		A9BA44DA0F1F2B687C7EB602 /* AnthropicModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10F6CAB4EBA45B17A293C4C0 /* AnthropicModel.swift */; };
+		A9C54D9E4FC609C3A85D553B /* DimensionBarChartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64F1F5B0738E60E8163A2FDB /* DimensionBarChartView.swift */; };
 		AD9D198E44358F88EF30E30B /* StructuralEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11A375822F278D205A1F9090 /* StructuralEvaluator.swift */; };
+		AE1A15A7E561DB90F19FF361 /* ElevatorPitchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCC9887FA1B8FA6F1AF29DAE /* ElevatorPitchView.swift */; };
 		AE5F4FDA4052322F82140791 /* ValidationFeedbackModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BCC3E8C4CBE011C33FC740B /* ValidationFeedbackModifier.swift */; };
 		AFEA82FE224E0347257B1DFC /* DropZoneTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFA22F5F2A41A4A96CFE4C47 /* DropZoneTests.swift */; };
 		B007E9CAE8E63D427DBBFF69 /* ParentGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B22653B114F07E9EA40C7C62 /* ParentGate.swift */; };
@@ -170,7 +183,9 @@
 		B4128092EF246AE96A5BF1E0 /* DropZoneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C05DDD40848A9E59E713026 /* DropZoneView.swift */; };
 		B46B0F09B751DF672F082614 /* StreamingTTSCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B930A94D3E14C1EBF3EDBB7 /* StreamingTTSCoordinator.swift */; };
 		B6403B3CA71AF12E11A38232 /* ConnectionLinesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2ED4B98BAC3EA13F5C61CBCD /* ConnectionLinesTests.swift */; };
+		B665C92DF1CD20E2C25E9DD8 /* ElevatorPitchSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E01132CC12B1CCE944CDE83F /* ElevatorPitchSessionTests.swift */; };
 		B69E88F9600BA196BDC08FCB /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB92388718B19A2E45FBDC1 /* SettingsView.swift */; };
+		B7C28920B91F304603968367 /* ProgressDashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC3572D84CA72E9A0723635D /* ProgressDashboardView.swift */; };
 		B9A55A00D5E93D6AC049A85C /* ConfigProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2927967CBDF0913F5EDD0EC7 /* ConfigProvider.swift */; };
 		B9CA27CA31AD9BE7B3F31EB0 /* SessionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = C02627D1A73370A9B58BE9CC /* SessionState.swift */; };
 		B9E64E1CAA8464301C3DC563 /* ConnectionLinesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3915AE540EBA11321FA76BB /* ConnectionLinesView.swift */; };
@@ -180,12 +195,15 @@
 		BC5F147A088AEBDA38856EEE /* DebugLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1355D670E0F227DE429EAB9 /* DebugLogger.swift */; };
 		BC6395CBB992EB5D23FEB685 /* SidebarViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1161CE00FACCF6715D7034A1 /* SidebarViewTests.swift */; };
 		BDF08178D405ECC24953BC24 /* SayItRight.xcodeproj in Resources */ = {isa = PBXBuildFile; fileRef = 3FAF495135EB918BBBE3A021 /* SayItRight.xcodeproj */; };
+		BE27D9D3A47875F43F2CB6FC /* ElevatorPitchSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B7D104D20992358220CF516 /* ElevatorPitchSession.swift */; };
 		BF7E68D87F7FE0DDCF4867D1 /* SystemPromptAssemblerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65A78B634A6D6F9D4CD57BC7 /* SystemPromptAssemblerTests.swift */; };
 		BFEC1C8AE1C77FC5D94AB5B6 /* SystemPromptAssembler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4096FB5122C41B3F25CCFB2 /* SystemPromptAssembler.swift */; };
 		C00B6CA5143A309F86D4D506 /* BlockFeedbackState.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA32E530E1641F627E7C5970 /* BlockFeedbackState.swift */; };
 		C15605E88266D05B8736AB18 /* BarbaraMood.swift in Sources */ = {isa = PBXBuildFile; fileRef = 942B7D62D7DC6CDF6EE5C3AD /* BarbaraMood.swift */; };
 		C372EDF597BB3E75358D1121 /* BarbaraVoiceProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F4D31053E77ACAC3D6E7D2 /* BarbaraVoiceProfile.swift */; };
 		C37CC4D67FE88C69E19D6FF4 /* PyramidBlockTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B70EF3120BD198913EAEE0A2 /* PyramidBlockTests.swift */; };
+		C3D6237CFE9553D6515E743A /* ElevatorPitchSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B7D104D20992358220CF516 /* ElevatorPitchSession.swift */; };
+		C4CE7E6FB0DA7A6B078EF083 /* AnalyseMyTextSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA73D30DCB7C56BAA6867CC2 /* AnalyseMyTextSession.swift */; };
 		C6707E67B7475B58554F2F92 /* BarbaraVoiceProfileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A6B15AE1ED645EEDFCA7DF5 /* BarbaraVoiceProfileTests.swift */; };
 		C68A1A0B560C01274838748E /* ErrorBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E27CEE853747DCC27BA168 /* ErrorBannerView.swift */; };
 		C70E6AC153240CF2D0DBCAB9 /* MECEValidationEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D07B7B9E84CD6DF8BC6ACCF /* MECEValidationEngineTests.swift */; };
@@ -211,6 +229,7 @@
 		D6A8A7F9EE4233595988BFA7 /* SayItClearlyCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F909A7D8C8D301AFFA580B6 /* SayItClearlyCoordinator.swift */; };
 		D6CD1F94E1C2E57A0888230E /* FirstLaunchSetupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C278322C149174D648ECF14 /* FirstLaunchSetupTests.swift */; };
 		DC8CB9656F62B3F2E9C313EE /* FeedbackBubbleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A92CDDC30DF529F4F6E693B /* FeedbackBubbleTests.swift */; };
+		DD46000474FB0168BB12A02E /* AnalyseMyTextSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 652143071B4E57A9035FE43B /* AnalyseMyTextSessionTests.swift */; };
 		DDD2F11F3AD9916F6E39F996 /* AppLanguage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1607A6E887C79A834F460459 /* AppLanguage.swift */; };
 		DE1CC7ECEADF4111754C15B0 /* VoiceInputViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FFAF667809AFED071F2163 /* VoiceInputViewModel.swift */; };
 		DE38095862958923B2416C42 /* BarbaraAvatarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A553A59D04C7ABFA86CF117E /* BarbaraAvatarTests.swift */; };
@@ -218,11 +237,13 @@
 		E051DAB7CE1CB6C9AE6C2D79 /* DropZone.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28E6F9B9D6818D8BCF742BCC /* DropZone.swift */; };
 		E071B3F83FAD19AECA65C8A1 /* ParentSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B08B6C7C928249161C6C0AC /* ParentSettingsView.swift */; };
 		E1C178382A2262BB8A5C7E72 /* Topic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 188F1F9BBC0111EE4F4EB660 /* Topic.swift */; };
+		E22384E3209373AA4D8B48C6 /* ElevatorPitchSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E01132CC12B1CCE944CDE83F /* ElevatorPitchSessionTests.swift */; };
 		E2A161E1F5258D6DBC5A3548 /* PracticeTextFileWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39FB9A6BB2DA0BC61384039F /* PracticeTextFileWriter.swift */; };
 		E2E771E2E6E4B969403D183A /* ResponseParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8D179C236AD14B5C8076627 /* ResponseParserTests.swift */; };
 		E30210DD8492DB766516661E /* SessionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70A1CB45AEA63A237D7499E4 /* SessionManager.swift */; };
 		E4C81D76331F3F76AE3D62DC /* SessionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70A1CB45AEA63A237D7499E4 /* SessionManager.swift */; };
 		E55D26181C652FF34FB5B162 /* PracticeText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48A1CF3D22441AE55554B302 /* PracticeText.swift */; };
+		E6C0CE28BD49508CA40E8454 /* ProgressDashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC3572D84CA72E9A0723635D /* ProgressDashboardView.swift */; };
 		E82E1F599E93664105775B47 /* LearnerProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49EB5CEF2D12A478BB1EA7AF /* LearnerProfile.swift */; };
 		E859602EE681847C2EB503CA /* StructuralEvaluatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3E7290B780810CAE4428003 /* StructuralEvaluatorTests.swift */; };
 		E85E8849F8661277DB8256F1 /* PracticeTextLibraryContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F58ED745199D9D446AC8FC6 /* PracticeTextLibraryContainer.swift */; };
@@ -230,6 +251,7 @@
 		E97996275531EAC63277B021 /* AnswerKeyComparisonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2A6B03C9A74B0140D2B2BE7 /* AnswerKeyComparisonTests.swift */; };
 		EA0D4B1C48E68CDED67FFA0F /* TextDifficultyCalibratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60AF6BBA9B0AF6383B674F02 /* TextDifficultyCalibratorTests.swift */; };
 		EA56A67113CF8CEB37FE4066 /* SessionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = C02627D1A73370A9B58BE9CC /* SessionState.swift */; };
+		EBCF2F671531CFA0053373BA /* AnalyseMyTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9386A4C1CF530878ECC12755 /* AnalyseMyTextView.swift */; };
 		EBE97AEDAD50F2E4A8AF50A3 /* PracticeTextLibraryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C70ADBF790944D3353F4FA32 /* PracticeTextLibraryTests.swift */; };
 		EC2B4036D1202B37FDCFF1B7 /* ParentGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B22653B114F07E9EA40C7C62 /* ParentGate.swift */; };
 		EC8D5C128F51D0CCF602CE9D /* SeenTextsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E399297963E1A59A4C958BFA /* SeenTextsTests.swift */; };
@@ -242,6 +264,7 @@
 		F3EA6C9E62178099319F591E /* DebugLogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D7F67899A791B97B42902B0 /* DebugLogView.swift */; };
 		F489AF2C43E8E5A051F6D164 /* NetworkErrorHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91ECF5F1EF7623373F5BBD2C /* NetworkErrorHandler.swift */; };
 		F5A28442A564B05F3EB1CFE0 /* MockSpeechRecognitionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A734FF80156849AAC5CD69 /* MockSpeechRecognitionService.swift */; };
+		F65C548B9D183E16669313BF /* ProfileUpdaterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98CBB6A6B6FD6628BB30BA6D /* ProfileUpdaterTests.swift */; };
 		F68A7E82CAC1C17DF3417D14 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2679A39DC09E233E6C5FB8DC /* Assets.xcassets */; };
 		F9F35AAB16261DE9156AFA81 /* DraggableBlockView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4373E47CEF1B184CF62920CB /* DraggableBlockView.swift */; };
 		FB4A6CAC2211C3CE1456B0C4 /* ChatViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40319D5211156AC1671570F5 /* ChatViewTests.swift */; };
@@ -249,6 +272,7 @@
 		FCB56E57EF361C8B0506CFEA /* StructuralEvaluatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3E7290B780810CAE4428003 /* StructuralEvaluatorTests.swift */; };
 		FCDB2F855E3D272EABFC4626 /* AnswerKeyComparisonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2A6B03C9A74B0140D2B2BE7 /* AnswerKeyComparisonTests.swift */; };
 		FCFA826700749EA41FCB4FDC /* PyramidBlock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AC8B2C13C23B149624FD027 /* PyramidBlock.swift */; };
+		FD4642D02538BAA526AC064C /* AnalyseMyTextSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 652143071B4E57A9035FE43B /* AnalyseMyTextSessionTests.swift */; };
 		FEA6E6E26B1F513C393C1444 /* SessionPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A466760C86E7CBA8E140814 /* SessionPickerView.swift */; };
 		FF71C89423AE71ED46EE2B27 /* NetworkErrorHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91ECF5F1EF7623373F5BBD2C /* NetworkErrorHandler.swift */; };
 /* End PBXBuildFile section */
@@ -309,6 +333,7 @@
 		2DF3448F79F9C75AEEF2A73E /* FindThePointSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindThePointSessionTests.swift; sourceTree = "<group>"; };
 		2ED4B98BAC3EA13F5C61CBCD /* ConnectionLinesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionLinesTests.swift; sourceTree = "<group>"; };
 		2F8727097172513F7D8AA109 /* SayItRight.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SayItRight.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		30EED07035F76FC2168D236A /* ProfileUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileUpdater.swift; sourceTree = "<group>"; };
 		36C6BF2F47F0B8EFFC2DF98B /* BarbaraAvatarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarbaraAvatarView.swift; sourceTree = "<group>"; };
 		39FB9A6BB2DA0BC61384039F /* PracticeTextFileWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticeTextFileWriter.swift; sourceTree = "<group>"; };
 		3D57221714F45B9C00201617 /* SpeechRecognitionServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechRecognitionServiceTests.swift; sourceTree = "<group>"; };
@@ -322,6 +347,7 @@
 		48A1CF3D22441AE55554B302 /* PracticeText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticeText.swift; sourceTree = "<group>"; };
 		49EB5CEF2D12A478BB1EA7AF /* LearnerProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearnerProfile.swift; sourceTree = "<group>"; };
 		4A6B15AE1ED645EEDFCA7DF5 /* BarbaraVoiceProfileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarbaraVoiceProfileTests.swift; sourceTree = "<group>"; };
+		4B7D104D20992358220CF516 /* ElevatorPitchSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElevatorPitchSession.swift; sourceTree = "<group>"; };
 		4C7E28ABC6EA21CD4558AB69 /* TopicBank.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = TopicBank.json; sourceTree = "<group>"; };
 		4F227EDAC8833CE0EA075111 /* SidebarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarView.swift; sourceTree = "<group>"; };
 		51E5916F947F218355F932A9 /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
@@ -335,6 +361,8 @@
 		61E27CEE853747DCC27BA168 /* ErrorBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorBannerView.swift; sourceTree = "<group>"; };
 		61F66A4FE516B8A86073D9B3 /* VoiceInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceInputView.swift; sourceTree = "<group>"; };
 		64BCF114772DA58597F6EC7A /* MECEValidationEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MECEValidationEngine.swift; sourceTree = "<group>"; };
+		64F1F5B0738E60E8163A2FDB /* DimensionBarChartView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DimensionBarChartView.swift; sourceTree = "<group>"; };
+		652143071B4E57A9035FE43B /* AnalyseMyTextSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyseMyTextSessionTests.swift; sourceTree = "<group>"; };
 		65A78B634A6D6F9D4CD57BC7 /* SystemPromptAssemblerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemPromptAssemblerTests.swift; sourceTree = "<group>"; };
 		65D79D2FA2765B439235C94A /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
 		69C98EBC60AB392AA8868374 /* ComparisonPromptBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComparisonPromptBuilder.swift; sourceTree = "<group>"; };
@@ -343,6 +371,7 @@
 		70A1CB45AEA63A237D7499E4 /* SessionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionManager.swift; sourceTree = "<group>"; };
 		72D83F01BEC457D843FA46B2 /* PyramidTreeState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PyramidTreeState.swift; sourceTree = "<group>"; };
 		761B9E06D45D03688B09D463 /* PracticeTextGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticeTextGeneratorTests.swift; sourceTree = "<group>"; };
+		76F67E39596D4AD4CCEAE6BB /* ElevatorPitchCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElevatorPitchCoordinator.swift; sourceTree = "<group>"; };
 		7A6659848CFB393F442C3B61 /* ChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatView.swift; sourceTree = "<group>"; };
 		7D0E72ADDB393F0AF5439B40 /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
 		81A11E691EB3DEE60B339B16 /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
@@ -353,8 +382,10 @@
 		8AB92388718B19A2E45FBDC1 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		8D20FDE7D46349EC7346DA67 /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
 		91ECF5F1EF7623373F5BBD2C /* NetworkErrorHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkErrorHandler.swift; sourceTree = "<group>"; };
+		9386A4C1CF530878ECC12755 /* AnalyseMyTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyseMyTextView.swift; sourceTree = "<group>"; };
 		942B7D62D7DC6CDF6EE5C3AD /* BarbaraMood.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarbaraMood.swift; sourceTree = "<group>"; };
 		95D3FAF0967C63A54E2C6E51 /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
+		98CBB6A6B6FD6628BB30BA6D /* ProfileUpdaterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileUpdaterTests.swift; sourceTree = "<group>"; };
 		9A0B8EDE7E53601DCAC1DB42 /* PINEntryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PINEntryView.swift; sourceTree = "<group>"; };
 		9A1C0B31006940A2DBFE5E41 /* LearnerProfileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearnerProfileTests.swift; sourceTree = "<group>"; };
 		9A466760C86E7CBA8E140814 /* SessionPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionPickerView.swift; sourceTree = "<group>"; };
@@ -362,10 +393,12 @@
 		9B930A94D3E14C1EBF3EDBB7 /* StreamingTTSCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamingTTSCoordinator.swift; sourceTree = "<group>"; };
 		9D07B7B9E84CD6DF8BC6ACCF /* MECEValidationEngineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MECEValidationEngineTests.swift; sourceTree = "<group>"; };
 		A1964D965458CCC6A3A747B0 /* TTSPlaybackServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TTSPlaybackServiceTests.swift; sourceTree = "<group>"; };
+		A3C3798349D47FE3497CC587 /* ProgressDashboardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressDashboardTests.swift; sourceTree = "<group>"; };
 		A553A59D04C7ABFA86CF117E /* BarbaraAvatarTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarbaraAvatarTests.swift; sourceTree = "<group>"; };
 		A7139C00F03FBFAD7BA4FAD8 /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
 		AA8D4F615BD301FC609D050A /* TreeLayoutEngineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TreeLayoutEngineTests.swift; sourceTree = "<group>"; };
 		AC256E9126646B1262512067 /* ValidationFeedbackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidationFeedbackTests.swift; sourceTree = "<group>"; };
+		AC3572D84CA72E9A0723635D /* ProgressDashboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressDashboardView.swift; sourceTree = "<group>"; };
 		B1355D670E0F227DE429EAB9 /* DebugLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugLogger.swift; sourceTree = "<group>"; };
 		B22653B114F07E9EA40C7C62 /* ParentGate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentGate.swift; sourceTree = "<group>"; };
 		B466AA033E6F289710EDCFC8 /* FindThePointView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindThePointView.swift; sourceTree = "<group>"; };
@@ -387,6 +420,8 @@
 		C7729E7948C0195AF7F2023B /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
 		C7A0D6917A3C05487B814E35 /* MessageBubbleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageBubbleView.swift; sourceTree = "<group>"; };
 		C8D179C236AD14B5C8076627 /* ResponseParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResponseParserTests.swift; sourceTree = "<group>"; };
+		CA73D30DCB7C56BAA6867CC2 /* AnalyseMyTextSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyseMyTextSession.swift; sourceTree = "<group>"; };
+		CCC9887FA1B8FA6F1AF29DAE /* ElevatorPitchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElevatorPitchView.swift; sourceTree = "<group>"; };
 		CE528A4BB6F7C58BD0CC3708 /* LearnerAvatar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearnerAvatar.swift; sourceTree = "<group>"; };
 		D08BE80207F27A8208D3CCB2 /* ChatMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessage.swift; sourceTree = "<group>"; };
 		D1A734FF80156849AAC5CD69 /* MockSpeechRecognitionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSpeechRecognitionService.swift; sourceTree = "<group>"; };
@@ -398,6 +433,7 @@
 		DC11499E66D1CCC6F0EDB5EE /* ComparisonResponseParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComparisonResponseParser.swift; sourceTree = "<group>"; };
 		DC1974647876CBDFA39B8A71 /* SeenTextsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeenTextsStore.swift; sourceTree = "<group>"; };
 		DE9990EFFDBC213F3F1D0B19 /* SayItRightApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SayItRightApp.swift; sourceTree = "<group>"; };
+		E01132CC12B1CCE944CDE83F /* ElevatorPitchSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElevatorPitchSessionTests.swift; sourceTree = "<group>"; };
 		E021EB6D73273983DB9E14F6 /* PracticeTextLibrary_en.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = PracticeTextLibrary_en.json; sourceTree = "<group>"; };
 		E040537D24996C58EBA537D8 /* Config.template.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Config.template.plist; sourceTree = "<group>"; };
 		E399297963E1A59A4C958BFA /* SeenTextsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeenTextsTests.swift; sourceTree = "<group>"; };
@@ -467,6 +503,8 @@
 			isa = PBXGroup;
 			children = (
 				7D0E72ADDB393F0AF5439B40 /* .gitkeep */,
+				64F1F5B0738E60E8163A2FDB /* DimensionBarChartView.swift */,
+				AC3572D84CA72E9A0723635D /* ProgressDashboardView.swift */,
 			);
 			path = Dashboard;
 			sourceTree = "<group>";
@@ -554,8 +592,11 @@
 			isa = PBXGroup;
 			children = (
 				81A11E691EB3DEE60B339B16 /* .gitkeep */,
+				CA73D30DCB7C56BAA6867CC2 /* AnalyseMyTextSession.swift */,
 				10F6CAB4EBA45B17A293C4C0 /* AnthropicModel.swift */,
 				C28CC98EB4FCDC9137D15433 /* AnthropicService.swift */,
+				76F67E39596D4AD4CCEAE6BB /* ElevatorPitchCoordinator.swift */,
+				4B7D104D20992358220CF516 /* ElevatorPitchSession.swift */,
 				19168BF6E4820E37458DAA57 /* FindThePointCoordinator.swift */,
 				D5FB097A1FAE84E286F0F1F6 /* FindThePointSession.swift */,
 				91ECF5F1EF7623373F5BBD2C /* NetworkErrorHandler.swift */,
@@ -584,6 +625,7 @@
 		9CA9825E2539A59A51BE06B7 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				652143071B4E57A9035FE43B /* AnalyseMyTextSessionTests.swift */,
 				F2A6B03C9A74B0140D2B2BE7 /* AnswerKeyComparisonTests.swift */,
 				F77568CC779F6818DEF9ADCC /* AnthropicServiceTests.swift */,
 				0D5A7EA09817CE62F1FE9796 /* AudioSessionManagerTests.swift */,
@@ -592,6 +634,7 @@
 				40319D5211156AC1671570F5 /* ChatViewTests.swift */,
 				2ED4B98BAC3EA13F5C61CBCD /* ConnectionLinesTests.swift */,
 				BFA22F5F2A41A4A96CFE4C47 /* DropZoneTests.swift */,
+				E01132CC12B1CCE944CDE83F /* ElevatorPitchSessionTests.swift */,
 				6A92CDDC30DF529F4F6E693B /* FeedbackBubbleTests.swift */,
 				2DF3448F79F9C75AEEF2A73E /* FindThePointSessionTests.swift */,
 				1C278322C149174D648ECF14 /* FirstLaunchSetupTests.swift */,
@@ -601,6 +644,8 @@
 				01F95CF0998D962402B03233 /* NetworkErrorHandlerTests.swift */,
 				761B9E06D45D03688B09D463 /* PracticeTextGeneratorTests.swift */,
 				C70ADBF790944D3353F4FA32 /* PracticeTextLibraryTests.swift */,
+				98CBB6A6B6FD6628BB30BA6D /* ProfileUpdaterTests.swift */,
+				A3C3798349D47FE3497CC587 /* ProgressDashboardTests.swift */,
 				B70EF3120BD198913EAEE0A2 /* PyramidBlockTests.swift */,
 				C8D179C236AD14B5C8076627 /* ResponseParserTests.swift */,
 				2C9512DE8E01F6C1AB4E4B8C /* SayItClearlySessionTests.swift */,
@@ -626,6 +671,7 @@
 				8D20FDE7D46349EC7346DA67 /* .gitkeep */,
 				49EB5CEF2D12A478BB1EA7AF /* LearnerProfile.swift */,
 				D7340051027E1031862796AD /* LearnerProfileStore.swift */,
+				30EED07035F76FC2168D236A /* ProfileUpdater.swift */,
 			);
 			path = LearnerProfile;
 			sourceTree = "<group>";
@@ -783,7 +829,9 @@
 			isa = PBXGroup;
 			children = (
 				2910D8E206E77E72AE6E8631 /* .gitkeep */,
+				9386A4C1CF530878ECC12755 /* AnalyseMyTextView.swift */,
 				2D7F67899A791B97B42902B0 /* DebugLogView.swift */,
+				CCC9887FA1B8FA6F1AF29DAE /* ElevatorPitchView.swift */,
 				B466AA033E6F289710EDCFC8 /* FindThePointView.swift */,
 				E493E1B347AC7D15C639949F /* FirstLaunchSetupView.swift */,
 				1DD215422DC5781D0AFDAAEE /* OnboardingView.swift */,
@@ -950,6 +998,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FD4642D02538BAA526AC064C /* AnalyseMyTextSessionTests.swift in Sources */,
 				E97996275531EAC63277B021 /* AnswerKeyComparisonTests.swift in Sources */,
 				00D8301F3E74117DF9AA973B /* AnthropicServiceTests.swift in Sources */,
 				58C18276239608ABD6F07EBB /* AudioSessionManagerTests.swift in Sources */,
@@ -958,6 +1007,7 @@
 				FB4A6CAC2211C3CE1456B0C4 /* ChatViewTests.swift in Sources */,
 				691C23DCCF2C5FE4EB2B14CB /* ConnectionLinesTests.swift in Sources */,
 				AFEA82FE224E0347257B1DFC /* DropZoneTests.swift in Sources */,
+				E22384E3209373AA4D8B48C6 /* ElevatorPitchSessionTests.swift in Sources */,
 				5EC9E9835C8E009CDF6CAEC4 /* FeedbackBubbleTests.swift in Sources */,
 				76A480936638CCB778908423 /* FindThePointSessionTests.swift in Sources */,
 				B9F552778A5BD6CEEFB7FC21 /* FirstLaunchSetupTests.swift in Sources */,
@@ -967,6 +1017,8 @@
 				D3A1BF1A3B70AAF52594F570 /* NetworkErrorHandlerTests.swift in Sources */,
 				731B7002E3DBB7D9CDE10685 /* PracticeTextGeneratorTests.swift in Sources */,
 				EBE97AEDAD50F2E4A8AF50A3 /* PracticeTextLibraryTests.swift in Sources */,
+				F65C548B9D183E16669313BF /* ProfileUpdaterTests.swift in Sources */,
+				404C385E99618BE1F1977825 /* ProgressDashboardTests.swift in Sources */,
 				C89D58F492C55065E008013A /* PyramidBlockTests.swift in Sources */,
 				812AC213EB49FEC705555E09 /* ResponseParserTests.swift in Sources */,
 				1851700C174060BC3AC3208C /* SayItClearlySessionTests.swift in Sources */,
@@ -989,6 +1041,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DD46000474FB0168BB12A02E /* AnalyseMyTextSessionTests.swift in Sources */,
 				FCDB2F855E3D272EABFC4626 /* AnswerKeyComparisonTests.swift in Sources */,
 				908ED70F336A90E3DBF4E198 /* AnthropicServiceTests.swift in Sources */,
 				60E3DD654D41C484DFD3281E /* AudioSessionManagerTests.swift in Sources */,
@@ -997,6 +1050,7 @@
 				56E59D06B02418F6D1057A03 /* ChatViewTests.swift in Sources */,
 				B6403B3CA71AF12E11A38232 /* ConnectionLinesTests.swift in Sources */,
 				396A7EF23BB5D5C0D9B29F87 /* DropZoneTests.swift in Sources */,
+				B665C92DF1CD20E2C25E9DD8 /* ElevatorPitchSessionTests.swift in Sources */,
 				DC8CB9656F62B3F2E9C313EE /* FeedbackBubbleTests.swift in Sources */,
 				16755F914DD22F021F0C1E04 /* FindThePointSessionTests.swift in Sources */,
 				D6CD1F94E1C2E57A0888230E /* FirstLaunchSetupTests.swift in Sources */,
@@ -1006,6 +1060,8 @@
 				28CABE726983AF0A238983DE /* NetworkErrorHandlerTests.swift in Sources */,
 				89CED9375747E4D03FCB8E66 /* PracticeTextGeneratorTests.swift in Sources */,
 				2D4D59D45FD3FDC4D737C08B /* PracticeTextLibraryTests.swift in Sources */,
+				41A85E6A507F013D8D83DDA7 /* ProfileUpdaterTests.swift in Sources */,
+				01725E7CBADF98137BDC26AA /* ProgressDashboardTests.swift in Sources */,
 				C37CC4D67FE88C69E19D6FF4 /* PyramidBlockTests.swift in Sources */,
 				E2E771E2E6E4B969403D183A /* ResponseParserTests.swift in Sources */,
 				D18F59F6E50DE4B10D1B6929 /* SayItClearlySessionTests.swift in Sources */,
@@ -1029,6 +1085,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				49828FC1CE9DAC9540F13C29 /* AdaptiveChatView.swift in Sources */,
+				588D9CEDFC0028729E9822A4 /* AnalyseMyTextSession.swift in Sources */,
+				A4A0DD5041F5926F318A2BB6 /* AnalyseMyTextView.swift in Sources */,
 				A4A5E4A6E927A6FF4AE200B1 /* AnswerKeyComparer.swift in Sources */,
 				33D64B1F80E3DC6DAB7F372D /* AnswerKeyComparison.swift in Sources */,
 				A9BA44DA0F1F2B687C7EB602 /* AnthropicModel.swift in Sources */,
@@ -1051,9 +1109,13 @@
 				B9E64E1CAA8464301C3DC563 /* ConnectionLinesView.swift in Sources */,
 				F3EA6C9E62178099319F591E /* DebugLogView.swift in Sources */,
 				487E6CBCA4808690CB6B31C4 /* DebugLogger.swift in Sources */,
+				A9C54D9E4FC609C3A85D553B /* DimensionBarChartView.swift in Sources */,
 				901D104DC385EA8F6044D909 /* DraggableBlockView.swift in Sources */,
 				E051DAB7CE1CB6C9AE6C2D79 /* DropZone.swift in Sources */,
 				8BED3E20F4C909B14BE520AA /* DropZoneView.swift in Sources */,
+				9D25E26FB942070B61F6E54D /* ElevatorPitchCoordinator.swift in Sources */,
+				BE27D9D3A47875F43F2CB6FC /* ElevatorPitchSession.swift in Sources */,
+				AE1A15A7E561DB90F19FF361 /* ElevatorPitchView.swift in Sources */,
 				C68A1A0B560C01274838748E /* ErrorBannerView.swift in Sources */,
 				6C7096189A52A789768C7042 /* EvaluationResult.swift in Sources */,
 				A5F6092C5DBADDBDC55A732F /* FeedbackBubbleView.swift in Sources */,
@@ -1082,6 +1144,8 @@
 				F0CC71F3229103F04C025A33 /* PracticeTextLibrary.swift in Sources */,
 				62641799AE854D5ED7B337B1 /* PracticeTextLibraryContainer.swift in Sources */,
 				386889749422B3AD42065CF9 /* PracticeTextView.swift in Sources */,
+				95A50EEDFAC1BC4B1996DF6D /* ProfileUpdater.swift in Sources */,
+				B7C28920B91F304603968367 /* ProgressDashboardView.swift in Sources */,
 				779DEBCF437A97E109B3E8BC /* PyramidBlock.swift in Sources */,
 				531F7C8788BD0D599A7E8D04 /* PyramidFeedbackOverlay.swift in Sources */,
 				CE49D1EC9F14EE85575FA236 /* PyramidTreeState.swift in Sources */,
@@ -1119,6 +1183,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				5F73FE131A1DB6BA939A2C5A /* AdaptiveChatView.swift in Sources */,
+				C4CE7E6FB0DA7A6B078EF083 /* AnalyseMyTextSession.swift in Sources */,
+				EBCF2F671531CFA0053373BA /* AnalyseMyTextView.swift in Sources */,
 				F00F932F2105F4C2E508109B /* AnswerKeyComparer.swift in Sources */,
 				9D641BA106661D4AD460D3A1 /* AnswerKeyComparison.swift in Sources */,
 				2B62856D49AD9FB989384F80 /* AnthropicModel.swift in Sources */,
@@ -1141,9 +1207,13 @@
 				A8CD8951B7D4294936CBB7B7 /* ConnectionLinesView.swift in Sources */,
 				3C009DF5A5015AB1595F05B2 /* DebugLogView.swift in Sources */,
 				BC5F147A088AEBDA38856EEE /* DebugLogger.swift in Sources */,
+				46A6335BD38DF3D1EEC54EE9 /* DimensionBarChartView.swift in Sources */,
 				F9F35AAB16261DE9156AFA81 /* DraggableBlockView.swift in Sources */,
 				0F0F6EFEABD224BE50436E3C /* DropZone.swift in Sources */,
 				B4128092EF246AE96A5BF1E0 /* DropZoneView.swift in Sources */,
+				8728021A5019601223697286 /* ElevatorPitchCoordinator.swift in Sources */,
+				C3D6237CFE9553D6515E743A /* ElevatorPitchSession.swift in Sources */,
+				42C2A1A109BB746F35591B2E /* ElevatorPitchView.swift in Sources */,
 				F138325B5D79C1F7D86FD19F /* ErrorBannerView.swift in Sources */,
 				2D80A3F94A0B23AF02D04401 /* EvaluationResult.swift in Sources */,
 				450B437F71624F37AA4EB50F /* FeedbackBubbleView.swift in Sources */,
@@ -1172,6 +1242,8 @@
 				A97A27185FAD7A443CC81A23 /* PracticeTextLibrary.swift in Sources */,
 				E85E8849F8661277DB8256F1 /* PracticeTextLibraryContainer.swift in Sources */,
 				6862FA1CB7124F4D08390F6B /* PracticeTextView.swift in Sources */,
+				4656E3C4F8DBBB5DDD9355D5 /* ProfileUpdater.swift in Sources */,
+				E6C0CE28BD49508CA40E8454 /* ProgressDashboardView.swift in Sources */,
 				FCFA826700749EA41FCB4FDC /* PyramidBlock.swift in Sources */,
 				C7AD8CE9CD5E3BC3C1568459 /* PyramidFeedbackOverlay.swift in Sources */,
 				FC483FFC26C8467FF1807413 /* PyramidTreeState.swift in Sources */,

--- a/app/SayItRight/Tests/ProgressDashboardTests.swift
+++ b/app/SayItRight/Tests/ProgressDashboardTests.swift
@@ -1,0 +1,71 @@
+import Foundation
+import Testing
+@testable import SayItRight
+
+@Suite("DimensionBarChartView")
+struct DimensionBarChartTests {
+
+    @Test("Display name for governingThought in English")
+    func displayNameEN() {
+        let name = DimensionBarChartView.displayName(for: "governingThought", language: "en")
+        #expect(name == "Leading with your point")
+    }
+
+    @Test("Display name for governingThought in German")
+    func displayNameDE() {
+        let name = DimensionBarChartView.displayName(for: "governingThought", language: "de")
+        #expect(name == "Mit dem Kerngedanken führen")
+    }
+
+    @Test("Display name for unknown dimension returns raw key")
+    func displayNameUnknown() {
+        let name = DimensionBarChartView.displayName(for: "unknownDimension", language: "en")
+        #expect(name == "unknownDimension")
+    }
+
+    @Test("All known dimensions have display names")
+    func allDimensionsHaveNames() {
+        let dimensions = [
+            "governingThought", "supportGrouping", "redundancy", "clarity",
+            "l1Gate", "meceQuality", "orderingLogic", "scqApplication", "horizontalLogic"
+        ]
+        for dim in dimensions {
+            let nameEN = DimensionBarChartView.displayName(for: dim, language: "en")
+            let nameDE = DimensionBarChartView.displayName(for: dim, language: "de")
+            #expect(nameEN != dim, "Missing EN name for \(dim)")
+            #expect(nameDE != dim, "Missing DE name for \(dim)")
+        }
+    }
+
+    @Test("maxScoreFor returns expected values")
+    func maxScores() {
+        #expect(DimensionBarChartView.maxScoreFor("governingThought") == 3)
+        #expect(DimensionBarChartView.maxScoreFor("supportGrouping") == 2)
+        #expect(DimensionBarChartView.maxScoreFor("redundancy") == 2)
+        #expect(DimensionBarChartView.maxScoreFor("clarity") == 3)
+        #expect(DimensionBarChartView.maxScoreFor("unknownDimension") == 3)
+    }
+}
+
+@Suite("ProgressDashboard — Preview Data")
+struct ProgressDashboardPreviewTests {
+
+    @Test("Preview populated profile has expected values")
+    func previewPopulated() {
+        let profile = LearnerProfile.previewPopulated
+        #expect(profile.sessionCount == 12)
+        #expect(profile.currentStreak == 3)
+        #expect(profile.longestStreak == 7)
+        #expect(profile.currentLevel == 1)
+        #expect(!profile.dimensionScores.isEmpty)
+        #expect(profile.structuralStrengths.contains("governingThought"))
+        #expect(profile.developmentAreas.contains("supportGrouping"))
+    }
+
+    @Test("Empty profile has zero sessions")
+    func emptyProfile() {
+        let profile = LearnerProfile.createDefault(displayName: "Test")
+        #expect(profile.sessionCount == 0)
+        #expect(profile.dimensionScores.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary
- Add `ProgressDashboardView` with current level, streak stats, and structural dimension bar chart
- Add `DimensionBarChartView` with bilingual dimension labels and colour-coded bars
- Add dashboard navigation via toolbar button on session picker
- Platform-adaptive: compact on iPhone, wide on iPad/Mac, with empty state for new users
- 7 new tests for dimension display names, max scores, and preview data

Closes #35

## Test plan
- [x] 523 tests pass (7 new)
- [x] Build succeeds on macOS
- [x] Previews for populated, empty, German, and iPad layouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)