### PR TITLE
feat: add revision diff view with sentence-level comparison (SIR-038)

### DIFF
--- a/app/SayItRight/Intelligence/StructuralEvaluator/SentenceDiff.swift
+++ b/app/SayItRight/Intelligence/StructuralEvaluator/SentenceDiff.swift
@@ -1,0 +1,116 @@
+import Foundation
+
+/// Computes sentence-level structural diffs between two text attempts.
+///
+/// Splits texts into sentences and classifies each as kept, added, removed,
+/// or moved. Designed for structural comparison, not character-level precision.
+struct SentenceDiff: Sendable {
+
+    /// A single sentence with its diff status.
+    struct DiffEntry: Sendable, Identifiable, Equatable {
+        let id: Int
+        let text: String
+        let status: DiffStatus
+    }
+
+    /// Classification of a sentence in the diff.
+    enum DiffStatus: String, Sendable, Equatable {
+        case kept       // Present in both, same position
+        case added      // Present only in revised version
+        case removed    // Present only in original version
+        case moved      // Present in both, different position
+    }
+
+    /// Result of a structural diff comparison.
+    struct DiffResult: Sendable {
+        /// Entries for the original text.
+        let original: [DiffEntry]
+        /// Entries for the revised text.
+        let revised: [DiffEntry]
+        /// Whether meaningful structural changes were detected.
+        let hasStructuralChanges: Bool
+    }
+
+    /// Compare two texts at the sentence level.
+    static func compare(original: String, revised: String) -> DiffResult {
+        let origSentences = splitSentences(original)
+        let revSentences = splitSentences(revised)
+
+        let origNormalised = origSentences.map { normalise($0) }
+        let revNormalised = revSentences.map { normalise($0) }
+
+        var origEntries: [DiffEntry] = []
+        var revEntries: [DiffEntry] = []
+
+        // Classify original sentences
+        for (i, sentence) in origSentences.enumerated() {
+            let norm = origNormalised[i]
+
+            if let revIndex = revNormalised.firstIndex(of: norm) {
+                if revIndex == i {
+                    origEntries.append(DiffEntry(id: i, text: sentence, status: .kept))
+                } else {
+                    origEntries.append(DiffEntry(id: i, text: sentence, status: .moved))
+                }
+            } else {
+                origEntries.append(DiffEntry(id: i, text: sentence, status: .removed))
+            }
+        }
+
+        // Classify revised sentences
+        for (i, sentence) in revSentences.enumerated() {
+            let norm = revNormalised[i]
+
+            if let origIndex = origNormalised.firstIndex(of: norm) {
+                if origIndex == i {
+                    revEntries.append(DiffEntry(id: 1000 + i, text: sentence, status: .kept))
+                } else {
+                    revEntries.append(DiffEntry(id: 1000 + i, text: sentence, status: .moved))
+                }
+            } else {
+                revEntries.append(DiffEntry(id: 1000 + i, text: sentence, status: .added))
+            }
+        }
+
+        let hasChanges = origEntries.contains { $0.status != .kept }
+            || revEntries.contains { $0.status != .kept }
+
+        return DiffResult(
+            original: origEntries,
+            revised: revEntries,
+            hasStructuralChanges: hasChanges
+        )
+    }
+
+    // MARK: - Helpers
+
+    /// Split text into sentences using linguistic boundaries.
+    static func splitSentences(_ text: String) -> [String] {
+        var sentences: [String] = []
+        text.enumerateSubstrings(
+            in: text.startIndex...,
+            options: [.bySentences, .localized]
+        ) { substring, _, _, _ in
+            if let sentence = substring?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !sentence.isEmpty {
+                sentences.append(sentence)
+            }
+        }
+        // Fallback: if enumeration yields nothing, split on period
+        if sentences.isEmpty && !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            sentences = text.components(separatedBy: ". ")
+                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                .filter { !$0.isEmpty }
+        }
+        return sentences
+    }
+
+    /// Normalise a sentence for comparison (lowercase, collapse whitespace).
+    static func normalise(_ sentence: String) -> String {
+        sentence.lowercased()
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+    }
+}

