### PR TITLE
feat: voice find-the-point session (#60)

### DIFF
--- a/app/SayItRight/App/SayItRightApp.swift
+++ b/app/SayItRight/App/SayItRightApp.swift
@@ -55,6 +55,7 @@ struct ContentView: View {
     @State private var showSayItClearly = false
     @State private var showVoiceSayItClearly = false
     @State private var showFindThePoint = false
+    @State private var showVoiceFindThePoint = false
     @State private var showElevatorPitch = false
     @State private var showVoiceElevatorPitch = false
     @State private var showAnalyseMyText = false
@@ -94,7 +95,15 @@ struct ContentView: View {
                     showSayItClearly = true
                     #endif
                 case .findThePoint:
+                    #if os(iOS)
+                    if horizontalSizeClass == .compact {
+                        showVoiceFindThePoint = true
+                    } else {
+                        showFindThePoint = true
+                    }
+                    #else
                     showFindThePoint = true
+                    #endif
                 case .elevatorPitch:
                     #if os(iOS)
                     if horizontalSizeClass == .compact {
@@ -143,6 +152,16 @@ struct ContentView: View {
                     language: language
                 ) {
                     showFindThePoint = false
+                }
+            }
+            .navigationDestination(isPresented: $showVoiceFindThePoint) {
+                VoiceFindThePointView(
+                    sessionManager: sessionManager,
+                    coordinator: findThePointCoordinator,
+                    profile: profile,
+                    language: language
+                ) {
+                    showVoiceFindThePoint = false
                 }
             }
             .navigationDestination(isPresented: $showElevatorPitch) {

--- a/app/SayItRight/Intelligence/ConversationManager/SessionManager.swift
+++ b/app/SayItRight/Intelligence/ConversationManager/SessionManager.swift
@@ -249,6 +249,24 @@ final class SessionManager {
         systemPrompt += "\n\n" + voiceModeDirective(language: language)
     }
 
+    /// Start a voice-first "Find the Point" session with a practice text.
+    ///
+    /// Identical to `startFindThePointSession` but appends a voice mode
+    /// directive instructing Barbara to keep spoken feedback concise.
+    func startVoiceFindThePointSession(practiceText: PracticeText, profile: LearnerProfile, language: String) async {
+        await startFindThePointSession(practiceText: practiceText, profile: profile, language: language)
+        systemPrompt += "\n\n" + voiceModeDirective(language: language)
+    }
+
+    /// Append the voice mode directive to the current system prompt.
+    ///
+    /// Call after a session is started via a coordinator to add concise
+    /// spoken-feedback instructions. Safe to call multiple times (idempotent
+    /// in practice since sessions reset the prompt).
+    func appendVoiceDirective(language: String) {
+        systemPrompt += "\n\n" + voiceModeDirective(language: language)
+    }
+
     /// Directive appended to the system prompt for voice sessions.
     ///
     /// Instructs Barbara to keep feedback concise for spoken delivery:

--- a/app/SayItRight/Presentation/VoiceDrill/VoiceFindThePointView.swift
+++ b/app/SayItRight/Presentation/VoiceDrill/VoiceFindThePointView.swift
@@ -1,0 +1,257 @@
+import SwiftUI
+
+/// Voice-first "Find the Point" session view for iPhone.
+///
+/// Displays a practice text for reading, then the user speaks their
+/// one-sentence governing thought extraction. Barbara evaluates via
+/// TTS + text. The practice text remains visible throughout.
+///
+/// Flow:
+/// 1. Practice text displayed at top (scrollable)
+/// 2. Barbara speaks introduction via TTS
+/// 3. User taps mic and speaks their extraction
+/// 4. Barbara evaluates and speaks feedback
+struct VoiceFindThePointView: View {
+    let sessionManager: SessionManager
+    let coordinator: FindThePointCoordinator
+    let profile: LearnerProfile
+    let language: String
+    var onDismiss: (() -> Void)?
+
+    @State private var viewModel: ChatViewModel
+    @State private var voiceInputVM: VoiceInputViewModel
+    @State private var ttsService: AppleTTSPlaybackService
+    @State private var audioSessionManager = AudioSessionManager()
+    @State private var sessionStarted = false
+    @State private var noTextsAvailable = false
+    @State private var selectedText: PracticeText?
+    @State private var isTTSSpeaking = false
+    @State private var lastSpokenMessageCount = 0
+
+    init(
+        sessionManager: SessionManager,
+        coordinator: FindThePointCoordinator,
+        profile: LearnerProfile,
+        language: String,
+        onDismiss: (() -> Void)? = nil
+    ) {
+        self.sessionManager = sessionManager
+        self.coordinator = coordinator
+        self.profile = profile
+        self.language = language
+        self.onDismiss = onDismiss
+        self._viewModel = State(initialValue: ChatViewModel(sessionManager: sessionManager))
+
+        let speechService = LiveSpeechRecognitionService(
+            locale: language == "de" ? .german : .english
+        )
+        let audioMgr = AudioSessionManager()
+        self._audioSessionManager = State(initialValue: audioMgr)
+        self._voiceInputVM = State(initialValue: VoiceInputViewModel(
+            speechService: speechService,
+            audioSessionManager: audioMgr
+        ))
+        self._ttsService = State(initialValue: AppleTTSPlaybackService())
+    }
+
+    var body: some View {
+        Group {
+            if noTextsAvailable {
+                noTextsView
+            } else if selectedText != nil {
+                VStack(spacing: 0) {
+                    // Practice text at top, always visible
+                    if let text = selectedText {
+                        ScrollView {
+                            PracticeTextView(text: text.text, language: language)
+                                .padding(.horizontal, 12)
+                                .padding(.vertical, 8)
+                        }
+                        .frame(maxHeight: 200)
+
+                        Divider()
+                    }
+
+                    // Chat with voice input below
+                    ChatView(
+                        viewModel: viewModel,
+                        voiceInputViewModel: voiceInputVM,
+                        onVoiceSubmit: { text in
+                            handleVoiceSubmit(text)
+                        }
+                    )
+                }
+            } else {
+                ProgressView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+        }
+        .navigationTitle(SessionType.findThePoint.displayName(language: language))
+        #if !os(macOS)
+        .navigationBarTitleDisplayMode(.inline)
+        #endif
+        .toolbar {
+            ToolbarItem(placement: .automatic) {
+                Button(action: endSessionAndDismiss) {
+                    Label(
+                        language == "de" ? "Beenden" : "End Session",
+                        systemImage: "xmark.circle"
+                    )
+                }
+            }
+        }
+        .task {
+            guard !sessionStarted else { return }
+            sessionStarted = true
+
+            ttsService.prewarm()
+            configureTTSVoice()
+
+            let text = await coordinator.startSession(
+                sessionManager: sessionManager,
+                profile: profile,
+                language: language
+            )
+            if let text {
+                selectedText = text
+                // Append voice mode directive
+                sessionManager.appendVoiceDirective(language: language)
+            } else {
+                noTextsAvailable = true
+            }
+        }
+        .onChange(of: viewModel.messages.count) { _, _ in
+            speakLatestBarbaraMessage()
+        }
+        .onChange(of: viewModel.messages.last?.isStreaming) { _, isStreaming in
+            if isStreaming == false {
+                speakLatestBarbaraMessage()
+            }
+        }
+    }
+
+    // MARK: - Voice Submit
+
+    private func handleVoiceSubmit(_ text: String) {
+        viewModel.inputText = text
+        viewModel.send()
+    }
+
+    // MARK: - TTS
+
+    private func configureTTSVoice() {
+        let voiceProfile: BarbaraVoiceProfile = language == "de" ? .german : .english
+        ttsService.configuration = voiceProfile.ttsConfiguration(for: .observation)
+    }
+
+    private func speakLatestBarbaraMessage() {
+        guard let lastMessage = viewModel.messages.last,
+              lastMessage.role == .barbara,
+              !lastMessage.text.isEmpty,
+              !lastMessage.isStreaming else { return }
+
+        let currentCount = viewModel.messages.count
+        guard currentCount > lastSpokenMessageCount else { return }
+        lastSpokenMessageCount = currentCount
+
+        let textToSpeak = lastMessage.text
+        isTTSSpeaking = true
+
+        ttsService.speak(textToSpeak, language: language) { [self] event in
+            if event == .finished {
+                Task { @MainActor in
+                    isTTSSpeaking = false
+                }
+            }
+        }
+    }
+
+    // MARK: - No Texts
+
+    private var noTextsView: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "doc.text.magnifyingglass")
+                .font(.system(size: 48))
+                .foregroundStyle(.secondary)
+
+            Text(language == "de"
+                 ? "Keine Texte verf\u{00FC}gbar"
+                 : "No texts available")
+                .font(.title3)
+                .fontWeight(.semibold)
+
+            Text(language == "de"
+                 ? "Es gibt aktuell keine passenden Texte f\u{00FC}r dein Level."
+                 : "There are no matching texts for your current level.")
+                .font(.body)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+
+            if let onDismiss {
+                Button(language == "de" ? "Zur\u{00FC}ck" : "Go Back") {
+                    onDismiss()
+                }
+                .buttonStyle(.borderedProminent)
+                .padding(.top, 8)
+            }
+        }
+        .padding(32)
+    }
+
+    // MARK: - Actions
+
+    private func endSessionAndDismiss() {
+        ttsService.stop()
+        voiceInputVM.reset()
+        audioSessionManager.deactivateSession()
+        sessionManager.endSession()
+        onDismiss?()
+    }
+}
+
+// MARK: - Previews
+
+private let voicePreviewText = PracticeText(
+    id: "preview-voice-ftp",
+    text: "School uniforms reduce social pressure by eliminating visible economic differences among students. When everyone wears the same clothes, students focus more on learning and less on fashion. Studies in three US states found a 23% reduction in bullying incidents after uniform adoption. However, critics argue that uniforms suppress individual expression, which is a core developmental need for teenagers.",
+    answerKey: AnswerKey(
+        governingThought: "School uniforms reduce social pressure but at the cost of individual expression.",
+        supports: [
+            SupportGroup(label: "Social equaliser", evidence: ["Eliminates visible economic differences", "23% reduction in bullying"]),
+            SupportGroup(label: "Critics counter", evidence: ["Suppresses individual expression", "Core developmental need"]),
+        ],
+        structuralAssessment: "Well-structured with a clear governing thought in the opening sentence."
+    ),
+    metadata: PracticeTextMetadata(
+        qualityLevel: .wellStructured,
+        difficultyRating: 1,
+        topicDomain: "school",
+        language: "en",
+        wordCount: 62,
+        targetLevel: 1
+    )
+)
+
+#Preview("Voice Find the Point") {
+    NavigationStack {
+        VoiceFindThePointView(
+            sessionManager: SessionManager(),
+            coordinator: FindThePointCoordinator(texts: [voicePreviewText]),
+            profile: .createDefault(displayName: "Alex"),
+            language: "en"
+        )
+    }
+    .environment(AppSettings.shared)
+}
+
+#Preview("No Texts") {
+    NavigationStack {
+        VoiceFindThePointView(
+            sessionManager: SessionManager(),
+            coordinator: FindThePointCoordinator(texts: []),
+            profile: .createDefault(displayName: "Alex"),
+            language: "en"
+        )
+    }
+    .environment(AppSettings.shared)
+}

