### PR TITLE
feat: voice elevator pitch session (#59)

### DIFF
--- a/app/SayItRight/App/SayItRightApp.swift
+++ b/app/SayItRight/App/SayItRightApp.swift
@@ -56,6 +56,7 @@ struct ContentView: View {
     @State private var showVoiceSayItClearly = false
     @State private var showFindThePoint = false
     @State private var showElevatorPitch = false
+    @State private var showVoiceElevatorPitch = false
     @State private var showAnalyseMyText = false
     @State private var showFixThisMess = false
     @State private var showSpotTheGap = false
@@ -95,7 +96,15 @@ struct ContentView: View {
                 case .findThePoint:
                     showFindThePoint = true
                 case .elevatorPitch:
+                    #if os(iOS)
+                    if horizontalSizeClass == .compact {
+                        showVoiceElevatorPitch = true
+                    } else {
+                        showElevatorPitch = true
+                    }
+                    #else
                     showElevatorPitch = true
+                    #endif
                 case .analyseMyText:
                     showAnalyseMyText = true
                 case .fixThisMess:
@@ -144,6 +153,16 @@ struct ContentView: View {
                     language: language
                 ) {
                     showElevatorPitch = false
+                }
+            }
+            .navigationDestination(isPresented: $showVoiceElevatorPitch) {
+                VoiceElevatorPitchView(
+                    sessionManager: sessionManager,
+                    coordinator: elevatorPitchCoordinator,
+                    profile: profile,
+                    language: language
+                ) {
+                    showVoiceElevatorPitch = false
                 }
             }
             .navigationDestination(isPresented: $showAnalyseMyText) {

--- a/app/SayItRight/Intelligence/ConversationManager/SessionManager.swift
+++ b/app/SayItRight/Intelligence/ConversationManager/SessionManager.swift
@@ -240,6 +240,15 @@ final class SessionManager {
         systemPrompt += "\n\n" + voiceModeDirective(language: language)
     }
 
+    /// Start a voice-first "Elevator Pitch" session with a specific topic.
+    ///
+    /// Identical to `startElevatorPitchSession` but appends a voice mode
+    /// directive instructing Barbara to keep spoken feedback concise.
+    func startVoiceElevatorPitchSession(topic: Topic, profile: LearnerProfile, language: String) async {
+        await startElevatorPitchSession(topic: topic, profile: profile, language: language)
+        systemPrompt += "\n\n" + voiceModeDirective(language: language)
+    }
+
     /// Directive appended to the system prompt for voice sessions.
     ///
     /// Instructs Barbara to keep feedback concise for spoken delivery:

--- a/app/SayItRight/Presentation/VoiceDrill/VoiceElevatorPitchView.swift
+++ b/app/SayItRight/Presentation/VoiceDrill/VoiceElevatorPitchView.swift
@@ -1,0 +1,394 @@
+import SwiftUI
+
+/// Voice-first "Elevator Pitch" / "30 Sekunden" session view for iPhone.
+///
+/// Combines the timed pressure of ElevatorPitchView with voice input/output:
+/// 1. Barbara speaks the topic and says "You have N seconds. Go." (TTS)
+/// 2. Timer starts after TTS finishes → mic auto-activates
+/// 3. STT captures the spoken response during the timed window
+/// 4. Recording stops when timer expires (or user taps early)
+/// 5. Barbara evaluates and speaks her feedback
+struct VoiceElevatorPitchView: View {
+    let sessionManager: SessionManager
+    let coordinator: ElevatorPitchCoordinator
+    let profile: LearnerProfile
+    let language: String
+    var onDismiss: (() -> Void)?
+
+    @State private var viewModel: ChatViewModel
+    @State private var voiceInputVM: VoiceInputViewModel
+    @State private var ttsService: AppleTTSPlaybackService
+    @State private var audioSessionManager = AudioSessionManager()
+    @State private var sessionStarted = false
+    @State private var noTopicsAvailable = false
+    @State private var isTTSSpeaking = false
+    @State private var lastSpokenMessageCount = 0
+    @State private var timerState = VoiceTimerState()
+    @State private var timerStartedAfterTTS = false
+
+    init(
+        sessionManager: SessionManager,
+        coordinator: ElevatorPitchCoordinator,
+        profile: LearnerProfile,
+        language: String,
+        onDismiss: (() -> Void)? = nil
+    ) {
+        self.sessionManager = sessionManager
+        self.coordinator = coordinator
+        self.profile = profile
+        self.language = language
+        self.onDismiss = onDismiss
+        self._viewModel = State(initialValue: ChatViewModel(sessionManager: sessionManager))
+
+        let speechService = LiveSpeechRecognitionService(
+            locale: language == "de" ? .german : .english
+        )
+        let audioMgr = AudioSessionManager()
+        self._audioSessionManager = State(initialValue: audioMgr)
+        self._voiceInputVM = State(initialValue: VoiceInputViewModel(
+            speechService: speechService,
+            audioSessionManager: audioMgr
+        ))
+        self._ttsService = State(initialValue: AppleTTSPlaybackService())
+    }
+
+    var body: some View {
+        Group {
+            if noTopicsAvailable {
+                noTopicsView
+            } else {
+                VStack(spacing: 0) {
+                    if timerState.isRunning || timerState.hasStarted {
+                        timerBar
+                    }
+
+                    ChatView(
+                        viewModel: viewModel,
+                        voiceInputViewModel: voiceInputVM,
+                        onVoiceSubmit: { text in
+                            submitPitch(text: text, timedOut: false)
+                        }
+                    )
+                }
+            }
+        }
+        .navigationTitle(SessionType.elevatorPitch.displayName(language: language))
+        #if !os(macOS)
+        .navigationBarTitleDisplayMode(.inline)
+        #endif
+        .toolbar {
+            ToolbarItem(placement: .automatic) {
+                Button(action: endSessionAndDismiss) {
+                    Label(
+                        language == "de" ? "Beenden" : "End Session",
+                        systemImage: "xmark.circle"
+                    )
+                }
+            }
+        }
+        .task {
+            guard !sessionStarted else { return }
+            sessionStarted = true
+
+            ttsService.prewarm()
+            configureTTSVoice()
+
+            // Select topic via coordinator, then start voice session directly
+            guard let topic = coordinator.selectTopic(
+                for: profile.currentLevel,
+                language: language
+            ) else {
+                noTopicsAvailable = true
+                return
+            }
+            await sessionManager.startVoiceElevatorPitchSession(
+                topic: topic,
+                profile: profile,
+                language: language
+            )
+        }
+        .onChange(of: viewModel.messages.count) { _, _ in
+            speakLatestBarbaraMessage()
+        }
+        .onChange(of: viewModel.messages.last?.isStreaming) { _, isStreaming in
+            if isStreaming == false {
+                speakLatestBarbaraMessage()
+            }
+        }
+    }
+
+    // MARK: - Timer Bar
+
+    private var timerBar: some View {
+        VStack(spacing: 4) {
+            HStack {
+                Image(systemName: "timer")
+                    .font(.caption)
+                Text(timerText)
+                    .font(.system(.title3, design: .monospaced).bold())
+                Spacer()
+                if timerState.isRunning {
+                    Button(action: { stopEarlyAndSubmit() }) {
+                        Label(
+                            language == "de" ? "Fertig" : "Done",
+                            systemImage: "stop.circle.fill"
+                        )
+                        .font(.caption.bold())
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.small)
+                }
+            }
+
+            GeometryReader { geo in
+                ZStack(alignment: .leading) {
+                    RoundedRectangle(cornerRadius: 3)
+                        .fill(Color.gray.opacity(0.2))
+                        .frame(height: 4)
+
+                    RoundedRectangle(cornerRadius: 3)
+                        .fill(timerColor)
+                        .frame(width: geo.size.width * timerProgress, height: 4)
+                        .animation(.linear(duration: 1), value: timerState.remainingSeconds)
+                }
+            }
+            .frame(height: 4)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 8)
+        .background(timerColor.opacity(0.08))
+    }
+
+    private var timerText: String {
+        let minutes = timerState.remainingSeconds / 60
+        let seconds = timerState.remainingSeconds % 60
+        if minutes > 0 {
+            return String(format: "%d:%02d", minutes, seconds)
+        }
+        return "\(seconds)s"
+    }
+
+    private var timerProgress: CGFloat {
+        guard timerState.totalSeconds > 0 else { return 0 }
+        return CGFloat(timerState.remainingSeconds) / CGFloat(timerState.totalSeconds)
+    }
+
+    private var timerColor: Color {
+        let ratio = timerProgress
+        if ratio > 0.5 { return .green }
+        if ratio > 0.17 { return .orange }
+        return .red
+    }
+
+    // MARK: - Timer Logic
+
+    private func startTimer(duration: Int) {
+        timerState.totalSeconds = duration
+        timerState.remainingSeconds = duration
+        timerState.isRunning = true
+        timerState.hasStarted = true
+
+        // Auto-start recording when timer begins
+        Task {
+            await voiceInputVM.startRecording()
+        }
+
+        timerState.timerTask = Task { @MainActor in
+            while timerState.remainingSeconds > 0 && !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(1))
+                guard !Task.isCancelled else { return }
+                timerState.remainingSeconds -= 1
+
+                #if os(iOS)
+                if timerState.remainingSeconds == 10 || timerState.remainingSeconds == 5 {
+                    let generator = UIImpactFeedbackGenerator(style: .medium)
+                    generator.impactOccurred()
+                }
+                #endif
+            }
+
+            if !Task.isCancelled && timerState.remainingSeconds <= 0 {
+                timerState.isRunning = false
+                autoSubmitVoice()
+            }
+        }
+    }
+
+    private func autoSubmitVoice() {
+        voiceInputVM.stopRecording()
+
+        // Grab whatever was transcribed
+        let text: String
+        if voiceInputVM.state == .review {
+            text = voiceInputVM.editableText
+        } else {
+            text = voiceInputVM.transcriptionText
+        }
+
+        voiceInputVM.reset()
+        submitPitch(text: text, timedOut: true)
+    }
+
+    private func stopEarlyAndSubmit() {
+        timerState.isRunning = false
+        timerState.timerTask?.cancel()
+        voiceInputVM.stopRecording()
+
+        let text: String
+        if voiceInputVM.state == .review {
+            text = voiceInputVM.editableText
+        } else {
+            text = voiceInputVM.transcriptionText
+        }
+
+        voiceInputVM.reset()
+        submitPitch(text: text, timedOut: false)
+    }
+
+    private func submitPitch(text: String, timedOut: Bool) {
+        timerState.isRunning = false
+        timerState.timerTask?.cancel()
+
+        Task {
+            await sessionManager.submitElevatorPitch(text: text, timedOut: timedOut)
+        }
+    }
+
+    // MARK: - TTS
+
+    private func configureTTSVoice() {
+        let voiceProfile: BarbaraVoiceProfile = language == "de" ? .german : .english
+        ttsService.configuration = voiceProfile.ttsConfiguration(for: .observation)
+    }
+
+    private func speakLatestBarbaraMessage() {
+        guard let lastMessage = viewModel.messages.last,
+              lastMessage.role == .barbara,
+              !lastMessage.text.isEmpty,
+              !lastMessage.isStreaming else { return }
+
+        let currentCount = viewModel.messages.count
+        guard currentCount > lastSpokenMessageCount else { return }
+        lastSpokenMessageCount = currentCount
+
+        let textToSpeak = lastMessage.text
+        isTTSSpeaking = true
+
+        ttsService.speak(textToSpeak, language: language) { [self] event in
+            if event == .finished {
+                Task { @MainActor in
+                    isTTSSpeaking = false
+
+                    // Start timer after Barbara's initial greeting finishes
+                    if !timerStartedAfterTTS,
+                       let session = sessionManager.elevatorPitchSession {
+                        timerStartedAfterTTS = true
+                        startTimer(duration: session.durationSeconds)
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - No Topics
+
+    private var noTopicsView: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "tray")
+                .font(.system(size: 48))
+                .foregroundStyle(.secondary)
+
+            Text(language == "de"
+                 ? "Keine Themen verf\u{00FC}gbar"
+                 : "No topics available")
+                .font(.title3)
+                .fontWeight(.semibold)
+
+            Text(language == "de"
+                 ? "Es gibt aktuell keine passenden Themen f\u{00FC}r dein Level."
+                 : "There are no matching topics for your current level.")
+                .font(.body)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+
+            if let onDismiss {
+                Button(language == "de" ? "Zur\u{00FC}ck" : "Go Back") {
+                    onDismiss()
+                }
+                .buttonStyle(.borderedProminent)
+                .padding(.top, 8)
+            }
+        }
+        .padding(32)
+    }
+
+    // MARK: - Actions
+
+    private func endSessionAndDismiss() {
+        timerState.timerTask?.cancel()
+        ttsService.stop()
+        voiceInputVM.reset()
+        audioSessionManager.deactivateSession()
+        sessionManager.endSession()
+        onDismiss?()
+    }
+}
+
+// MARK: - Voice Timer State
+
+@MainActor
+private struct VoiceTimerState {
+    var totalSeconds: Int = 0
+    var remainingSeconds: Int = 0
+    var isRunning: Bool = false
+    var hasStarted: Bool = false
+    var timerTask: Task<Void, Never>?
+}
+
+// MARK: - Previews
+
+#Preview("Voice Elevator Pitch") {
+    NavigationStack {
+        VoiceElevatorPitchView(
+            sessionManager: SessionManager(),
+            coordinator: ElevatorPitchCoordinator(topics: [
+                Topic(
+                    id: "preview-vep",
+                    titleEN: "School uniforms",
+                    titleDE: "Schuluniformen",
+                    promptEN: "Should schools require uniforms? You have 60 seconds.",
+                    promptDE: "Sollten Schulen Uniformen vorschreiben? Du hast 60 Sekunden.",
+                    domain: .school,
+                    level: 1,
+                    barbaraFavorite: true
+                )
+            ]),
+            profile: .createDefault(displayName: "Alex"),
+            language: "en"
+        )
+    }
+    .environment(AppSettings.shared)
+}
+
+#Preview("Voice Elevator Pitch — German") {
+    NavigationStack {
+        VoiceElevatorPitchView(
+            sessionManager: SessionManager(),
+            coordinator: ElevatorPitchCoordinator(topics: [
+                Topic(
+                    id: "preview-vep-de",
+                    titleEN: "Homework",
+                    titleDE: "Hausaufgaben",
+                    promptEN: "Should homework be abolished?",
+                    promptDE: "Sollten Hausaufgaben abgeschafft werden? Du hast 60 Sekunden.",
+                    domain: .school,
+                    level: 1,
+                    barbaraFavorite: false
+                )
+            ]),
+            profile: .createDefault(displayName: "Maxi", language: "de"),
+            language: "de"
+        )
+    }
+    .environment(AppSettings.shared)
+}

--- a/app/SayItRight/SayItRight.xcodeproj/project.pbxproj
+++ b/app/SayItRight/SayItRight.xcodeproj/project.pbxproj
@@ -195,6 +195,7 @@
 		945C5AB0AE1C1A1164802CF7 /* PracticeText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48A1CF3D22441AE55554B302 /* PracticeText.swift */; };
 		94BD55EA2659D676E06DEAAE /* MacChatInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C051275C85D1D1ED1778AC59 /* MacChatInputView.swift */; };
 		95A50EEDFAC1BC4B1996DF6D /* ProfileUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30EED07035F76FC2168D236A /* ProfileUpdater.swift */; };