--- a/app/SayItRight/Presentation/Session/RevisionDiffView.swift
+++ b/app/SayItRight/Presentation/Session/RevisionDiffView.swift
@@ -1,0 +1,228 @@
+import SwiftUI
+
+/// Shows a structural diff between the learner's first and final attempt.
+///
+/// Platform behavior:
+/// - **iPhone**: Segmented control to toggle between Attempt 1 and Attempt 2.
+/// - **iPad/Mac**: Side-by-side comparison.
+struct RevisionDiffView: View {
+    let originalText: String
+    let revisedText: String
+    let language: String
+
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    @State private var selectedAttempt = 0
+
+    private var isWide: Bool {
+        #if os(macOS)
+        true
+        #else
+        horizontalSizeClass == .regular
+        #endif
+    }
+
+    private var diffResult: SentenceDiff.DiffResult {
+        SentenceDiff.compare(original: originalText, revised: revisedText)
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 16) {
+                if !diffResult.hasStructuralChanges {
+                    noChangesView
+                } else if isWide {
+                    sideBySideView
+                } else {
+                    toggleView
+                }
+
+                legendView
+            }
+            .padding(16)
+        }
+        .navigationTitle(language == "de" ? "Vergleich" : "Revision Diff")
+        #if !os(macOS)
+        .navigationBarTitleDisplayMode(.inline)
+        #endif
+    }
+
+    // MARK: - No Changes
+
+    private var noChangesView: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "equal.circle")
+                .font(.system(size: 36))
+                .foregroundStyle(.secondary)
+
+            Text(language == "de"
+                ? "Keine strukturellen Änderungen erkannt"
+                : "No structural changes detected")
+                .font(.headline)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 40)
+    }
+
+    // MARK: - Side by Side (iPad/Mac)
+
+    private var sideBySideView: some View {
+        HStack(alignment: .top, spacing: 16) {
+            diffColumn(
+                title: language == "de" ? "Versuch 1" : "Attempt 1",
+                entries: diffResult.original
+            )
+            Divider()
+            diffColumn(
+                title: language == "de" ? "Versuch 2" : "Attempt 2",
+                entries: diffResult.revised
+            )
+        }
+    }
+
+    // MARK: - Toggle View (iPhone)
+
+    private var toggleView: some View {
+        VStack(spacing: 12) {
+            Picker("", selection: $selectedAttempt) {
+                Text(language == "de" ? "Versuch 1" : "Attempt 1").tag(0)
+                Text(language == "de" ? "Versuch 2" : "Attempt 2").tag(1)
+            }
+            .pickerStyle(.segmented)
+
+            if selectedAttempt == 0 {
+                diffEntries(diffResult.original)
+            } else {
+                diffEntries(diffResult.revised)
+            }
+        }
+    }
+
+    // MARK: - Diff Display
+
+    private func diffColumn(title: String, entries: [SentenceDiff.DiffEntry]) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title)
+                .font(.headline)
+                .foregroundStyle(.secondary)
+
+            diffEntries(entries)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func diffEntries(_ entries: [SentenceDiff.DiffEntry]) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            ForEach(entries) { entry in
+                HStack(alignment: .top, spacing: 8) {
+                    Circle()
+                        .fill(colorFor(entry.status))
+                        .frame(width: 8, height: 8)
+                        .padding(.top, 5)
+
+                    Text(entry.text)
+                        .font(.body)
+                        .foregroundStyle(entry.status == .removed ? .secondary : .primary)
+                        .strikethrough(entry.status == .removed)
+                }
+                .padding(.vertical, 4)
+                .padding(.horizontal, 8)
+                .background(backgroundFor(entry.status))
+                .clipShape(RoundedRectangle(cornerRadius: 6))
+            }
+        }
+    }
+
+    // MARK: - Legend
+
+    private var legendView: some View {
+        HStack(spacing: 16) {
+            legendItem(color: .green, label: language == "de" ? "Hinzugefügt" : "Added")
+            legendItem(color: .red, label: language == "de" ? "Entfernt" : "Removed")
+            legendItem(color: .purple, label: language == "de" ? "Verschoben" : "Moved")
+        }
+        .font(.caption)
+        .foregroundStyle(.secondary)
+        .padding(.top, 8)
+    }
+
+    private func legendItem(color: Color, label: String) -> some View {
+        HStack(spacing: 4) {
+            Circle().fill(color).frame(width: 6, height: 6)
+            Text(label)
+        }
+    }
+
+    // MARK: - Colors
+
+    private func colorFor(_ status: SentenceDiff.DiffStatus) -> Color {
+        switch status {
+        case .kept: .gray
+        case .added: .green
+        case .removed: .red
+        case .moved: .purple
+        }
+    }
+
+    private func backgroundFor(_ status: SentenceDiff.DiffStatus) -> some ShapeStyle {
+        switch status {
+        case .kept: Color.clear
+        case .added: Color.green.opacity(0.1)
+        case .removed: Color.red.opacity(0.1)
+        case .moved: Color.purple.opacity(0.1)
+        }
+    }
+}
+
+// MARK: - Previews
+
+#Preview("Improved Revision") {
+    NavigationStack {
+        RevisionDiffView(
+            originalText: "There are many reasons why schools should start later. Research shows students are tired. Sleep is important for learning. The main point is that later start times improve academic performance.",
+            revisedText: "Later school start times improve academic performance. Research shows students are tired in early mornings. Sleep is critical for learning and memory consolidation.",
+            language: "en"
+        )
+    }
+}
+
+#Preview("Minimal Changes") {
+    NavigationStack {
+        RevisionDiffView(
+            originalText: "Schools should start later. Students need more sleep.",
+            revisedText: "Schools should start later. Students need more sleep. This helps them focus.",
+            language: "en"
+        )
+    }
+}
+
+#Preview("Unchanged") {
+    NavigationStack {
+        RevisionDiffView(
+            originalText: "Schools should start later. Students need more sleep.",
+            revisedText: "Schools should start later. Students need more sleep.",
+            language: "en"
+        )
+    }
+}
+
+#Preview("German") {
+    NavigationStack {
+        RevisionDiffView(
+            originalText: "Es gibt viele Gründe für Schuluniformen. Schüler werden gleich behandelt.",
+            revisedText: "Schuluniformen fördern Gleichbehandlung. Schüler werden nicht nach Kleidung beurteilt. Das reduziert sozialen Druck.",
+            language: "de"
+        )
+    }
+}
+
+#Preview("iPad Side-by-Side") {
+    NavigationStack {
+        RevisionDiffView(
+            originalText: "There are many reasons. Research shows things. The point is this.",
+            revisedText: "The point is this: research shows clear evidence. Multiple studies confirm the findings.",
+            language: "en"
+        )
+    }
+    .environment(\.horizontalSizeClass, .regular)
+}

