### PR TITLE
feat: add adaptive difficulty engine (SIR-037)

### DIFF
--- a/app/SayItRight/Intelligence/ConversationManager/SayItClearlyCoordinator.swift
+++ b/app/SayItRight/Intelligence/ConversationManager/SayItClearlyCoordinator.swift
@@ -48,7 +48,7 @@ final class SayItClearlyCoordinator {
         profile: LearnerProfile,
         language: String
     ) async -> Topic? {
-        guard let topic = selectTopic(for: profile.currentLevel, language: language) else {
+        guard let topic = selectAdaptiveTopic(for: profile, language: language) else {
             return nil
         }
 
@@ -74,6 +74,15 @@ final class SayItClearlyCoordinator {
         // All topics seen — reset and try again
         recentTopicIDs.removeAll()
         return topicBank.randomTopic(for: level, excluding: recentTopicIDs)
+    }
+
+    /// Select a topic using adaptive difficulty based on the learner's profile.
+    ///
+    /// Uses `AdaptiveDifficultyEngine` to determine whether to consolidate
+    /// or stretch, then selects an appropriately levelled topic.
+    func selectAdaptiveTopic(for profile: LearnerProfile, language: String) -> Topic? {
+        let adaptiveLevel = AdaptiveDifficultyEngine.topicLevel(for: profile)
+        return selectTopic(for: adaptiveLevel, language: language)
     }
 
     /// Mark a topic as recently seen.

--- a/app/SayItRight/Intelligence/StructuralEvaluator/AdaptiveDifficultyEngine.swift
+++ b/app/SayItRight/Intelligence/StructuralEvaluator/AdaptiveDifficultyEngine.swift
@@ -1,0 +1,177 @@
+import Foundation
+
+/// Determines the learner's difficulty state and calibrates topic selection.
+///
+/// Uses the learner's rolling dimension averages to decide whether to consolidate
+/// at the current level, stretch with harder topics, or signal readiness for promotion.
+///
+/// The state machine:
+/// - **consolidating**: Stay at current level. < 60% of dimensions are strong.
+/// - **stretching**: Mix in next-level topics (70/30 current/stretch). >= 60% strong.
+/// - **readyForPromotion**: All key dimensions are strong. Level-up candidate.
+struct AdaptiveDifficultyEngine: Sendable {
+
+    // MARK: - Configuration
+
+    /// Minimum rolling average (normalised 0-1) to consider a dimension "strong".
+    static let strongThreshold: Double = 0.7
+
+    /// Minimum rolling average (normalised 0-1) below which a dimension is "weak".
+    static let weakThreshold: Double = 0.4
+
+    /// Fraction of dimensions that must be strong to start stretching.
+    static let stretchFraction: Double = 0.6
+
+    /// Minimum sessions before stretch can begin.
+    static let minSessionsForStretch: Int = 5
+
+    /// Minimum sessions before promotion can be considered.
+    static let minSessionsForPromotion: Int = 10
+
+    /// Ratio of current-level topics when stretching.
+    static let stretchCurrentRatio: Double = 0.7
+
+    // MARK: - Difficulty State
+
+    enum DifficultyState: String, Sendable {
+        case consolidating
+        case stretching
+        case readyForPromotion
+    }
+
+    // MARK: - Public API
+
+    /// Compute the difficulty state for a given profile.
+    static func difficultyState(for profile: LearnerProfile) -> DifficultyState {
+        let dimensions = dimensionsForLevel(profile.currentLevel)
+        guard !dimensions.isEmpty else { return .consolidating }
+
+        let strongCount = dimensions.filter { dim in
+            isStrong(dim, in: profile)
+        }.count
+
+        let weakCount = dimensions.filter { dim in
+            isWeak(dim, in: profile)
+        }.count
+
+        let strongFraction = Double(strongCount) / Double(dimensions.count)
+
+        // Not enough sessions yet
+        if profile.sessionCount < minSessionsForStretch {
+            return .consolidating
+        }
+
+        // All key dimensions strong, no weak ones, enough sessions
+        if strongCount == dimensions.count
+            && weakCount == 0
+            && profile.sessionCount >= minSessionsForPromotion {
+            return .readyForPromotion
+        }
+
+        // Enough strong dimensions to start stretching
+        if strongFraction >= stretchFraction {
+            return .stretching
+        }
+
+        return .consolidating
+    }
+
+    /// Select the appropriate topic level for a profile.
+    ///
+    /// Returns the level to use for topic selection. When stretching, uses
+    /// a deterministic pattern to mix current and next-level topics.
+    static func topicLevel(
+        for profile: LearnerProfile,
+        sessionIndex: Int? = nil
+    ) -> Int {
+        let state = difficultyState(for: profile)
+        let currentLevel = profile.currentLevel
+        let index = sessionIndex ?? profile.sessionCount
+
+        switch state {
+        case .consolidating:
+            return currentLevel
+        case .stretching:
+            // 70% current, 30% stretch — deterministic pattern
+            let isStretchSlot = (index % 10) >= Int(stretchCurrentRatio * 10)
+            return isStretchSlot ? min(currentLevel + 1, 4) : currentLevel
+        case .readyForPromotion:
+            // Mix evenly between current and next to prepare for transition
+            return (index % 2 == 0) ? currentLevel : min(currentLevel + 1, 4)
+        }
+    }
+
+    /// Identify the weakest dimensions that need targeted practice.
+    static func weakDimensions(for profile: LearnerProfile) -> [String] {
+        let dimensions = dimensionsForLevel(profile.currentLevel)
+        return dimensions.filter { isWeak($0, in: profile) }.sorted()
+    }
+
+    /// Identify strong dimensions.
+    static func strongDimensions(for profile: LearnerProfile) -> [String] {
+        let dimensions = dimensionsForLevel(profile.currentLevel)
+        return dimensions.filter { isStrong($0, in: profile) }.sorted()
+    }
+
+    /// Build a difficulty context string for system prompt injection.
+    static func difficultyContext(for profile: LearnerProfile) -> String {
+        let state = difficultyState(for: profile)
+        let weak = weakDimensions(for: profile)
+        let strong = strongDimensions(for: profile)
+
+        var lines: [String] = []
+        lines.append("Difficulty state: \(state.rawValue)")
+
+        if !strong.isEmpty {
+            lines.append("Strong dimensions: \(strong.joined(separator: ", "))")
+        }
+        if !weak.isEmpty {
+            lines.append("Weak dimensions (focus here): \(weak.joined(separator: ", "))")
+        }
+
+        switch state {
+        case .consolidating:
+            lines.append("Coaching approach: Patient, encouraging. Focus on fundamentals.")
+        case .stretching:
+            lines.append("Coaching approach: More demanding. Introduce higher-level concepts.")
+        case .readyForPromotion:
+            lines.append("Coaching approach: Challenge-oriented. The learner is close to leveling up.")
+        }
+
+        return lines.joined(separator: "\n")
+    }
+
+    // MARK: - Private Helpers
+
+    /// Key dimensions evaluated at each level.
+    static func dimensionsForLevel(_ level: Int) -> [String] {
+        switch level {
+        case 1:
+            return ["governingThought", "supportGrouping", "redundancy", "clarity"]
+        case 2:
+            return ["l1Gate", "meceQuality", "orderingLogic", "scqApplication", "horizontalLogic"]
+        default:
+            // L3+ includes all L2 dimensions (L3-specific dimensions not yet implemented)
+            return ["l1Gate", "meceQuality", "orderingLogic", "scqApplication", "horizontalLogic"]
+        }
+    }
+
+    private static func isStrong(_ dimension: String, in profile: LearnerProfile) -> Bool {
+        guard let avg = profile.rollingAverage(for: dimension),
+              let maxScore = ProfileUpdater.maxScores[dimension],
+              maxScore > 0 else {
+            return false
+        }
+        return (avg / Double(maxScore)) >= strongThreshold
+    }
+
+    private static func isWeak(_ dimension: String, in profile: LearnerProfile) -> Bool {
+        guard let avg = profile.rollingAverage(for: dimension),
+              let maxScore = ProfileUpdater.maxScores[dimension],
+              maxScore > 0 else {
+            // No data = weak by default (needs practice)
+            return true
+        }
+        return (avg / Double(maxScore)) < weakThreshold
+    }
+}

--- a/app/SayItRight/Intelligence/StructuralEvaluator/StructuralEvaluator.swift
+++ b/app/SayItRight/Intelligence/StructuralEvaluator/StructuralEvaluator.swift
@@ -42,8 +42,11 @@ actor StructuralEvaluator {
 
     func prepareSession(level: Int, sessionType: String, language: String, profile: LearnerProfile) {
         callCount = 0
+        let difficultyContext = AdaptiveDifficultyEngine.difficultyContext(for: profile)
         cachedSystemPrompt = systemPromptAssembler.assemble(
-            level: level, sessionType: sessionType, language: language, profileJSON: profile.toPromptJSON()
+            level: level, sessionType: sessionType, language: language,
+            profileJSON: profile.toPromptJSON(),
+            difficultyContext: difficultyContext
         )
     }
 

--- a/app/SayItRight/Intelligence/SystemPrompt/SystemPromptAssembler.swift
+++ b/app/SayItRight/Intelligence/SystemPrompt/SystemPromptAssembler.swift
@@ -30,6 +30,11 @@ struct SystemPromptAssembler {
     ///   - profileJSON: JSON string of the learner profile
     /// - Returns: The assembled system prompt string
     func assemble(level: Int, sessionType: String, language: String, profileJSON: String) -> String {
+        assemble(level: level, sessionType: sessionType, language: language, profileJSON: profileJSON, difficultyContext: nil)
+    }
+
+    /// Assemble a system prompt with optional adaptive difficulty context.
+    func assemble(level: Int, sessionType: String, language: String, profileJSON: String, difficultyContext: String?) -> String {
         var parts: [String] = []
 
         // 1–3: Identity, Pedagogy, Rubric
@@ -56,6 +61,11 @@ struct SystemPromptAssembler {
 
         // 6: Learner profile
         parts.append("# Learner Profile\n\n```json\n\(profileJSON)\n```")
+
+        // 6b: Difficulty context (adaptive)
+        if let context = difficultyContext, !context.isEmpty {
+            parts.append("# Adaptive Difficulty\n\n\(context)")
+        }
 
         // 7: Output format
         if let outputFormat = loadBlock("output-format-\(language)") {

--- a/app/SayItRight/SayItRight.xcodeproj/project.pbxproj
+++ b/app/SayItRight/SayItRight.xcodeproj/project.pbxproj
@@ -93,6 +93,7 @@
 		5065401FEFC87872EDCF1B5F /* SessionHistoryStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E96E00792CE206BD08DE44C1 /* SessionHistoryStore.swift */; };
 		531F7C8788BD0D599A7E8D04 /* PyramidFeedbackOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 147D1E1AF8B5697A25D1EFFB /* PyramidFeedbackOverlay.swift */; };
 		537119E6E50C56A7FBE6CF59 /* AudioSessionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED72B2F78895FD96D69C5698 /* AudioSessionManager.swift */; };
+		551B5D55D83D830E1E13748E /* AdaptiveDifficultyEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35D136B15681796D9B441FCE /* AdaptiveDifficultyEngine.swift */; };
 		5673D8240DB6073E30B4EAF5 /* LearnerProfileStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7340051027E1031862796AD /* LearnerProfileStore.swift */; };
 		56E59D06B02418F6D1057A03 /* ChatViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40319D5211156AC1671570F5 /* ChatViewTests.swift */; };
 		57BFD8048F458724D5220EE4 /* SidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F227EDAC8833CE0EA075111 /* SidebarView.swift */; };