+		96D63E6451B239809823E6EA /* VoiceElevatorPitchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF9A6BF1241D474DACAAE762 /* VoiceElevatorPitchTests.swift */; };
 		9737407A667AA231AF72F475 /* ChatUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 252179F898FB39D52A3DD9B7 /* ChatUITests.swift */; };
 		9B75A691D0F56293D7AF2B2B /* ComparisonPromptBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69C98EBC60AB392AA8868374 /* ComparisonPromptBuilder.swift */; };
 		9C6C847EC9BCCD14AE067A8A /* TTSPlaybackServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1964D965458CCC6A3A747B0 /* TTSPlaybackServiceTests.swift */; };
@@ -223,9 +224,11 @@
 		A9B7342D214CE45653F5BAB3 /* LearnerAvatar.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE528A4BB6F7C58BD0CC3708 /* LearnerAvatar.swift */; };
 		A9BA44DA0F1F2B687C7EB602 /* AnthropicModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10F6CAB4EBA45B17A293C4C0 /* AnthropicModel.swift */; };
 		A9C54D9E4FC609C3A85D553B /* DimensionBarChartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64F1F5B0738E60E8163A2FDB /* DimensionBarChartView.swift */; };
+		AA84EBC9B2E3A2AEE4D24AEE /* VoiceElevatorPitchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBF554DE2E568F5716D89DD7 /* VoiceElevatorPitchView.swift */; };
 		AD8F19056F59A9446FB10082 /* SpotTheGapHintTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBB5356B054475EC18A358C6 /* SpotTheGapHintTests.swift */; };
 		AD9D198E44358F88EF30E30B /* StructuralEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11A375822F278D205A1F9090 /* StructuralEvaluator.swift */; };
 		AE1A15A7E561DB90F19FF361 /* ElevatorPitchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCC9887FA1B8FA6F1AF29DAE /* ElevatorPitchView.swift */; };