--- a/app/SayItRight/SayItRight.xcodeproj/project.pbxproj
+++ b/app/SayItRight/SayItRight.xcodeproj/project.pbxproj
@@ -62,6 +62,7 @@
 		2D80A3F94A0B23AF02D04401 /* EvaluationResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 238EF463FFDCF9B00EC4123A /* EvaluationResult.swift */; };
 		2DDE080F3029A0750773ED22 /* BarbaraVoiceProfileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A6B15AE1ED645EEDFCA7DF5 /* BarbaraVoiceProfileTests.swift */; };
 		2F52829C24DE0D1E7D980EB2 /* FirstLaunchSetupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E493E1B347AC7D15C639949F /* FirstLaunchSetupView.swift */; };
+		32A7C946EE1DBD9A38776B96 /* SentenceDiff.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6F5A6679EC9EA0FDF699347 /* SentenceDiff.swift */; };
 		32D5314255E68AE513C355B9 /* StreamingTTSCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DF0427FCB8E6843FA1E136B /* StreamingTTSCoordinatorTests.swift */; };
 		33274CD62BE5B41D80760AC0 /* SystemPromptAssemblerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65A78B634A6D6F9D4CD57BC7 /* SystemPromptAssemblerTests.swift */; };
 		33D64B1F80E3DC6DAB7F372D /* AnswerKeyComparison.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1910976EBE55B2D0A2B347CA /* AnswerKeyComparison.swift */; };
@@ -152,6 +153,7 @@
 		8D0594B48254C2F95AB7F9F3 /* LearnerAvatar.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE528A4BB6F7C58BD0CC3708 /* LearnerAvatar.swift */; };
 		8DE0054F17D7F85924AFAA02 /* SeenTextsTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C3D288AEDB1EF42A2CF3455 /* SeenTextsTracker.swift */; };
 		8E8D202555A73B2756F2EBB0 /* TTSPlaybackService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4F296F432E8A069994E5167 /* TTSPlaybackService.swift */; };