@@ -200,6 +201,7 @@
 		BBB3CACEC5AE458782FFD0D0 /* ValidationFeedbackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC256E9126646B1262512067 /* ValidationFeedbackTests.swift */; };
 		BC5F147A088AEBDA38856EEE /* DebugLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1355D670E0F227DE429EAB9 /* DebugLogger.swift */; };
 		BC6395CBB992EB5D23FEB685 /* SidebarViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1161CE00FACCF6715D7034A1 /* SidebarViewTests.swift */; };
+		BCAED56CECCA608E8B82DEA3 /* AdaptiveDifficultyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 076FD5273952AC72498F002F /* AdaptiveDifficultyTests.swift */; };
 		BDF08178D405ECC24953BC24 /* SayItRight.xcodeproj in Resources */ = {isa = PBXBuildFile; fileRef = 3FAF495135EB918BBBE3A021 /* SayItRight.xcodeproj */; };
 		BE27D9D3A47875F43F2CB6FC /* ElevatorPitchSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B7D104D20992358220CF516 /* ElevatorPitchSession.swift */; };
 		BF7E68D87F7FE0DDCF4867D1 /* SystemPromptAssemblerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65A78B634A6D6F9D4CD57BC7 /* SystemPromptAssemblerTests.swift */; };
@@ -229,6 +231,7 @@
 		CE5B36B251DCE97CBA0D847C /* SessionHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79103E672E97A7B33767ED30 /* SessionHistoryView.swift */; };
 		CFD488522376107A7697D0ED /* SessionHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79103E672E97A7B33767ED30 /* SessionHistoryView.swift */; };
 		D18F59F6E50DE4B10D1B6929 /* SayItClearlySessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9512DE8E01F6C1AB4E4B8C /* SayItClearlySessionTests.swift */; };