+		AE22A38235CA0C0C911A69EF /* VoiceElevatorPitchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBF554DE2E568F5716D89DD7 /* VoiceElevatorPitchView.swift */; };
 		AE5F4FDA4052322F82140791 /* ValidationFeedbackModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BCC3E8C4CBE011C33FC740B /* ValidationFeedbackModifier.swift */; };
 		AFEA82FE224E0347257B1DFC /* DropZoneTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFA22F5F2A41A4A96CFE4C47 /* DropZoneTests.swift */; };
 		B007E9CAE8E63D427DBBFF69 /* ParentGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B22653B114F07E9EA40C7C62 /* ParentGate.swift */; };
@@ -301,6 +304,7 @@
 		DE1CC7ECEADF4111754C15B0 /* VoiceInputViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FFAF667809AFED071F2163 /* VoiceInputViewModel.swift */; };
 		DE38095862958923B2416C42 /* BarbaraAvatarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A553A59D04C7ABFA86CF117E /* BarbaraAvatarTests.swift */; };
 		DE4B413678C1C56B351AAF07 /* SpeechRecognitionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD87491EB57716C7181C506 /* SpeechRecognitionService.swift */; };
+		DF0BFD0DC5FBFC8BC038693D /* VoiceElevatorPitchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF9A6BF1241D474DACAAE762 /* VoiceElevatorPitchTests.swift */; };
 		E051DAB7CE1CB6C9AE6C2D79 /* DropZone.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28E6F9B9D6818D8BCF742BCC /* DropZone.swift */; };
 		E071B3F83FAD19AECA65C8A1 /* ParentSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B08B6C7C928249161C6C0AC /* ParentSettingsView.swift */; };
 		E1C178382A2262BB8A5C7E72 /* Topic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 188F1F9BBC0111EE4F4EB660 /* Topic.swift */; };