+		8F2A3431111B3072FE14DE79 /* RevisionDiffView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92030535097EE61AEB0991D5 /* RevisionDiffView.swift */; };
 		901D104DC385EA8F6044D909 /* DraggableBlockView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4373E47CEF1B184CF62920CB /* DraggableBlockView.swift */; };
 		908ED70F336A90E3DBF4E198 /* AnthropicServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F77568CC779F6818DEF9ADCC /* AnthropicServiceTests.swift */; };
 		93FD1F354940149B9002ABA4 /* StreamingTTSCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B930A94D3E14C1EBF3EDBB7 /* StreamingTTSCoordinator.swift */; };
@@ -170,6 +172,7 @@
 		A21F3D22008E858CE7D1DE45 /* PracticeTextLibrary_de.json in Resources */ = {isa = PBXBuildFile; fileRef = BEE1CAA3817E82AA6D53AF15 /* PracticeTextLibrary_de.json */; };
 		A4A0DD5041F5926F318A2BB6 /* AnalyseMyTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9386A4C1CF530878ECC12755 /* AnalyseMyTextView.swift */; };
 		A4A5E4A6E927A6FF4AE200B1 /* AnswerKeyComparer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AEAE8216CAB132332EE8012 /* AnswerKeyComparer.swift */; };
+		A537EB5EBAE43CD551E1157D /* SentenceDiffTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 897590D408780860448C0A3D /* SentenceDiffTests.swift */; };
 		A5F6092C5DBADDBDC55A732F /* FeedbackBubbleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A30E1A80DC1D1B71AF67390 /* FeedbackBubbleView.swift */; };
 		A632A75DC9C01E1B20BFD9B0 /* SessionHistoryStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E96E00792CE206BD08DE44C1 /* SessionHistoryStore.swift */; };
 		A6AC757407E2F30AB816970C /* MECEValidationEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D07B7B9E84CD6DF8BC6ACCF /* MECEValidationEngineTests.swift */; };
@@ -232,6 +235,7 @@
 		CFD488522376107A7697D0ED /* SessionHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79103E672E97A7B33767ED30 /* SessionHistoryView.swift */; };
 		D18F59F6E50DE4B10D1B6929 /* SayItClearlySessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9512DE8E01F6C1AB4E4B8C /* SayItClearlySessionTests.swift */; };
 		D3070A5C5100B0857F8ACA4B /* AdaptiveDifficultyEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35D136B15681796D9B441FCE /* AdaptiveDifficultyEngine.swift */; };
+		D321D148DA9BEB7DF0CB1209 /* SentenceDiffTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 897590D408780860448C0A3D /* SentenceDiffTests.swift */; };
 		D3A1BF1A3B70AAF52594F570 /* NetworkErrorHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F95CF0998D962402B03233 /* NetworkErrorHandlerTests.swift */; };
 		D43F8B89B23167F2FA4EE2A2 /* MockSpeechRecognitionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A734FF80156849AAC5CD69 /* MockSpeechRecognitionService.swift */; };
 		D55641BDCB16A06138C8F443 /* SeenTextsTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C3D288AEDB1EF42A2CF3455 /* SeenTextsTracker.swift */; };
@@ -239,6 +243,8 @@
 		D694E416EBC8627305D26DF2 /* TextDifficultyCalibrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4CF3E7C70F0FAB82378322A /* TextDifficultyCalibrator.swift */; };
 		D6A8A7F9EE4233595988BFA7 /* SayItClearlyCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F909A7D8C8D301AFFA580B6 /* SayItClearlyCoordinator.swift */; };
 		D6CD1F94E1C2E57A0888230E /* FirstLaunchSetupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C278322C149174D648ECF14 /* FirstLaunchSetupTests.swift */; };
