### PR TITLE
feat: Break mode profile integration (SIR-051)

### DIFF
--- a/app/SayItRight/Content/PracticeTexts/TextDifficultyCalibrator.swift
+++ b/app/SayItRight/Content/PracticeTexts/TextDifficultyCalibrator.swift
@@ -11,10 +11,8 @@ struct TextDifficultyCalibrator: Sendable {
     /// Rolling average threshold above which L2 users unlock adversarial texts.
     static let highScoreThreshold: Double = 0.75
 
-    /// Break-mode dimension keys used to compute the rolling average.
-    static let breakDimensions: [String] = [
-        "governing_thought", "support_grouping", "clarity"
-    ]
+    /// Break-mode dimension keys used to compute the rolling average for adversarial unlocking.
+    static let breakDimensions: [String] = ProfileUpdater.breakDimensions
 
     /// Fraction of results that should be at the learner's current difficulty band.
     static let currentDifficultyWeight: Double = 0.60

--- a/app/SayItRight/Content/ProgressionCriteria/ProgressionCriteria.swift
+++ b/app/SayItRight/Content/ProgressionCriteria/ProgressionCriteria.swift
@@ -31,14 +31,16 @@ struct ProgressionCriteria: Sendable {
         LevelCriteria(
             fromLevel: 2,
             minDimensionAverage: 0.75,
-            requiredDimensions: ["l1Gate", "meceQuality", "orderingLogic", "scqApplication", "horizontalLogic"],
+            requiredDimensions: ["l1Gate", "meceQuality", "orderingLogic", "scqApplication", "horizontalLogic",
+                                 "extractionAccuracy", "flawIdentification", "restructuringQuality"],
             minConsecutiveQualifying: 5,
             minTotalSessions: 10
         ),
         LevelCriteria(
             fromLevel: 3,
             minDimensionAverage: 0.80,
-            requiredDimensions: ["l1Gate", "meceQuality", "orderingLogic", "scqApplication", "horizontalLogic"],
+            requiredDimensions: ["l1Gate", "meceQuality", "orderingLogic", "scqApplication", "horizontalLogic",
+                                 "extractionAccuracy", "flawIdentification", "restructuringQuality"],
             minConsecutiveQualifying: 7,
             minTotalSessions: 15
         ),

--- a/app/SayItRight/Intelligence/StructuralEvaluator/AdaptiveDifficultyEngine.swift
+++ b/app/SayItRight/Intelligence/StructuralEvaluator/AdaptiveDifficultyEngine.swift
@@ -143,16 +143,16 @@ struct AdaptiveDifficultyEngine: Sendable {
 
     // MARK: - Private Helpers
 
-    /// Key dimensions evaluated at each level.
+    /// Key dimensions evaluated at each level (Build + Break).
     static func dimensionsForLevel(_ level: Int) -> [String] {
         switch level {
         case 1:
-            return ["governingThought", "supportGrouping", "redundancy", "clarity"]
+            return ProfileUpdater.buildDimensionsL1
         case 2:
-            return ["l1Gate", "meceQuality", "orderingLogic", "scqApplication", "horizontalLogic"]
+            return ProfileUpdater.buildDimensionsL2 + ProfileUpdater.breakDimensions
         default:
-            // L3+ includes all L2 dimensions (L3-specific dimensions not yet implemented)
-            return ["l1Gate", "meceQuality", "orderingLogic", "scqApplication", "horizontalLogic"]
+            // L3+ includes all L2 Build + Break dimensions
+            return ProfileUpdater.buildDimensionsL2 + ProfileUpdater.breakDimensions
         }
     }
 

--- a/app/SayItRight/Presentation/Dashboard/DimensionBarChartView.swift
+++ b/app/SayItRight/Presentation/Dashboard/DimensionBarChartView.swift
@@ -80,6 +80,10 @@ struct DimensionBarChartView: View {
             "orderingLogic": ("Ordering logic", "Ordnungslogik"),
             "scqApplication": ("SCQ framing", "SCQ-Rahmen"),
             "horizontalLogic": ("Horizontal logic", "Horizontale Logik"),
+            // Break mode dimensions
+            "extractionAccuracy": ("Extracting structure", "Struktur erkennen"),
+            "flawIdentification": ("Finding structural flaws", "Strukturelle Fehler finden"),
+            "restructuringQuality": ("Restructuring quality", "Qualität der Umstrukturierung"),
         ]
 
         if let name = names[dimension] {

--- a/app/SayItRight/SayItRight.xcodeproj/project.pbxproj
+++ b/app/SayItRight/SayItRight.xcodeproj/project.pbxproj
@@ -193,6 +193,7 @@
 		9E94F43764B254F793A66465 /* PINEntryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0B8EDE7E53601DCAC1DB42 /* PINEntryView.swift */; };
 		9F4591B7ECA4FB6CA5E1F133 /* SpotTheGapSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = D017723020F6F34961708FA5 /* SpotTheGapSession.swift */; };
 		9FF735052B95F66DE636AF76 /* FindThePointSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5FB097A1FAE84E286F0F1F6 /* FindThePointSession.swift */; };
+		A04684C5FA38C05AE7ADD9AB /* BreakModeProfileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72E114135776783B6B39A5FC /* BreakModeProfileTests.swift */; };
 		A0BC2607510CD45A0EB77F83 /* DecodeAndRebuildSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C1C17B6886769CDF1D032C0 /* DecodeAndRebuildSession.swift */; };
 		A14921A5A09F6F75BE93E7DD /* DecodeAndRebuildCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7457AD0D49EDBFFC9A164161 /* DecodeAndRebuildCoordinator.swift */; };
 		A21F3D22008E858CE7D1DE45 /* PracticeTextLibrary_de.json in Resources */ = {isa = PBXBuildFile; fileRef = BEE1CAA3817E82AA6D53AF15 /* PracticeTextLibrary_de.json */; };