@@ -552,6 +556,7 @@
 		D693A9655797CEF326A8BA1C /* SessionHistoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionHistoryTests.swift; sourceTree = "<group>"; };
 		D6C50086B3A681AE4B706D0B /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
 		D7340051027E1031862796AD /* LearnerProfileStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearnerProfileStore.swift; sourceTree = "<group>"; };
+		DBF554DE2E568F5716D89DD7 /* VoiceElevatorPitchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceElevatorPitchView.swift; sourceTree = "<group>"; };
 		DC11499E66D1CCC6F0EDB5EE /* ComparisonResponseParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComparisonResponseParser.swift; sourceTree = "<group>"; };
 		DC1974647876CBDFA39B8A71 /* SeenTextsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeenTextsStore.swift; sourceTree = "<group>"; };
 		DE9990EFFDBC213F3F1D0B19 /* SayItRightApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SayItRightApp.swift; sourceTree = "<group>"; };
@@ -567,6 +572,7 @@
 		EA32E530E1641F627E7C5970 /* BlockFeedbackState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockFeedbackState.swift; sourceTree = "<group>"; };
 		EBB5356B054475EC18A358C6 /* SpotTheGapHintTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotTheGapHintTests.swift; sourceTree = "<group>"; };
 		ED72B2F78895FD96D69C5698 /* AudioSessionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioSessionManager.swift; sourceTree = "<group>"; };
+		EF9A6BF1241D474DACAAE762 /* VoiceElevatorPitchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceElevatorPitchTests.swift; sourceTree = "<group>"; };
 		F2A6B03C9A74B0140D2B2BE7 /* AnswerKeyComparisonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnswerKeyComparisonTests.swift; sourceTree = "<group>"; };
 		F311FDA056466909DBBC103C /* DecodeAndRebuildTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecodeAndRebuildTests.swift; sourceTree = "<group>"; };
 		F3E7290B780810CAE4428003 /* StructuralEvaluatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StructuralEvaluatorTests.swift; sourceTree = "<group>"; };
@@ -666,6 +672,7 @@
 				8309BF4EE774FABE588555F4 /* MicrophoneButton.swift */,
 				FF9D188FA8779E14011857FD /* ThinkingIndicatorView.swift */,
 				E4F296F432E8A069994E5167 /* TTSPlaybackService.swift */,