+		D74B3E49DCE283F274B0FAE0 /* SentenceDiff.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6F5A6679EC9EA0FDF699347 /* SentenceDiff.swift */; };
+		D895EB4DE625E96EF1AC8F4F /* RevisionDiffView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92030535097EE61AEB0991D5 /* RevisionDiffView.swift */; };
 		DC8CB9656F62B3F2E9C313EE /* FeedbackBubbleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A92CDDC30DF529F4F6E693B /* FeedbackBubbleTests.swift */; };
 		DD46000474FB0168BB12A02E /* AnalyseMyTextSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 652143071B4E57A9035FE43B /* AnalyseMyTextSessionTests.swift */; };
 		DDD2F11F3AD9916F6E39F996 /* AppLanguage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1607A6E887C79A834F460459 /* AppLanguage.swift */; };
@@ -394,9 +400,11 @@
 		8309BF4EE774FABE588555F4 /* MicrophoneButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicrophoneButton.swift; sourceTree = "<group>"; };
 		86E2D821520E6552AE4B65B7 /* SayItRightTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = SayItRightTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		87C3E174CED5835D593C922D /* Config.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Config.plist; sourceTree = "<group>"; };
+		897590D408780860448C0A3D /* SentenceDiffTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentenceDiffTests.swift; sourceTree = "<group>"; };
 		8AB92388718B19A2E45FBDC1 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		8D20FDE7D46349EC7346DA67 /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
 		91ECF5F1EF7623373F5BBD2C /* NetworkErrorHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkErrorHandler.swift; sourceTree = "<group>"; };
+		92030535097EE61AEB0991D5 /* RevisionDiffView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RevisionDiffView.swift; sourceTree = "<group>"; };
 		9386A4C1CF530878ECC12755 /* AnalyseMyTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyseMyTextView.swift; sourceTree = "<group>"; };
 		942B7D62D7DC6CDF6EE5C3AD /* BarbaraMood.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarbaraMood.swift; sourceTree = "<group>"; };
 		95D3FAF0967C63A54E2C6E51 /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
@@ -432,6 +440,7 @@
 		C28CC98EB4FCDC9137D15433 /* AnthropicService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnthropicService.swift; sourceTree = "<group>"; };
 		C347D7912E827154F7F23208 /* PracticeTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticeTextView.swift; sourceTree = "<group>"; };
 		C3915AE540EBA11321FA76BB /* ConnectionLinesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionLinesView.swift; sourceTree = "<group>"; };
+		C6F5A6679EC9EA0FDF699347 /* SentenceDiff.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentenceDiff.swift; sourceTree = "<group>"; };
 		C70ADBF790944D3353F4FA32 /* PracticeTextLibraryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticeTextLibraryTests.swift; sourceTree = "<group>"; };
 		C7729E7948C0195AF7F2023B /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
 		C7A0D6917A3C05487B814E35 /* MessageBubbleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageBubbleView.swift; sourceTree = "<group>"; };
@@ -670,6 +679,7 @@
 				C8D179C236AD14B5C8076627 /* ResponseParserTests.swift */,
 				2C9512DE8E01F6C1AB4E4B8C /* SayItClearlySessionTests.swift */,
 				E399297963E1A59A4C958BFA /* SeenTextsTests.swift */,
+				897590D408780860448C0A3D /* SentenceDiffTests.swift */,
 				D693A9655797CEF326A8BA1C /* SessionHistoryTests.swift */,
 				57ACC716C56B7F8E16DBDFB3 /* SessionManagerTests.swift */,
 				1161CE00FACCF6715D7034A1 /* SidebarViewTests.swift */,
@@ -724,6 +734,7 @@
 				DC11499E66D1CCC6F0EDB5EE /* ComparisonResponseParser.swift */,
 				238EF463FFDCF9B00EC4123A /* EvaluationResult.swift */,
 				64BCF114772DA58597F6EC7A /* MECEValidationEngine.swift */,
+				C6F5A6679EC9EA0FDF699347 /* SentenceDiff.swift */,
 				11A375822F278D205A1F9090 /* StructuralEvaluator.swift */,
 			);
 			path = StructuralEvaluator;
@@ -862,6 +873,7 @@
 				1B08B6C7C928249161C6C0AC /* ParentSettingsView.swift */,
 				9A0B8EDE7E53601DCAC1DB42 /* PINEntryView.swift */,
 				C347D7912E827154F7F23208 /* PracticeTextView.swift */,
+				92030535097EE61AEB0991D5 /* RevisionDiffView.swift */,
 				47BCCF7B7169BFF3B4722C58 /* SayItClearlyView.swift */,
 				9A466760C86E7CBA8E140814 /* SessionPickerView.swift */,
 				8AB92388718B19A2E45FBDC1 /* SettingsView.swift */,