@@ -235,6 +236,7 @@
 		BDF08178D405ECC24953BC24 /* SayItRight.xcodeproj in Resources */ = {isa = PBXBuildFile; fileRef = 3FAF495135EB918BBBE3A021 /* SayItRight.xcodeproj */; };
 		BE27D9D3A47875F43F2CB6FC /* ElevatorPitchSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B7D104D20992358220CF516 /* ElevatorPitchSession.swift */; };
 		BF7E68D87F7FE0DDCF4867D1 /* SystemPromptAssemblerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65A78B634A6D6F9D4CD57BC7 /* SystemPromptAssemblerTests.swift */; };
+		BFB0F3572A32CDAB2C8100FD /* BreakModeProfileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72E114135776783B6B39A5FC /* BreakModeProfileTests.swift */; };
 		BFEC1C8AE1C77FC5D94AB5B6 /* SystemPromptAssembler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4096FB5122C41B3F25CCFB2 /* SystemPromptAssembler.swift */; };
 		C00B6CA5143A309F86D4D506 /* BlockFeedbackState.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA32E530E1641F627E7C5970 /* BlockFeedbackState.swift */; };
 		C04A2190D8A20EA7838C2282 /* FixThisMessSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1023A980330BA11476479AC6 /* FixThisMessSessionTests.swift */; };
@@ -430,6 +432,7 @@
 		6BCBA23B5D640E11325097D0 /* KeychainService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainService.swift; sourceTree = "<group>"; };
 		70A1CB45AEA63A237D7499E4 /* SessionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionManager.swift; sourceTree = "<group>"; };
 		72D83F01BEC457D843FA46B2 /* PyramidTreeState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PyramidTreeState.swift; sourceTree = "<group>"; };
+		72E114135776783B6B39A5FC /* BreakModeProfileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BreakModeProfileTests.swift; sourceTree = "<group>"; };
 		7457AD0D49EDBFFC9A164161 /* DecodeAndRebuildCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecodeAndRebuildCoordinator.swift; sourceTree = "<group>"; };
 		761B9E06D45D03688B09D463 /* PracticeTextGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticeTextGeneratorTests.swift; sourceTree = "<group>"; };
 		76F67E39596D4AD4CCEAE6BB /* ElevatorPitchCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElevatorPitchCoordinator.swift; sourceTree = "<group>"; };
@@ -717,6 +720,7 @@
 				0D5A7EA09817CE62F1FE9796 /* AudioSessionManagerTests.swift */,
 				A553A59D04C7ABFA86CF117E /* BarbaraAvatarTests.swift */,
 				4A6B15AE1ED645EEDFCA7DF5 /* BarbaraVoiceProfileTests.swift */,