+				DBF554DE2E568F5716D89DD7 /* VoiceElevatorPitchView.swift */,
 				61F66A4FE516B8A86073D9B3 /* VoiceInputView.swift */,
 				26FFAF667809AFED071F2163 /* VoiceInputViewModel.swift */,
 				F8565117528BB06983545B8A /* VoiceSayItClearlyView.swift */,
@@ -808,6 +815,7 @@
 				AA8D4F615BD301FC609D050A /* TreeLayoutEngineTests.swift */,
 				A1964D965458CCC6A3A747B0 /* TTSPlaybackServiceTests.swift */,
 				AC256E9126646B1262512067 /* ValidationFeedbackTests.swift */,
+				EF9A6BF1241D474DACAAE762 /* VoiceElevatorPitchTests.swift */,
 				705DD7DFE2CA7A3BA37785EA /* VoiceSayItClearlyTests.swift */,
 			);
 			path = Tests;
@@ -1261,6 +1269,7 @@
 				272E62E1088D208085F245B5 /* TextDifficultyCalibratorTests.swift in Sources */,
 				112C860A4101D395FAA0F637 /* TreeLayoutEngineTests.swift in Sources */,
 				21DAB04C88F950A1145C76C4 /* ValidationFeedbackTests.swift in Sources */,