@@ -1048,6 +1060,7 @@
 				812AC213EB49FEC705555E09 /* ResponseParserTests.swift in Sources */,
 				1851700C174060BC3AC3208C /* SayItClearlySessionTests.swift in Sources */,
 				EC8D5C128F51D0CCF602CE9D /* SeenTextsTests.swift in Sources */,
+				A537EB5EBAE43CD551E1157D /* SentenceDiffTests.swift in Sources */,
 				00A617235833FE856DAFE447 /* SessionHistoryTests.swift in Sources */,
 				37C28646E0EEDAC5D185ADC7 /* SessionManagerTests.swift in Sources */,
 				25C8BCA79939B0F44945A97F /* SidebarViewTests.swift in Sources */,
@@ -1093,6 +1106,7 @@
 				E2E771E2E6E4B969403D183A /* ResponseParserTests.swift in Sources */,
 				D18F59F6E50DE4B10D1B6929 /* SayItClearlySessionTests.swift in Sources */,
 				3C3D496429C02F2A19997126 /* SeenTextsTests.swift in Sources */,
+				D321D148DA9BEB7DF0CB1209 /* SentenceDiffTests.swift in Sources */,
 				2C83ABF0241F42C8239A5DB3 /* SessionHistoryTests.swift in Sources */,
 				3D30DF4F7A2D515EBD37FF5F /* SessionManagerTests.swift in Sources */,
 				BC6395CBB992EB5D23FEB685 /* SidebarViewTests.swift in Sources */,
@@ -1179,12 +1193,14 @@
 				531F7C8788BD0D599A7E8D04 /* PyramidFeedbackOverlay.swift in Sources */,
 				CE49D1EC9F14EE85575FA236 /* PyramidTreeState.swift in Sources */,
 				033B5DE1A4166D33D74334B9 /* ResponseParser.swift in Sources */,
+				D895EB4DE625E96EF1AC8F4F /* RevisionDiffView.swift in Sources */,
 				CBA2E68B2CD7D99D6220EB03 /* SayItClearlyCoordinator.swift in Sources */,
 				1FD2F0E1A94E7F60D96B6601 /* SayItClearlySession.swift in Sources */,
 				803EEA750EBA59009E814F7C /* SayItClearlyView.swift in Sources */,
 				3A691C0923E2348327202674 /* SayItRightApp.swift in Sources */,
 				17805A9B8E4E6A4F93F3D8A5 /* SeenTextsStore.swift in Sources */,
 				D55641BDCB16A06138C8F443 /* SeenTextsTracker.swift in Sources */,
+				32A7C946EE1DBD9A38776B96 /* SentenceDiff.swift in Sources */,
 				5065401FEFC87872EDCF1B5F /* SessionHistoryStore.swift in Sources */,
 				CE5B36B251DCE97CBA0D847C /* SessionHistoryView.swift in Sources */,
 				E4C81D76331F3F76AE3D62DC /* SessionManager.swift in Sources */,
@@ -1281,12 +1297,14 @@
 				C7AD8CE9CD5E3BC3C1568459 /* PyramidFeedbackOverlay.swift in Sources */,
 				FC483FFC26C8467FF1807413 /* PyramidTreeState.swift in Sources */,
 				5F51449B08403989803DD749 /* ResponseParser.swift in Sources */,
+				8F2A3431111B3072FE14DE79 /* RevisionDiffView.swift in Sources */,
 				D6A8A7F9EE4233595988BFA7 /* SayItClearlyCoordinator.swift in Sources */,
 				CBB14ED4FCF8AF6C0D25CA19 /* SayItClearlySession.swift in Sources */,
 				1460EBA977EDC2340452180C /* SayItClearlyView.swift in Sources */,
 				75AE4B49A8AA6C07DFCFE084 /* SayItRightApp.swift in Sources */,
 				81E23FA9C56B29B66E3ECD13 /* SeenTextsStore.swift in Sources */,
 				8DE0054F17D7F85924AFAA02 /* SeenTextsTracker.swift in Sources */,
