### PR TITLE
feat: add 3-tier progressive hint system for Spot The Gap (SIR-047)

### DIFF
--- a/app/SayItRight/Content/PracticeTexts/PracticeText.swift
+++ b/app/SayItRight/Content/PracticeTexts/PracticeText.swift
@@ -20,6 +20,25 @@ struct StructuralFlaw: Codable, Sendable, Equatable {
     let description: String
     /// Where in the text the flaw occurs (e.g. "paragraph 2", "support pillar 3").
     let location: String
+    /// Progressive hint tiers for "Spot the gap" exercises.
+    let hints: HintTiers?
+
+    init(type: String, description: String, location: String, hints: HintTiers? = nil) {
+        self.type = type
+        self.description = description
+        self.location = location
+        self.hints = hints
+    }
+}
+
+/// 3-tier progressive hints for structural flaw identification.
+struct HintTiers: Codable, Sendable, Equatable {
+    /// Tier 1: General area hint (e.g., "Look at the grouping").
+    let tier1: String
+    /// Tier 2: Specific element hint (e.g., "Compare support B and C").
+    let tier2: String
+    /// Tier 3: Full reveal with explanation.
+    let tier3: String
 }
 
 /// Answer key for a practice text, describing its pyramid structure.

--- a/app/SayItRight/Intelligence/ConversationManager/SessionManager.swift
+++ b/app/SayItRight/Intelligence/ConversationManager/SessionManager.swift
@@ -551,15 +551,30 @@ final class SessionManager {
         Description: \(flaw?.description ?? "No flaw description")
         Location: \(flaw?.location ?? "unspecified")
 
+        ## Progressive Hint System (3 tiers)
+        When the learner misidentifies the flaw, provide progressively specific hints:
+
+        ### After attempt 1 (Tier 1 — general area):
+        \(flaw?.hints?.tier1 ?? "Hint: identify the general structural area (grouping, evidence, conclusion) where the problem lies. Do NOT name the specific flaw.")
+
+        ### After attempt 2 (Tier 2 — specific element):
+        \(flaw?.hints?.tier2 ?? "Hint: narrow to the specific support group or evidence item. Compare specific elements.")
+
+        ### After attempt 3 (Tier 3 — full reveal):
+        \(flaw?.hints?.tier3 ?? "Reveal the flaw with a full structural explanation. Explain WHY it's a flaw and what correct structure would look like.")
+
         ## Evaluation Guidelines
         - The learner has up to 3 attempts to identify the flaw.
-        - If they identify it correctly: confirm with a detailed explanation.
-        - If they misidentify: acknowledge any valid observations but redirect. \
-        Say "Good eye, but that's not the main problem. Keep looking."
-        - After 3 failed attempts: reveal the flaw with a teaching explanation.
+        - If they identify it correctly at any point: confirm with a detailed explanation.
+        - If they misidentify: acknowledge any valid observations, then deliver the \
+        appropriate tier hint. Say "Good eye, but that's not the main problem." then \
+        give the hint for their current tier.
+        - After 3 failed attempts: use Tier 3 to reveal the flaw with a teaching explanation.
         - Only evaluate STRUCTURAL flaws — not content disagreements.
         - Valid flaw identifications don't need to match the exact wording, \
         just the structural concept.
+        - Hints teach the NARROWING methodology: area → element → specific. \
+        This narrowing process IS the skill being taught.
         """
     }
 

--- a/app/SayItRight/Intelligence/ConversationManager/SpotTheGapSession.swift
+++ b/app/SayItRight/Intelligence/ConversationManager/SpotTheGapSession.swift
@@ -49,4 +49,24 @@ struct SpotTheGapSession: Sendable {
 
     /// Whether this text has a known structural flaw.
     var hasKnownFlaw: Bool { structuralFlaw != nil }
+
+    /// Current hint tier (0 = no hints given, 1-3 = tiers given).
+    var currentHintTier: Int { min(attemptCount, 3) }
+
+    /// The hint for the current tier, if pre-generated hints are available.
+    var currentHint: String? {
+        guard let hints = structuralFlaw?.hints else { return nil }
+        switch currentHintTier {
+        case 1: return hints.tier1
+        case 2: return hints.tier2
+        case 3: return hints.tier3
+        default: return nil
+        }
+    }
+
+    /// Whether the flaw has been revealed (tier 3 reached).
+    var isFlawRevealed: Bool { currentHintTier >= 3 }
+
+    /// Whether pre-generated hints are available.
+    var hasPreGeneratedHints: Bool { structuralFlaw?.hints != nil }
 }

--- a/app/SayItRight/SayItRight.xcodeproj/project.pbxproj
+++ b/app/SayItRight/SayItRight.xcodeproj/project.pbxproj
@@ -133,6 +133,7 @@
 		673457079BE69921EBC15164 /* SessionSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABF4D8A07EE48301BBF12A0C /* SessionSummary.swift */; };
 		68324B657FD362B1C2BDBE57 /* CelebrationEffectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D24253A3138E22C5ED601F03 /* CelebrationEffectView.swift */; };
 		6862FA1CB7124F4D08390F6B /* PracticeTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C347D7912E827154F7F23208 /* PracticeTextView.swift */; };
+		68E0AB7B44A15E47662CBAC4 /* SpotTheGapHintTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBB5356B054475EC18A358C6 /* SpotTheGapHintTests.swift */; };
 		691C23DCCF2C5FE4EB2B14CB /* ConnectionLinesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2ED4B98BAC3EA13F5C61CBCD /* ConnectionLinesTests.swift */; };
 		694D7A17D77BC80EF7C0DFE6 /* AppSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81A63E61EA4ABC850E93CB2E /* AppSettings.swift */; };
 		69648C78907876EC6BDB6892 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB92388718B19A2E45FBDC1 /* SettingsView.swift */; };
@@ -201,6 +202,7 @@
 		A9B7342D214CE45653F5BAB3 /* LearnerAvatar.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE528A4BB6F7C58BD0CC3708 /* LearnerAvatar.swift */; };
 		A9BA44DA0F1F2B687C7EB602 /* AnthropicModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10F6CAB4EBA45B17A293C4C0 /* AnthropicModel.swift */; };
 		A9C54D9E4FC609C3A85D553B /* DimensionBarChartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64F1F5B0738E60E8163A2FDB /* DimensionBarChartView.swift */; };
+		AD8F19056F59A9446FB10082 /* SpotTheGapHintTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBB5356B054475EC18A358C6 /* SpotTheGapHintTests.swift */; };
 		AD9D198E44358F88EF30E30B /* StructuralEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11A375822F278D205A1F9090 /* StructuralEvaluator.swift */; };
 		AE1A15A7E561DB90F19FF361 /* ElevatorPitchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCC9887FA1B8FA6F1AF29DAE /* ElevatorPitchView.swift */; };
 		AE5F4FDA4052322F82140791 /* ValidationFeedbackModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BCC3E8C4CBE011C33FC740B /* ValidationFeedbackModifier.swift */; };
@@ -505,6 +507,7 @@
 		E53301B75E9027FAD04FAA44 /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
 		E96E00792CE206BD08DE44C1 /* SessionHistoryStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionHistoryStore.swift; sourceTree = "<group>"; };
 		EA32E530E1641F627E7C5970 /* BlockFeedbackState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockFeedbackState.swift; sourceTree = "<group>"; };
+		EBB5356B054475EC18A358C6 /* SpotTheGapHintTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotTheGapHintTests.swift; sourceTree = "<group>"; };
 		ED72B2F78895FD96D69C5698 /* AudioSessionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioSessionManager.swift; sourceTree = "<group>"; };
 		F2A6B03C9A74B0140D2B2BE7 /* AnswerKeyComparisonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnswerKeyComparisonTests.swift; sourceTree = "<group>"; };
 		F3E7290B780810CAE4428003 /* StructuralEvaluatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StructuralEvaluatorTests.swift; sourceTree = "<group>"; };
@@ -726,6 +729,7 @@
 				57ACC716C56B7F8E16DBDFB3 /* SessionManagerTests.swift */,
 				1161CE00FACCF6715D7034A1 /* SidebarViewTests.swift */,
 				3D57221714F45B9C00201617 /* SpeechRecognitionServiceTests.swift */,
+				EBB5356B054475EC18A358C6 /* SpotTheGapHintTests.swift */,
 				7D6E766B91AF9A75C1FBD2F7 /* SpotTheGapSessionTests.swift */,
 				5E4E18B61DA2D4BD3AB29AD9 /* StreamingSentenceDetectorTests.swift */,
 				2DF0427FCB8E6843FA1E136B /* StreamingTTSCoordinatorTests.swift */,
@@ -1115,6 +1119,7 @@
 				37C28646E0EEDAC5D185ADC7 /* SessionManagerTests.swift in Sources */,
 				25C8BCA79939B0F44945A97F /* SidebarViewTests.swift in Sources */,
 				33D97DD448F0E5566052D4BC /* SpeechRecognitionServiceTests.swift in Sources */,
+				68E0AB7B44A15E47662CBAC4 /* SpotTheGapHintTests.swift in Sources */,
 				135CB2AD458844ACF2E1688D /* SpotTheGapSessionTests.swift in Sources */,
 				26EF845803D483A39BCEA37B /* StreamingSentenceDetectorTests.swift in Sources */,
 				5DA2F76EA751F3EF0CB55386 /* StreamingTTSCoordinatorTests.swift in Sources */,
@@ -1164,6 +1169,7 @@
 				3D30DF4F7A2D515EBD37FF5F /* SessionManagerTests.swift in Sources */,
 				BC6395CBB992EB5D23FEB685 /* SidebarViewTests.swift in Sources */,
 				EE7B786DFC8E07B8C334D925 /* SpeechRecognitionServiceTests.swift in Sources */,
+				AD8F19056F59A9446FB10082 /* SpotTheGapHintTests.swift in Sources */,
 				5C86D9DAEC72EF9310D070CF /* SpotTheGapSessionTests.swift in Sources */,
 				2979108A06095D07DB94AC91 /* StreamingSentenceDetectorTests.swift in Sources */,
 				32D5314255E68AE513C355B9 /* StreamingTTSCoordinatorTests.swift in Sources */,

--- a/app/SayItRight/Tests/SpotTheGapHintTests.swift
+++ b/app/SayItRight/Tests/SpotTheGapHintTests.swift
@@ -1,0 +1,142 @@
+import Foundation
+import Testing
+@testable import SayItRight
+
+@Suite("SpotTheGapSession — Hints")
+struct SpotTheGapHintTests {
+
+    private static func makeFlawWithHints() -> StructuralFlaw {
+        StructuralFlaw(
+            type: "misaligned_evidence",
+            description: "Support B's evidence doesn't support Support B's claim.",
+            location: "support group B",
+            hints: HintTiers(
+                tier1: "The problem isn't in the conclusion. Look at the supporting evidence.",
+                tier2: "Compare the evidence under Support B to its label. Does the evidence actually support that claim?",
+                tier3: "Support B claims 'wind creates jobs' but the evidence talks about solar panel manufacturing costs. The evidence is misaligned — it belongs under a different support group."
+            )
+        )
+    }
+
+    private static func makeText(withHints: Bool = true) -> PracticeText {
+        PracticeText(
+            id: "pt-hint-test",
+            text: "Renewable energy is the future. Solar is cheap. Wind creates jobs. Therefore we should switch.",
+            answerKey: AnswerKey(
+                governingThought: "Renewable energy is the future.",
+                supports: [
+                    SupportGroup(label: "Cost", evidence: ["Solar is cheap"]),
+                    SupportGroup(label: "Jobs", evidence: ["Wind creates jobs"]),
+                ],
+                structuralAssessment: "Misaligned evidence in support B.",
+                structuralFlaw: withHints ? makeFlawWithHints() : StructuralFlaw(
+                    type: "misaligned_evidence",
+                    description: "Evidence misaligned.",
+                    location: "support B"
+                )
+            ),
+            metadata: PracticeTextMetadata(
+                qualityLevel: .adversarial,
+                difficultyRating: 4,
+                topicDomain: "society",
+                language: "en",
+                wordCount: 18,
+                targetLevel: 2
+            )
+        )
+    }
+
+    @Test("Hint tier advances with attempts")
+    func hintTierProgression() {
+        var session = SpotTheGapSession(practiceText: Self.makeText())
+
+        #expect(session.currentHintTier == 0)
+
+        session.recordAttempt("Wrong guess 1")
+        #expect(session.currentHintTier == 1)
+        #expect(session.currentHint?.contains("conclusion") == true)
+
+        session.recordAttempt("Wrong guess 2")
+        #expect(session.currentHintTier == 2)
+        #expect(session.currentHint?.contains("Support B") == true)
+
+        session.recordAttempt("Wrong guess 3")
+        #expect(session.currentHintTier == 3)
+        #expect(session.isFlawRevealed)
+        #expect(session.currentHint?.contains("misaligned") == true)
+    }
+
+    @Test("Session without pre-generated hints returns nil")
+    func noPreGeneratedHints() {
+        var session = SpotTheGapSession(practiceText: Self.makeText(withHints: false))
+        #expect(!session.hasPreGeneratedHints)
+
+        session.recordAttempt("Guess")
+        #expect(session.currentHint == nil)
+    }
+
+    @Test("Has pre-generated hints flag")
+    func hasHintsFlag() {
+        let session = SpotTheGapSession(practiceText: Self.makeText(withHints: true))
+        #expect(session.hasPreGeneratedHints)
+    }
+
+    @Test("Flaw not revealed until tier 3")
+    func flawNotRevealedEarly() {
+        var session = SpotTheGapSession(practiceText: Self.makeText())
+        #expect(!session.isFlawRevealed)
+
+        session.recordAttempt("Attempt 1")
+        #expect(!session.isFlawRevealed)
+
+        session.recordAttempt("Attempt 2")
+        #expect(!session.isFlawRevealed)
+
+        session.recordAttempt("Attempt 3")
+        #expect(session.isFlawRevealed)
+    }
+}
+
+@Suite("HintTiers")
+struct HintTiersTests {
+
+    @Test("HintTiers is Codable")
+    func codableRoundTrip() throws {
+        let hints = HintTiers(
+            tier1: "Look at the grouping.",
+            tier2: "Compare groups B and C.",
+            tier3: "Groups B and C overlap — they're not MECE."
+        )
+        let data = try JSONEncoder().encode(hints)
+        let decoded = try JSONDecoder().decode(HintTiers.self, from: data)
+        #expect(decoded == hints)
+    }
+
+    @Test("StructuralFlaw with hints is Codable")
+    func flawWithHintsCodable() throws {
+        let flaw = StructuralFlaw(
+            type: "missing_group",
+            description: "A key support group is missing.",
+            location: "overall structure",
+            hints: HintTiers(
+                tier1: "Something is missing.",
+                tier2: "Count the support groups.",
+                tier3: "The economic argument has no support group."
+            )
+        )
+        let data = try JSONEncoder().encode(flaw)
+        let decoded = try JSONDecoder().decode(StructuralFlaw.self, from: data)
+        #expect(decoded == flaw)
+        #expect(decoded.hints?.tier1 == "Something is missing.")
+    }
+
+    @Test("StructuralFlaw without hints is backward compatible")
+    func flawWithoutHints() throws {
+        let json = """
+        {"type":"gap","description":"A gap","location":"here"}
+        """
+        let flaw = try JSONDecoder().decode(StructuralFlaw.self, from: Data(json.utf8))
+        #expect(flaw.hints == nil)
+        #expect(flaw.type == "gap")
+    }
+}


### PR DESCRIPTION
## Summary
- Add `HintTiers` struct (tier1/tier2/tier3) to `StructuralFlaw`
- `SpotTheGapSession` tracks hint tier progression and reveals hints per attempt
- System prompt directive includes progressive hint instructions per tier
- Backward compatible: hints are optional in `StructuralFlaw`
- 7 new tests for hint progression, codable round-trips, backward compatibility

Closes #47

## Test plan
- [x] 589 tests pass (7 new)
- [x] Build succeeds on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)