+				96D63E6451B239809823E6EA /* VoiceElevatorPitchTests.swift in Sources */,
 				8B42E4659938F6B197D2BE6D /* VoiceSayItClearlyTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1314,6 +1323,7 @@
 				EA0D4B1C48E68CDED67FFA0F /* TextDifficultyCalibratorTests.swift in Sources */,
 				15C2944B9C7F642A1F1CE5E0 /* TreeLayoutEngineTests.swift in Sources */,
 				BBB3CACEC5AE458782FFD0D0 /* ValidationFeedbackTests.swift in Sources */,
+				DF0BFD0DC5FBFC8BC038693D /* VoiceElevatorPitchTests.swift in Sources */,
 				322C09D5891901217A964082 /* VoiceSayItClearlyTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1429,6 +1439,7 @@
 				465D99D2F607EE3A29C71228 /* Topic.swift in Sources */,
 				64A04AB12BD9FD132B0D9F8A /* TreeLayoutEngine.swift in Sources */,
 				AE5F4FDA4052322F82140791 /* ValidationFeedbackModifier.swift in Sources */,
+				AE22A38235CA0C0C911A69EF /* VoiceElevatorPitchView.swift in Sources */,
 				00659B8342F2BACC70A60BFB /* VoiceInputView.swift in Sources */,
 				DE1CC7ECEADF4111754C15B0 /* VoiceInputViewModel.swift in Sources */,
 				6906E515B0FCA779B01818B5 /* VoiceSayItClearlyView.swift in Sources */,
@@ -1561,6 +1572,7 @@
 				E1C178382A2262BB8A5C7E72 /* Topic.swift in Sources */,
 				4DBA3C9AB5E598841BC408FA /* TreeLayoutEngine.swift in Sources */,
 				6D1844C5C88EF8B196CEE8A1 /* ValidationFeedbackModifier.swift in Sources */,
+				AA84EBC9B2E3A2AEE4D24AEE /* VoiceElevatorPitchView.swift in Sources */,
 				7B05C7916E626A00EABE4E1E /* VoiceInputView.swift in Sources */,
 				81160A48F23B0693F8B6BE38 /* VoiceInputViewModel.swift in Sources */,
 				4AEE63E3C80544718B5058DA /* VoiceSayItClearlyView.swift in Sources */,