+				D74B3E49DCE283F274B0FAE0 /* SentenceDiff.swift in Sources */,
 				A632A75DC9C01E1B20BFD9B0 /* SessionHistoryStore.swift in Sources */,
 				CFD488522376107A7697D0ED /* SessionHistoryView.swift in Sources */,
 				E30210DD8492DB766516661E /* SessionManager.swift in Sources */,

--- a/app/SayItRight/Tests/SentenceDiffTests.swift
+++ b/app/SayItRight/Tests/SentenceDiffTests.swift
@@ -1,0 +1,91 @@
+import Foundation
+import Testing
+@testable import SayItRight
+
+@Suite("SentenceDiff")
+struct SentenceDiffTests {
+
+    @Test("Identical texts have no structural changes")
+    func identicalTexts() {
+        let result = SentenceDiff.compare(
+            original: "Schools should start later. Students need sleep.",
+            revised: "Schools should start later. Students need sleep."
+        )
+        #expect(!result.hasStructuralChanges)
+        #expect(result.original.allSatisfy { $0.status == .kept })
+        #expect(result.revised.allSatisfy { $0.status == .kept })
+    }
+
+    @Test("Added sentence detected")
+    func addedSentence() {
+        let result = SentenceDiff.compare(
+            original: "Schools should start later.",
+            revised: "Schools should start later. This helps academic performance."
+        )
+        #expect(result.hasStructuralChanges)
+        #expect(result.revised.contains { $0.status == .added })
+    }
+
+    @Test("Removed sentence detected")
+    func removedSentence() {
+        let result = SentenceDiff.compare(
+            original: "Schools should start later. There are many reasons for this.",
+            revised: "Schools should start later."
+        )
+        #expect(result.hasStructuralChanges)
+        #expect(result.original.contains { $0.status == .removed })
+    }
+
+    @Test("Moved sentence detected")
+    func movedSentence() {
+        let result = SentenceDiff.compare(
+            original: "There are many reasons. The main point is this. Evidence supports it.",
+            revised: "The main point is this. There are many reasons. Evidence supports it."
+        )
+        #expect(result.hasStructuralChanges)
+        #expect(result.original.contains { $0.status == .moved })
+        #expect(result.revised.contains { $0.status == .moved })
+    }
+
+    @Test("Split sentences handles standard punctuation")
+    func splitSentences() {
+        let sentences = SentenceDiff.splitSentences(
+            "First sentence. Second sentence! Third sentence?"
+        )
+        #expect(sentences.count == 3)
+    }
+
+    @Test("Normalise collapses whitespace and lowercases")
+    func normalise() {
+        let result = SentenceDiff.normalise("  Hello   WORLD  ")
+        #expect(result == "hello world")
+    }
+
+    @Test("Case-insensitive matching")
+    func caseInsensitive() {
+        let result = SentenceDiff.compare(
+            original: "Schools Should Start Later.",
+            revised: "schools should start later."
+        )
+        #expect(!result.hasStructuralChanges)
+    }
+
+    @Test("Empty texts produce no entries")
+    func emptyTexts() {
+        let result = SentenceDiff.compare(original: "", revised: "")
+        #expect(result.original.isEmpty)
+        #expect(result.revised.isEmpty)
+        #expect(!result.hasStructuralChanges)
+    }
+
+    @Test("Complete rewrite marks all as removed and added")
+    func completeRewrite() {
+        let result = SentenceDiff.compare(
+            original: "Old content here. Another old sentence.",
+            revised: "Completely new content. Different structure entirely."
+        )
+        #expect(result.hasStructuralChanges)
+        #expect(result.original.allSatisfy { $0.status == .removed })
+        #expect(result.revised.allSatisfy { $0.status == .added })
+    }
+}


### PR DESCRIPTION
## Summary
- Add `SentenceDiff` engine for sentence-level structural diff (kept/added/removed/moved)
- Add `RevisionDiffView` with platform-adaptive display (side-by-side on iPad/Mac, segmented toggle on iPhone)
- Colour-coded highlighting: green=added, red=removed, purple=moved
- Legend and "no changes detected" empty state

Closes #38

## Test plan
- [x] 554 tests pass (9 new: identical, added, removed, moved, rewrite, normalisation, case-insensitive)
- [x] Build succeeds on macOS
- [x] Previews for improved, minimal, unchanged, German, iPad layouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)