+		D3070A5C5100B0857F8ACA4B /* AdaptiveDifficultyEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35D136B15681796D9B441FCE /* AdaptiveDifficultyEngine.swift */; };
 		D3A1BF1A3B70AAF52594F570 /* NetworkErrorHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F95CF0998D962402B03233 /* NetworkErrorHandlerTests.swift */; };
 		D43F8B89B23167F2FA4EE2A2 /* MockSpeechRecognitionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A734FF80156849AAC5CD69 /* MockSpeechRecognitionService.swift */; };
 		D55641BDCB16A06138C8F443 /* SeenTextsTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C3D288AEDB1EF42A2CF3455 /* SeenTextsTracker.swift */; };
@@ -263,6 +266,7 @@
 		EBE97AEDAD50F2E4A8AF50A3 /* PracticeTextLibraryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C70ADBF790944D3353F4FA32 /* PracticeTextLibraryTests.swift */; };
 		EC2B4036D1202B37FDCFF1B7 /* ParentGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B22653B114F07E9EA40C7C62 /* ParentGate.swift */; };
 		EC8D5C128F51D0CCF602CE9D /* SeenTextsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E399297963E1A59A4C958BFA /* SeenTextsTests.swift */; };
+		EDBBC9474916AA15B1A66C30 /* AdaptiveDifficultyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 076FD5273952AC72498F002F /* AdaptiveDifficultyTests.swift */; };
 		EE7B786DFC8E07B8C334D925 /* SpeechRecognitionServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D57221714F45B9C00201617 /* SpeechRecognitionServiceTests.swift */; };
 		F00F932F2105F4C2E508109B /* AnswerKeyComparer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AEAE8216CAB132332EE8012 /* AnswerKeyComparer.swift */; };
 		F0CC71F3229103F04C025A33 /* PracticeTextLibrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BFD6B8D5C586B0C9ADEEBA5 /* PracticeTextLibrary.swift */; };