+				72E114135776783B6B39A5FC /* BreakModeProfileTests.swift */,
 				40319D5211156AC1671570F5 /* ChatViewTests.swift */,
 				2ED4B98BAC3EA13F5C61CBCD /* ConnectionLinesTests.swift */,
 				F311FDA056466909DBBC103C /* DecodeAndRebuildTests.swift */,
@@ -1109,6 +1113,7 @@
 				58C18276239608ABD6F07EBB /* AudioSessionManagerTests.swift in Sources */,
 				232A2240F8CDCBF5093977DA /* BarbaraAvatarTests.swift in Sources */,
 				2DDE080F3029A0750773ED22 /* BarbaraVoiceProfileTests.swift in Sources */,
+				BFB0F3572A32CDAB2C8100FD /* BreakModeProfileTests.swift in Sources */,
 				FB4A6CAC2211C3CE1456B0C4 /* ChatViewTests.swift in Sources */,
 				691C23DCCF2C5FE4EB2B14CB /* ConnectionLinesTests.swift in Sources */,
 				2BA09208E878385E27A82A73 /* DecodeAndRebuildTests.swift in Sources */,
@@ -1160,6 +1165,7 @@
 				60E3DD654D41C484DFD3281E /* AudioSessionManagerTests.swift in Sources */,
 				DE38095862958923B2416C42 /* BarbaraAvatarTests.swift in Sources */,
 				C6707E67B7475B58554F2F92 /* BarbaraVoiceProfileTests.swift in Sources */,
+				A04684C5FA38C05AE7ADD9AB /* BreakModeProfileTests.swift in Sources */,
 				56E59D06B02418F6D1057A03 /* ChatViewTests.swift in Sources */,
 				B6403B3CA71AF12E11A38232 /* ConnectionLinesTests.swift in Sources */,
 				C6A4492196A222A1E25F65CB /* DecodeAndRebuildTests.swift in Sources */,

--- a/app/SayItRight/State/LearnerProfile/ProfileUpdater.swift
+++ b/app/SayItRight/State/LearnerProfile/ProfileUpdater.swift
@@ -15,17 +15,38 @@ struct ProfileUpdater: Sendable {
     /// Rolling average below this marks a dimension as a development area.
     static let developmentThreshold: Double = 0.5
 
-    /// Maximum scores per dimension (L1 rubric).
+    /// Maximum scores per dimension (Build + Break rubrics).
     static let maxScores: [String: Int] = [
+        // Build mode (L1 rubric)
         "governingThought": 3,
         "supportGrouping": 2,
         "redundancy": 2,
         "clarity": 3,
+        // Build mode (L2 rubric)
         "l1Gate": 3,
         "meceQuality": 3,
         "orderingLogic": 3,
         "scqApplication": 2,
-        "horizontalLogic": 2
+        "horizontalLogic": 2,
+        // Break mode dimensions
+        "extractionAccuracy": 3,
+        "flawIdentification": 3,
+        "restructuringQuality": 3,
+    ]
+
+    /// Break mode dimension keys.
+    static let breakDimensions: [String] = [
+        "extractionAccuracy", "flawIdentification", "restructuringQuality"
+    ]
+
+    /// Build mode dimension keys (L1).
+    static let buildDimensionsL1: [String] = [
+        "governingThought", "supportGrouping", "redundancy", "clarity"
+    ]
+
+    /// Build mode dimension keys (L2+).
+    static let buildDimensionsL2: [String] = [
+        "l1Gate", "meceQuality", "orderingLogic", "scqApplication", "horizontalLogic"
     ]
 
     // MARK: - Public API

--- a/app/SayItRight/Tests/AdaptiveDifficultyTests.swift
+++ b/app/SayItRight/Tests/AdaptiveDifficultyTests.swift
@@ -181,11 +181,14 @@ struct AdaptiveDifficultyTests {
         #expect(dims.contains("clarity"))
     }
 
-    @Test("L2 has 5 dimensions")
+    @Test("L2 has 8 dimensions (5 Build + 3 Break)")
     func l2Dimensions() {
         let dims = AdaptiveDifficultyEngine.dimensionsForLevel(2)
-        #expect(dims.count == 5)
+        #expect(dims.count == 8)
         #expect(dims.contains("meceQuality"))
         #expect(dims.contains("horizontalLogic"))
+        #expect(dims.contains("extractionAccuracy"))
+        #expect(dims.contains("flawIdentification"))
+        #expect(dims.contains("restructuringQuality"))
     }
 }