--- a/app/SayItRight/Tests/VoiceFindThePointTests.swift
+++ b/app/SayItRight/Tests/VoiceFindThePointTests.swift
@@ -1,0 +1,88 @@
+import Testing
+@testable import SayItRight
+
+@Suite("Voice Find the Point")
+struct VoiceFindThePointTests {
+
+    // MARK: - Voice Mode Directive
+
+    @Test("Voice directive applied for find-the-point session")
+    @MainActor
+    func voiceDirectiveApplied() {
+        let sm = SessionManager()
+        let directive = sm.voiceModeDirective(language: "en")
+        #expect(directive.contains("Voice Mode"))
+        #expect(directive.contains("2-3 sentences"))
+    }
+
+    @Test("appendVoiceDirective is callable")
+    @MainActor
+    func appendVoiceDirectiveCallable() {
+        let sm = SessionManager()
+        // Should not crash on an empty system prompt
+        sm.appendVoiceDirective(language: "en")
+        sm.appendVoiceDirective(language: "de")
+    }
+
+    // MARK: - ChatViewModel Integration
+
+    @Test("ChatViewModel receives voice input text")
+    @MainActor
+    func chatViewModelReceivesInput() {
+        let sm = SessionManager()
+        let vm = ChatViewModel(sessionManager: sm)
+        vm.inputText = "The author argues that uniforms reduce social pressure."
+        #expect(vm.inputText == "The author argues that uniforms reduce social pressure.")
+    }
+
+    // MARK: - Practice Text Display
+
+    @Test("PracticeText has accessible text for display")
+    func practiceTextAccessible() {
+        let text = PracticeText(
+            id: "test-001",
+            text: "School uniforms reduce social pressure.",
+            answerKey: AnswerKey(
+                governingThought: "Uniforms reduce social pressure.",
+                supports: [],
+                structuralAssessment: "Well-structured."
+            ),
+            metadata: PracticeTextMetadata(
+                qualityLevel: .wellStructured,
+                difficultyRating: 1,
+                topicDomain: "school",
+                language: "en",
+                wordCount: 6,
+                targetLevel: 1
+            )
+        )
+        #expect(!text.text.isEmpty)
+        #expect(text.answerKey.governingThought.contains("pressure"))
+    }
+
+    // MARK: - Quality Selection
+
+    @Test("FindThePointCoordinator selects texts")
+    @MainActor
+    func coordinatorSelectsTexts() {
+        let text = PracticeText(
+            id: "test-002",
+            text: "Sample text for testing.",
+            answerKey: AnswerKey(
+                governingThought: "Testing.",
+                supports: [],
+                structuralAssessment: "Simple."
+            ),
+            metadata: PracticeTextMetadata(
+                qualityLevel: .wellStructured,
+                difficultyRating: 1,
+                topicDomain: "school",
+                language: "en",
+                wordCount: 5,
+                targetLevel: 1
+            )
+        )
+        let coordinator = FindThePointCoordinator(texts: [text])
+        _ = coordinator // Coordinator created successfully
+    }
+}


### PR DESCRIPTION
## Summary
- Voice-first Find the Point session for iPhone (compact size class)
- `VoiceFindThePointView`: practice text display + voice input (STT) + TTS playback
- Practice text remains visible at top while user speaks their extraction
- Barbara evaluates governing thought extraction via spoken + text feedback
- `startVoiceFindThePointSession` + `appendVoiceDirective` on SessionManager
- iPhone routes to voice variant, iPad/Mac use text variant

## Test plan
- [x] Build succeeds (macOS)
- [x] 637 unit tests pass (including 5 new voice find-the-point tests)
- [ ] Manual: verify practice text visible during voice interaction
- [ ] Manual: verify TTS speaks Barbara's introduction and feedback

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)