@@ -307,6 +311,7 @@
 		02BB2E4C4988BEA73B0B9060 /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
 		0571FE24B4A26446F89C5096 /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
 		0756AEBC135E6923ED87C8A0 /* AdaptiveChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdaptiveChatView.swift; sourceTree = "<group>"; };
+		076FD5273952AC72498F002F /* AdaptiveDifficultyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdaptiveDifficultyTests.swift; sourceTree = "<group>"; };
 		0A30E1A80DC1D1B71AF67390 /* FeedbackBubbleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackBubbleView.swift; sourceTree = "<group>"; };
 		0AEAE8216CAB132332EE8012 /* AnswerKeyComparer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnswerKeyComparer.swift; sourceTree = "<group>"; };
 		0D5A7EA09817CE62F1FE9796 /* AudioSessionManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioSessionManagerTests.swift; sourceTree = "<group>"; };
@@ -342,6 +347,7 @@
 		2ED4B98BAC3EA13F5C61CBCD /* ConnectionLinesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionLinesTests.swift; sourceTree = "<group>"; };
 		2F8727097172513F7D8AA109 /* SayItRight.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SayItRight.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		30EED07035F76FC2168D236A /* ProfileUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileUpdater.swift; sourceTree = "<group>"; };
+		35D136B15681796D9B441FCE /* AdaptiveDifficultyEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdaptiveDifficultyEngine.swift; sourceTree = "<group>"; };
 		36C6BF2F47F0B8EFFC2DF98B /* BarbaraAvatarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarbaraAvatarView.swift; sourceTree = "<group>"; };
 		39FB9A6BB2DA0BC61384039F /* PracticeTextFileWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticeTextFileWriter.swift; sourceTree = "<group>"; };
 		3D57221714F45B9C00201617 /* SpeechRecognitionServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechRecognitionServiceTests.swift; sourceTree = "<group>"; };
@@ -638,6 +644,7 @@
 		9CA9825E2539A59A51BE06B7 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				076FD5273952AC72498F002F /* AdaptiveDifficultyTests.swift */,
 				652143071B4E57A9035FE43B /* AnalyseMyTextSessionTests.swift */,
 				F2A6B03C9A74B0140D2B2BE7 /* AnswerKeyComparisonTests.swift */,
 				F77568CC779F6818DEF9ADCC /* AnthropicServiceTests.swift */,