--- a/app/SayItRight/Tests/BreakModeProfileTests.swift
+++ b/app/SayItRight/Tests/BreakModeProfileTests.swift
@@ -1,0 +1,191 @@
+import Foundation
+import Testing
+@testable import SayItRight
+
+@Suite("Break Mode Profile Integration")
+struct BreakModeProfileTests {
+
+    // MARK: - Dimension Definitions
+
+    @Test("Break mode dimensions defined in ProfileUpdater")
+    func breakDimensionsDefined() {
+        let breakDims = ProfileUpdater.breakDimensions
+        #expect(breakDims.contains("extractionAccuracy"))
+        #expect(breakDims.contains("flawIdentification"))
+        #expect(breakDims.contains("restructuringQuality"))
+        #expect(breakDims.count == 3)
+    }
+
+    @Test("Break dimensions have max scores")
+    func breakDimensionMaxScores() {
+        for dim in ProfileUpdater.breakDimensions {
+            let maxScore = ProfileUpdater.maxScores[dim]
+            #expect(maxScore != nil, "Missing max score for \(dim)")
+            #expect(maxScore! > 0, "Max score for \(dim) must be > 0")
+        }
+    }
+
+    @Test("Build dimensions defined in ProfileUpdater")
+    func buildDimensionsDefined() {
+        #expect(ProfileUpdater.buildDimensionsL1.count == 4)
+        #expect(ProfileUpdater.buildDimensionsL2.count == 5)
+    }
+
+    // MARK: - Profile Updates with Break Scores
+
+    @Test("Break dimension scores recorded in profile")
+    func breakScoresRecorded() {
+        var profile = LearnerProfile.createDefault(displayName: "Test")
+
+        profile.recordScore(2, for: "extractionAccuracy")
+        profile.recordScore(3, for: "flawIdentification")
+        profile.recordScore(1, for: "restructuringQuality")
+
+        #expect(profile.dimensionScores["extractionAccuracy"] == [2])
+        #expect(profile.dimensionScores["flawIdentification"] == [3])
+        #expect(profile.dimensionScores["restructuringQuality"] == [1])
+    }
+
+    @Test("Rolling averages work for Break dimensions")
+    func breakRollingAverages() {
+        var profile = LearnerProfile.createDefault(displayName: "Test")
+
+        for score in [1, 2, 3, 2, 3] {
+            profile.recordScore(score, for: "extractionAccuracy")
+        }
+
+        let avg = profile.rollingAverage(for: "extractionAccuracy")
+        #expect(avg == 2.2)
+    }
+
+    @Test("ProfileUpdater handles Break dimension scores")
+    func profileUpdaterBreakScores() {
+        let updater = ProfileUpdater()
+        var profile = LearnerProfile.createDefault(displayName: "Test")
+
+        let metadata = BarbaraMetadata(
+            scores: [
+                "extractionAccuracy": 3,
+                "flawIdentification": 2,
+            ],
+            totalScore: 5,
+            mood: .evaluating,
+            progressionSignal: .improving,
+            revisionRound: 0,
+            sessionPhase: .evaluation,
+            feedbackFocus: "extraction",
+            language: "en"
+        )
+
+        updater.updateProfile(&profile, from: metadata, sessionType: "find-the-point")
+        #expect(profile.dimensionScores["extractionAccuracy"] == [3])
+        #expect(profile.dimensionScores["flawIdentification"] == [2])
+        #expect(profile.sessionCount == 1)
+    }
+
+    @Test("Strengths and weaknesses include Break dimensions")
+    func strengthsAndWeaknessesIncludeBreak() {
+        let updater = ProfileUpdater()
+        var profile = LearnerProfile.createDefault(displayName: "Test")
+
+        // Strong extraction (max 3, scores avg 3.0 → 100%)
+        for _ in 0..<5 {
+            profile.recordScore(3, for: "extractionAccuracy")
+        }
+
+        // Weak flaw identification (max 3, scores avg 1.0 → 33%)
+        for _ in 0..<5 {
+            profile.recordScore(1, for: "flawIdentification")
+        }
+
+        // Trigger strength recalculation
+        let metadata = BarbaraMetadata(
+            scores: ["extractionAccuracy": 3],
+            totalScore: 3,
+            mood: .evaluating,
+            progressionSignal: .none,
+            revisionRound: 0,
+            sessionPhase: .evaluation,
+            feedbackFocus: "extraction",
+            language: "en"
+        )
+        updater.updateProfile(&profile, from: metadata, sessionType: "find-the-point")
+
+        #expect(profile.structuralStrengths.contains("extractionAccuracy"))
+        #expect(profile.developmentAreas.contains("flawIdentification"))
+    }
+
+    // MARK: - Adaptive Difficulty
+
+    @Test("L2 dimensions include Break mode")
+    func l2DimensionsIncludeBreak() {
+        let dims = AdaptiveDifficultyEngine.dimensionsForLevel(2)
+        #expect(dims.contains("extractionAccuracy"))
+        #expect(dims.contains("flawIdentification"))
+        #expect(dims.contains("restructuringQuality"))
+        // Also includes Build dimensions
+        #expect(dims.contains("meceQuality"))
+    }
+
+    @Test("L1 dimensions do not include Break mode")
+    func l1DimensionsExcludeBreak() {
+        let dims = AdaptiveDifficultyEngine.dimensionsForLevel(1)
+        #expect(!dims.contains("extractionAccuracy"))
+        #expect(!dims.contains("flawIdentification"))
+        #expect(!dims.contains("restructuringQuality"))
+    }
+
+    // MARK: - Level Transition
+
+    @Test("L2 progression requires Break dimensions")
+    func l2ProgressionRequiresBreak() {
+        let criteria = ProgressionCriteria.default.criteria(fromLevel: 2)
+        #expect(criteria != nil)
+        #expect(criteria!.requiredDimensions.contains("extractionAccuracy"))
+        #expect(criteria!.requiredDimensions.contains("flawIdentification"))
+        #expect(criteria!.requiredDimensions.contains("restructuringQuality"))
+    }
+
+    @Test("L1 progression does not require Break dimensions")
+    func l1ProgressionNoBreak() {
+        let criteria = ProgressionCriteria.default.criteria(fromLevel: 1)
+        #expect(criteria != nil)
+        #expect(!criteria!.requiredDimensions.contains("extractionAccuracy"))
+    }
+
+    // MARK: - Dashboard Display Names
+
+    @Test("Break dimensions have display names in English")
+    func breakDimensionDisplayNamesEN() {
+        let name = DimensionBarChartView.displayName(for: "extractionAccuracy", language: "en")
+        #expect(name == "Extracting structure")
+
+        let name2 = DimensionBarChartView.displayName(for: "flawIdentification", language: "en")
+        #expect(name2 == "Finding structural flaws")
+
+        let name3 = DimensionBarChartView.displayName(for: "restructuringQuality", language: "en")
+        #expect(name3 == "Restructuring quality")
+    }
+
+    @Test("Break dimensions have display names in German")
+    func breakDimensionDisplayNamesDE() {
+        let name = DimensionBarChartView.displayName(for: "extractionAccuracy", language: "de")
+        #expect(name == "Struktur erkennen")
+    }
+
+    @Test("Break dimensions have max scores in bar chart")
+    func breakDimensionMaxScoresChart() {
+        let max1 = DimensionBarChartView.maxScoreFor("extractionAccuracy")
+        #expect(max1 == 3)
+
+        let max2 = DimensionBarChartView.maxScoreFor("flawIdentification")
+        #expect(max2 == 3)
+    }
+
+    // MARK: - TextDifficultyCalibrator
+
+    @Test("TextDifficultyCalibrator uses ProfileUpdater break dimensions")
+    func calibratorBreakDimensions() {
+        #expect(TextDifficultyCalibrator.breakDimensions == ProfileUpdater.breakDimensions)
+    }
+}


### PR DESCRIPTION
## Summary
- 3 Break mode dimensions added: extractionAccuracy, flawIdentification, restructuringQuality
- ProfileUpdater.maxScores extended with Break dimensions (max 3 each)
- Dashboard shows Break dimensions with bilingual display names
- L2+ progression now requires competence in both Build AND Break modes
- AdaptiveDifficultyEngine includes Break dimensions for L2+ level evaluation
- TextDifficultyCalibrator unified to use ProfileUpdater.breakDimensions

## Test plan
- [x] Build succeeds
- [x] 618 tests pass (15 new Break mode profile tests)
- [x] Break dimensions have max scores, display names, and chart support
- [x] L2 dimensions count updated from 5 to 8 (5 Build + 3 Break)
- [x] L1 progression unchanged (no Break dims required)
- [x] L2/L3 progression requires Break dimensions

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)