--- a/app/SayItRight/Tests/VoiceElevatorPitchTests.swift
+++ b/app/SayItRight/Tests/VoiceElevatorPitchTests.swift
@@ -1,0 +1,102 @@
+import Testing
+@testable import SayItRight
+
+@Suite("Voice Elevator Pitch")
+struct VoiceElevatorPitchTests {
+
+    // MARK: - Voice Mode Directive
+
+    @Test("Voice mode directive appended for elevator pitch")
+    @MainActor
+    func voiceModeDirectiveExists() {
+        let sm = SessionManager()
+        let directive = sm.voiceModeDirective(language: "en")
+        #expect(!directive.isEmpty)
+        #expect(directive.contains("Voice Mode"))
+        #expect(directive.contains("2-3 sentences"))
+    }
+
+    // MARK: - Timer Duration by Level
+
+    @Test("Timer duration is 60s for level 1")
+    func timerDurationLevel1() {
+        let duration = ElevatorPitchSession.duration(for: 1)
+        #expect(duration == 60)
+    }
+
+    @Test("Timer duration is 30s for level 2+")
+    func timerDurationLevel2() {
+        let duration = ElevatorPitchSession.duration(for: 2)
+        #expect(duration == 30)
+        let duration3 = ElevatorPitchSession.duration(for: 3)
+        #expect(duration3 == 30)
+    }
+
+    // MARK: - Session Recording
+
+    @Test("ElevatorPitchSession records response and timeout status")
+    func sessionRecordsResponse() {
+        var session = ElevatorPitchSession(
+            topic: Topic(
+                id: "test",
+                titleEN: "Test",
+                titleDE: "Test",
+                promptEN: "Test prompt",
+                promptDE: "Testfrage",
+                domain: .school,
+                level: 1,
+                barbaraFavorite: false
+            ),
+            durationSeconds: 30
+        )
+        #expect(!session.hasResponse)
+
+        session.recordResponse("My structured response", timedOut: false)
+        #expect(session.hasResponse)
+        #expect(session.responseText == "My structured response")
+        #expect(!session.timedOut)
+    }
+
+    @Test("ElevatorPitchSession records timeout")
+    func sessionRecordsTimeout() {
+        var session = ElevatorPitchSession(
+            topic: Topic(
+                id: "test",
+                titleEN: "Test",
+                titleDE: "Test",
+                promptEN: "Test prompt",
+                promptDE: "Testfrage",
+                domain: .school,
+                level: 1,
+                barbaraFavorite: false
+            ),
+            durationSeconds: 60
+        )
+
+        session.recordResponse("Partial response", timedOut: true)
+        #expect(session.hasResponse)
+        #expect(session.timedOut)
+    }
+
+    // MARK: - ChatViewModel Integration
+
+    @Test("ChatViewModel can be created for voice elevator pitch")
+    @MainActor
+    func chatViewModelCreation() {
+        let sm = SessionManager()
+        let vm = ChatViewModel(sessionManager: sm)
+        #expect(vm.inputText.isEmpty)
+    }
+
+    // MARK: - Voice Directive Both Languages
+
+    @Test("Voice mode directive works for both languages")
+    @MainActor
+    func voiceDirectiveBothLanguages() {
+        let sm = SessionManager()
+        let en = sm.voiceModeDirective(language: "en")
+        let de = sm.voiceModeDirective(language: "de")
+        #expect(!en.isEmpty)
+        #expect(!de.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary
- Voice-first elevator pitch session for iPhone (compact size class)
- `VoiceElevatorPitchView`: combines countdown timer + voice input (STT) + TTS playback
- Timer starts after Barbara's TTS greeting finishes, mic auto-activates
- Auto-submits when timer expires, or user can stop early
- `startVoiceElevatorPitchSession` on SessionManager appends voice mode directive
- iPhone routes to voice variant, iPad/Mac use text variant

## Test plan
- [x] Build succeeds (macOS)
- [x] 632 unit tests pass (including 7 new voice elevator pitch tests)
- [ ] Manual: verify timer countdown and auto-submit on iPhone
- [ ] Manual: verify TTS speaks topic before timer starts
- [ ] Manual: verify early stop captures partial transcription

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)