@@ -710,6 +717,7 @@
 			isa = PBXGroup;
 			children = (
 				1BEBAE680A83F0277794FDFA /* .gitkeep */,
+				35D136B15681796D9B441FCE /* AdaptiveDifficultyEngine.swift */,
 				0AEAE8216CAB132332EE8012 /* AnswerKeyComparer.swift */,
 				1910976EBE55B2D0A2B347CA /* AnswerKeyComparison.swift */,
 				69C98EBC60AB392AA8868374 /* ComparisonPromptBuilder.swift */,
@@ -1014,6 +1022,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BCAED56CECCA608E8B82DEA3 /* AdaptiveDifficultyTests.swift in Sources */,
 				FD4642D02538BAA526AC064C /* AnalyseMyTextSessionTests.swift in Sources */,
 				E97996275531EAC63277B021 /* AnswerKeyComparisonTests.swift in Sources */,
 				00D8301F3E74117DF9AA973B /* AnthropicServiceTests.swift in Sources */,
@@ -1058,6 +1067,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EDBBC9474916AA15B1A66C30 /* AdaptiveDifficultyTests.swift in Sources */,
 				DD46000474FB0168BB12A02E /* AnalyseMyTextSessionTests.swift in Sources */,
 				FCDB2F855E3D272EABFC4626 /* AnswerKeyComparisonTests.swift in Sources */,
 				908ED70F336A90E3DBF4E198 /* AnthropicServiceTests.swift in Sources */,
@@ -1103,6 +1113,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				49828FC1CE9DAC9540F13C29 /* AdaptiveChatView.swift in Sources */,
+				D3070A5C5100B0857F8ACA4B /* AdaptiveDifficultyEngine.swift in Sources */,
 				588D9CEDFC0028729E9822A4 /* AnalyseMyTextSession.swift in Sources */,
 				A4A0DD5041F5926F318A2BB6 /* AnalyseMyTextView.swift in Sources */,
 				A4A5E4A6E927A6FF4AE200B1 /* AnswerKeyComparer.swift in Sources */,
@@ -1204,6 +1215,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				5F73FE131A1DB6BA939A2C5A /* AdaptiveChatView.swift in Sources */,
+				551B5D55D83D830E1E13748E /* AdaptiveDifficultyEngine.swift in Sources */,
 				C4CE7E6FB0DA7A6B078EF083 /* AnalyseMyTextSession.swift in Sources */,
 				EBCF2F671531CFA0053373BA /* AnalyseMyTextView.swift in Sources */,
 				F00F932F2105F4C2E508109B /* AnswerKeyComparer.swift in Sources */,

--- a/app/SayItRight/Tests/AdaptiveDifficultyTests.swift
+++ b/app/SayItRight/Tests/AdaptiveDifficultyTests.swift
@@ -1,0 +1,191 @@
+import Foundation
+import Testing
+@testable import SayItRight
+
+@Suite("AdaptiveDifficultyEngine")
+struct AdaptiveDifficultyTests {
+
+    // MARK: - Helpers
+
+    private func makeProfile(
+        level: Int = 1,
+        sessionCount: Int = 0,
+        scores: [String: [Int]] = [:]
+    ) -> LearnerProfile {
+        var profile = LearnerProfile.createDefault(displayName: "Test")
+        profile.currentLevel = level
+        profile.sessionCount = sessionCount
+        for (dim, values) in scores {
+            for v in values {
+                profile.recordScore(v, for: dim)
+            }
+        }
+        return profile
+    }
+
+    // MARK: - Difficulty State
+
+    @Test("New profile is consolidating")
+    func newProfileConsolidating() {
+        let profile = makeProfile()
+        let state = AdaptiveDifficultyEngine.difficultyState(for: profile)
+        #expect(state == .consolidating)
+    }
+
+    @Test("Profile with few sessions is consolidating even with good scores")
+    func fewSessionsConsolidating() {
+        let profile = makeProfile(sessionCount: 3, scores: [
+            "governingThought": [3, 3, 3],
+            "supportGrouping": [2, 2, 2],
+            "redundancy": [2, 2, 2],
+            "clarity": [3, 3, 3],
+        ])
+        let state = AdaptiveDifficultyEngine.difficultyState(for: profile)
+        #expect(state == .consolidating)
+    }
+
+    @Test("Profile with enough sessions and strong scores is stretching")
+    func stretchingState() {
+        // 3/4 dimensions strong (75% > 60% threshold)
+        let profile = makeProfile(sessionCount: 6, scores: [
+            "governingThought": [3, 3, 3, 3, 3],
+            "supportGrouping": [2, 2, 2, 2, 2],
+            "redundancy": [2, 2, 2, 2, 2],
+            "clarity": [1, 1, 1, 1, 1], // weak
+        ])
+        let state = AdaptiveDifficultyEngine.difficultyState(for: profile)
+        #expect(state == .stretching)
+    }
+
+    @Test("Profile with all dimensions strong and enough sessions is ready for promotion")
+    func readyForPromotion() {
+        let profile = makeProfile(sessionCount: 12, scores: [
+            "governingThought": [3, 3, 3, 3, 3],
+            "supportGrouping": [2, 2, 2, 2, 2],
+            "redundancy": [2, 2, 2, 2, 2],
+            "clarity": [3, 3, 3, 3, 3],
+        ])
+        let state = AdaptiveDifficultyEngine.difficultyState(for: profile)
+        #expect(state == .readyForPromotion)
+    }
+
+    @Test("Profile with one weak dimension is not ready for promotion")
+    func notReadyWithWeakDimension() {
+        let profile = makeProfile(sessionCount: 12, scores: [
+            "governingThought": [3, 3, 3, 3, 3],
+            "supportGrouping": [0, 0, 0, 0, 0], // weak
+            "redundancy": [2, 2, 2, 2, 2],
+            "clarity": [3, 3, 3, 3, 3],
+        ])
+        let state = AdaptiveDifficultyEngine.difficultyState(for: profile)
+        #expect(state != .readyForPromotion)
+    }
+
+    // MARK: - Topic Level Selection
+
+    @Test("Consolidating profile gets current level topics")
+    func topicLevelConsolidating() {
+        let profile = makeProfile(level: 1, sessionCount: 2)
+        let level = AdaptiveDifficultyEngine.topicLevel(for: profile)
+        #expect(level == 1)
+    }
+
+    @Test("Stretching profile gets mix of current and next level")
+    func topicLevelStretching() {
+        let profile = makeProfile(level: 1, sessionCount: 6, scores: [
+            "governingThought": [3, 3, 3, 3, 3],
+            "supportGrouping": [2, 2, 2, 2, 2],
+            "redundancy": [2, 2, 2, 2, 2],
+            "clarity": [1, 1, 1, 1, 1],
+        ])
+        // 70% current (index 0-6), 30% stretch (index 7-9)
+        let currentLevel = AdaptiveDifficultyEngine.topicLevel(for: profile, sessionIndex: 0)
+        let stretchLevel = AdaptiveDifficultyEngine.topicLevel(for: profile, sessionIndex: 8)
+        #expect(currentLevel == 1)
+        #expect(stretchLevel == 2)
+    }
+
+    @Test("Topic level never exceeds 4")
+    func topicLevelCapped() {
+        let profile = makeProfile(level: 4, sessionCount: 6, scores: [
+            "l1Gate": [3, 3, 3, 3, 3],
+            "meceQuality": [3, 3, 3, 3, 3],
+            "orderingLogic": [3, 3, 3, 3, 3],
+            "scqApplication": [2, 2, 2, 2, 2],
+            "horizontalLogic": [0, 0, 0, 0, 0],
+        ])
+        let level = AdaptiveDifficultyEngine.topicLevel(for: profile, sessionIndex: 8)
+        #expect(level <= 4)
+    }
+
+    // MARK: - Weak/Strong Dimensions
+
+    @Test("Weak dimensions identified correctly")
+    func weakDimensions() {
+        let profile = makeProfile(level: 1, scores: [
+            "governingThought": [3, 3, 3],
+            "supportGrouping": [0, 0, 0], // weak
+            "redundancy": [0, 0, 0], // weak
+            "clarity": [3, 3, 3],
+        ])
+        let weak = AdaptiveDifficultyEngine.weakDimensions(for: profile)
+        #expect(weak.contains("supportGrouping"))
+        #expect(weak.contains("redundancy"))
+        #expect(!weak.contains("governingThought"))
+    }
+
+    @Test("Strong dimensions identified correctly")
+    func strongDimensions() {
+        let profile = makeProfile(level: 1, scores: [
+            "governingThought": [3, 3, 3],
+            "supportGrouping": [0, 0, 0],
+            "clarity": [3, 3, 3],
+        ])
+        let strong = AdaptiveDifficultyEngine.strongDimensions(for: profile)
+        #expect(strong.contains("governingThought"))
+        #expect(strong.contains("clarity"))
+        #expect(!strong.contains("supportGrouping"))
+    }
+
+    // MARK: - Difficulty Context
+
+    @Test("Difficulty context includes state and dimensions")
+    func difficultyContext() {
+        let profile = makeProfile(level: 1, sessionCount: 6, scores: [
+            "governingThought": [3, 3, 3, 3, 3],
+            "supportGrouping": [2, 2, 2, 2, 2],
+            "redundancy": [2, 2, 2, 2, 2],
+            "clarity": [0, 0, 0, 0, 0],
+        ])
+        let context = AdaptiveDifficultyEngine.difficultyContext(for: profile)
+        #expect(context.contains("stretching"))
+        #expect(context.contains("clarity"))
+        #expect(context.contains("More demanding"))
+    }
+
+    @Test("New user context says consolidating with patient approach")
+    func newUserContext() {
+        let profile = makeProfile()
+        let context = AdaptiveDifficultyEngine.difficultyContext(for: profile)
+        #expect(context.contains("consolidating"))
+        #expect(context.contains("Patient"))
+    }
+
+    // MARK: - Level Dimensions
+
+    @Test("L1 has 4 dimensions")
+    func l1Dimensions() {
+        let dims = AdaptiveDifficultyEngine.dimensionsForLevel(1)
+        #expect(dims.count == 4)
+        #expect(dims.contains("governingThought"))
+        #expect(dims.contains("clarity"))
+    }
+
+    @Test("L2 has 5 dimensions")
+    func l2Dimensions() {
+        let dims = AdaptiveDifficultyEngine.dimensionsForLevel(2)
+        #expect(dims.count == 5)
+        #expect(dims.contains("meceQuality"))
+        #expect(dims.contains("horizontalLogic"))
+    }
+}


### PR DESCRIPTION
## Summary
- Add `AdaptiveDifficultyEngine` with consolidating/stretching/readyForPromotion state machine
- Topic selection uses 70/30 current/stretch mix when learner is stretching
- System prompt now includes difficulty context (state, weak/strong dimensions, coaching approach)
- `SayItClearlyCoordinator` uses adaptive topic level selection
- `StructuralEvaluator` injects difficulty context into assembled prompt

Closes #37

## Test plan
- [x] 545 tests pass (14 new: state transitions, topic level, weak/strong detection, context generation)
- [x] Build succeeds on macOS
- [x] Deterministic: state depends only on profile, no randomness

🤖 Generated with [Claude Code](https://claude.com/claude-code)