### PR TITLE
feat: Build the Pyramid session integration

### DIFF
--- a/app/SayItRight/App/SayItRightApp.swift
+++ b/app/SayItRight/App/SayItRightApp.swift
@@ -51,6 +51,7 @@ struct ContentView: View {
     @State private var elevatorPitchCoordinator = ElevatorPitchCoordinator()
     @State private var fixThisMessCoordinator = FixThisMessCoordinator()
     @State private var spotTheGapCoordinator = SpotTheGapCoordinator()
+    @State private var buildThePyramidCoordinator = BuildThePyramidCoordinator()
     @State private var decodeAndRebuildCoordinator = DecodeAndRebuildCoordinator()
     @State private var showSayItClearly = false
     @State private var showVoiceSayItClearly = false
@@ -58,6 +59,7 @@ struct ContentView: View {
     @State private var showVoiceFindThePoint = false
     @State private var showElevatorPitch = false
     @State private var showVoiceElevatorPitch = false
+    @State private var showBuildThePyramid = false
     @State private var showAnalyseMyText = false
     @State private var showFixThisMess = false
     @State private var showSpotTheGap = false
@@ -114,6 +116,8 @@ struct ContentView: View {
                     #else
                     showElevatorPitch = true
                     #endif
+                case .buildThePyramid:
+                    showBuildThePyramid = true
                 case .analyseMyText:
                     showAnalyseMyText = true
                 case .fixThisMess:
@@ -182,6 +186,16 @@ struct ContentView: View {
                     language: language
                 ) {
                     showVoiceElevatorPitch = false
+                }
+            }
+            .navigationDestination(isPresented: $showBuildThePyramid) {
+                BuildThePyramidView(
+                    sessionManager: sessionManager,
+                    coordinator: buildThePyramidCoordinator,
+                    profile: profile,
+                    language: language
+                ) {
+                    showBuildThePyramid = false
                 }
             }
             .navigationDestination(isPresented: $showAnalyseMyText) {

--- a/app/SayItRight/Content/PracticeTexts/TextDifficultyCalibrator.swift
+++ b/app/SayItRight/Content/PracticeTexts/TextDifficultyCalibrator.swift
@@ -150,7 +150,7 @@ struct TextDifficultyCalibrator: Sendable {
         case .decodeAndRebuild:
             // Only buried-lead and rambling texts (there must be structural work to do)
             return texts.filter { [.buriedLead, .rambling].contains($0.metadata.qualityLevel) }
-        case .sayItClearly, .elevatorPitch, .analyseMyText:
+        case .sayItClearly, .elevatorPitch, .analyseMyText, .buildThePyramid:
             // Build mode — no text selection needed, but if called, return all
             return texts
         }

--- a/app/SayItRight/Content/PyramidExercises/PyramidExercise.swift
+++ b/app/SayItRight/Content/PyramidExercises/PyramidExercise.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+/// A pyramid builder exercise containing blocks to arrange and an answer key.
+///
+/// The exercise provides a governing thought (fixed at pyramid top) and a set
+/// of scrambled blocks that the user must arrange into the correct tree structure.
+struct PyramidExercise: Codable, Sendable, Identifiable {
+    let id: String
+    let titleEN: String
+    let titleDE: String
+    let level: Int
+    let language: String
+
+    /// The governing thought block (fixed at top).
+    let governingThought: ExerciseBlock
+
+    /// Scrambled blocks to arrange.
+    let blocks: [ExerciseBlock]
+
+    /// Answer key for validation.
+    let answerKey: PyramidAnswerKey
+
+    func title(for language: String) -> String {
+        language == "de" ? titleDE : titleEN
+    }
+}
+
+/// A single block in a pyramid exercise.
+struct ExerciseBlock: Codable, Sendable, Identifiable {
+    let id: String
+    let text: String
+    let type: ExerciseBlockType
+}
+
+/// Block type in exercise data.
+enum ExerciseBlockType: String, Codable, Sendable {
+    case governingThought = "governing_thought"
+    case supportPoint = "support_point"
+    case evidence = "evidence"
+
+    /// Convert to the presentation-layer BlockType.
+    var blockType: BlockType {
+        switch self {
+        case .governingThought: .governingThought
+        case .supportPoint: .supportPoint
+        case .evidence: .evidence
+        }
+    }
+}

--- a/app/SayItRight/Content/PyramidExercises/PyramidExerciseLibrary.swift
+++ b/app/SayItRight/Content/PyramidExercises/PyramidExerciseLibrary.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+/// Library of pyramid builder exercises, loaded from bundled JSON.
+struct PyramidExerciseLibrary: Sendable {
+    let exercises: [PyramidExercise]
+
+    /// Load exercises from the app bundle.
+    static func loadFromBundle() -> PyramidExerciseLibrary {
+        guard let url = Bundle.main.url(forResource: "pyramid-exercises", withExtension: "json"),
+              let data = try? Data(contentsOf: url),
+              let exercises = try? JSONDecoder().decode([PyramidExercise].self, from: data)
+        else {
+            return PyramidExerciseLibrary(exercises: [])
+        }
+        return PyramidExerciseLibrary(exercises: exercises)
+    }
+
+    init(exercises: [PyramidExercise]) {
+        self.exercises = exercises
+    }
+
+    /// Filter exercises by level and language.
+    func exercises(for level: Int, language: String) -> [PyramidExercise] {
+        exercises.filter { $0.level <= level && $0.language == language }
+    }
+
+    /// Select a random exercise, excluding recently seen IDs.
+    func randomExercise(for level: Int, language: String, excluding: Set<String>) -> PyramidExercise? {
+        let candidates = exercises(for: level, language: language)
+            .filter { !excluding.contains($0.id) }
+        if let result = candidates.randomElement() {
+            return result
+        }
+        // If all excluded, reset and pick any
+        return exercises(for: level, language: language).randomElement()
+    }
+}

--- a/app/SayItRight/Content/PyramidExercises/pyramid-exercises.json
+++ b/app/SayItRight/Content/PyramidExercises/pyramid-exercises.json
@@ -1,0 +1,185 @@
+[
+  {
+    "id": "pe-001-en",
+    "titleEN": "School Uniforms",
+    "titleDE": "Schuluniformen",
+    "level": 1,
+    "language": "en",
+    "governingThought": {
+      "id": "gt-001",
+      "text": "Schools should adopt uniforms because they reduce social pressure and improve focus.",
+      "type": "governing_thought"
+    },
+    "blocks": [
+      {
+        "id": "sp-001",
+        "text": "Uniforms reduce visible economic differences",
+        "type": "support_point"
+      },
+      {
+        "id": "sp-002",
+        "text": "Students focus more on learning",
+        "type": "support_point"
+      },
+      {
+        "id": "ev-001",
+        "text": "23% reduction in bullying incidents in pilot schools",
+        "type": "evidence"
+      },
+      {
+        "id": "ev-002",
+        "text": "Students no longer compete over brand-name clothing",
+        "type": "evidence"
+      },
+      {
+        "id": "ev-003",
+        "text": "Teacher surveys report fewer distractions in class",
+        "type": "evidence"
+      },
+      {
+        "id": "ev-004",
+        "text": "Homework completion rates rose 15% after uniform adoption",
+        "type": "evidence"
+      }
+    ],
+    "answerKey": {
+      "governingThoughtID": "gt-001",
+      "validGroupings": [
+        {
+          "groups": [
+            {
+              "parentBlockID": "sp-001",
+              "memberBlockIDs": ["ev-001", "ev-002"]
+            },
+            {
+              "parentBlockID": "sp-002",
+              "memberBlockIDs": ["ev-003", "ev-004"]
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "id": "pe-002-en",
+    "titleEN": "Homework Debate",
+    "titleDE": "Hausaufgaben-Debatte",
+    "level": 1,
+    "language": "en",
+    "governingThought": {
+      "id": "gt-002",
+      "text": "Homework should be reduced because it causes stress without improving learning outcomes.",
+      "type": "governing_thought"
+    },
+    "blocks": [
+      {
+        "id": "sp-003",
+        "text": "Excessive homework causes student burnout",
+        "type": "support_point"
+      },
+      {
+        "id": "sp-004",
+        "text": "Research shows diminishing returns beyond 1 hour",
+        "type": "support_point"
+      },
+      {
+        "id": "ev-005",
+        "text": "40% of students report homework-related anxiety",
+        "type": "evidence"
+      },
+      {
+        "id": "ev-006",
+        "text": "Sleep deprivation linked to heavy homework loads",
+        "type": "evidence"
+      },
+      {
+        "id": "ev-007",
+        "text": "Stanford study: no correlation between homework volume and test scores after 90 minutes",
+        "type": "evidence"
+      },
+      {
+        "id": "ev-008",
+        "text": "Finland assigns minimal homework and ranks top in PISA",
+        "type": "evidence"
+      }
+    ],
+    "answerKey": {
+      "governingThoughtID": "gt-002",
+      "validGroupings": [
+        {
+          "groups": [
+            {
+              "parentBlockID": "sp-003",
+              "memberBlockIDs": ["ev-005", "ev-006"]
+            },
+            {
+              "parentBlockID": "sp-004",
+              "memberBlockIDs": ["ev-007", "ev-008"]
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "id": "pe-001-de",
+    "titleEN": "School Uniforms",
+    "titleDE": "Schuluniformen",
+    "level": 1,
+    "language": "de",
+    "governingThought": {
+      "id": "gt-de-001",
+      "text": "Schulen sollten Uniformen einf\u00fchren, weil sie sozialen Druck reduzieren und die Konzentration verbessern.",
+      "type": "governing_thought"
+    },
+    "blocks": [
+      {
+        "id": "sp-de-001",
+        "text": "Uniformen reduzieren sichtbare wirtschaftliche Unterschiede",
+        "type": "support_point"
+      },
+      {
+        "id": "sp-de-002",
+        "text": "Sch\u00fcler konzentrieren sich mehr aufs Lernen",
+        "type": "support_point"
+      },
+      {
+        "id": "ev-de-001",
+        "text": "23% weniger Mobbing-Vorf\u00e4lle in Pilotschulen",
+        "type": "evidence"
+      },
+      {
+        "id": "ev-de-002",
+        "text": "Sch\u00fcler konkurrieren nicht mehr um Markenkleidung",
+        "type": "evidence"
+      },
+      {
+        "id": "ev-de-003",
+        "text": "Lehrer berichten von weniger Ablenkungen im Unterricht",
+        "type": "evidence"
+      },
+      {
+        "id": "ev-de-004",
+        "text": "Hausaufgaben-Abschlussrate stieg um 15% nach Uniform-Einf\u00fchrung",
+        "type": "evidence"
+      }
+    ],
+    "answerKey": {
+      "governingThoughtID": "gt-de-001",
+      "validGroupings": [
+        {
+          "groups": [
+            {
+              "parentBlockID": "sp-de-001",
+              "memberBlockIDs": ["ev-de-001", "ev-de-002"]
+            },
+            {
+              "parentBlockID": "sp-de-002",
+              "memberBlockIDs": ["ev-de-003", "ev-de-004"]
+            }
+          ]
+        }
+      ]
+    }
+  }
+]

--- a/app/SayItRight/Intelligence/ConversationManager/BuildThePyramidCoordinator.swift
+++ b/app/SayItRight/Intelligence/ConversationManager/BuildThePyramidCoordinator.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+/// Orchestrates the "Build the Pyramid" session flow.
+///
+/// Selects an exercise from the library and manages the session lifecycle
+/// including validation attempts and answer reveal.
+@MainActor
+@Observable
+final class BuildThePyramidCoordinator {
+
+    var recentExerciseIDs: Set<String> = []
+
+    private let library: PyramidExerciseLibrary
+    private let validationEngine = MECEValidationEngine()
+    private let maxRecentExercises = 10
+
+    init(library: PyramidExerciseLibrary = .loadFromBundle()) {
+        self.library = library
+    }
+
+    /// Convenience initialiser for testing.
+    init(exercises: [PyramidExercise]) {
+        self.library = PyramidExerciseLibrary(exercises: exercises)
+    }
+
+    /// Start a pyramid builder session.
+    ///
+    /// - Returns: The selected exercise, or `nil` if none available.
+    @discardableResult
+    func startSession(
+        sessionManager: SessionManager,
+        profile: LearnerProfile,
+        language: String
+    ) async -> PyramidExercise? {
+        guard let exercise = library.randomExercise(
+            for: profile.currentLevel,
+            language: language,
+            excluding: recentExerciseIDs
+        ) else {
+            return nil
+        }
+
+        trackSeen(exercise)
+        await sessionManager.startBuildThePyramidSession(
+            exercise: exercise,
+            profile: profile,
+            language: language
+        )
+        return exercise
+    }
+
+    /// Validate the user's pyramid arrangement.
+    func validateArrangement(
+        userTree: UserPyramidTree,
+        answerKey: PyramidAnswerKey
+    ) -> PyramidValidationResult {
+        validationEngine.validate(userTree: userTree, answerKey: answerKey)
+    }
+
+    private func trackSeen(_ exercise: PyramidExercise) {
+        recentExerciseIDs.insert(exercise.id)
+        if recentExerciseIDs.count > maxRecentExercises {
+            recentExerciseIDs.removeAll()
+            recentExerciseIDs.insert(exercise.id)
+        }
+    }
+}

--- a/app/SayItRight/Intelligence/ConversationManager/BuildThePyramidSession.swift
+++ b/app/SayItRight/Intelligence/ConversationManager/BuildThePyramidSession.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+/// Tracks the state of a "Build the Pyramid" session.
+struct BuildThePyramidSession: Sendable {
+    let exercise: PyramidExercise
+    let startedAt: Date
+    private(set) var attempts: Int = 0
+    private(set) var lastScore: Double?
+    private(set) var isComplete: Bool = false
+    private(set) var showedAnswer: Bool = false
+
+    /// Maximum attempts before "show answer" is offered.
+    let maxAttempts: Int
+
+    init(exercise: PyramidExercise, maxAttempts: Int = 3, startedAt: Date = .now) {
+        self.exercise = exercise
+        self.maxAttempts = maxAttempts
+        self.startedAt = startedAt
+    }
+
+    mutating func recordAttempt(score: Double) {
+        attempts += 1
+        lastScore = score
+        if score >= 1.0 {
+            isComplete = true
+        }
+    }
+
+    mutating func revealAnswer() {
+        showedAnswer = true
+        isComplete = true
+    }
+
+    var canShowAnswer: Bool {
+        attempts >= maxAttempts && !isComplete
+    }
+}

--- a/app/SayItRight/Intelligence/ConversationManager/SessionManager.swift
+++ b/app/SayItRight/Intelligence/ConversationManager/SessionManager.swift
@@ -46,6 +46,9 @@ final class SessionManager {
     /// The active "Spot the gap" session state, if any.
     private(set) var spotTheGapSession: SpotTheGapSession?
 
+    /// The active "Build the pyramid" session state, if any.
+    private(set) var buildThePyramidSession: BuildThePyramidSession?
+
     /// The active "Decode and rebuild" session state, if any.
     private(set) var decodeAndRebuildSession: DecodeAndRebuildSession?
 
@@ -109,6 +112,7 @@ final class SessionManager {
         analyseMyTextSession = nil
         fixThisMessSession = nil
         spotTheGapSession = nil
+        buildThePyramidSession = nil
         decodeAndRebuildSession = nil
 
         lastEvaluationResult = nil
@@ -154,6 +158,7 @@ final class SessionManager {
         analyseMyTextSession = nil
         fixThisMessSession = nil
         spotTheGapSession = nil
+        buildThePyramidSession = nil
         decodeAndRebuildSession = nil
 
         lastEvaluationResult = nil
@@ -206,6 +211,7 @@ final class SessionManager {
         analyseMyTextSession = nil
         fixThisMessSession = nil
         spotTheGapSession = nil
+        buildThePyramidSession = nil
         decodeAndRebuildSession = nil
 
         sessionState = .loading
@@ -353,6 +359,7 @@ final class SessionManager {
         analyseMyTextSession = nil
         fixThisMessSession = nil
         spotTheGapSession = nil
+        buildThePyramidSession = nil
         decodeAndRebuildSession = nil
 
         let duration = ElevatorPitchSession.duration(for: profile.currentLevel)
@@ -437,6 +444,7 @@ final class SessionManager {
         elevatorPitchSession = nil
         fixThisMessSession = nil
         spotTheGapSession = nil
+        buildThePyramidSession = nil
         decodeAndRebuildSession = nil
         analyseMyTextSession = AnalyseMyTextSession()
 
@@ -513,6 +521,7 @@ final class SessionManager {
         elevatorPitchSession = nil
         analyseMyTextSession = nil
         spotTheGapSession = nil
+        buildThePyramidSession = nil
         decodeAndRebuildSession = nil
         fixThisMessSession = FixThisMessSession(practiceText: practiceText)
 
@@ -584,6 +593,7 @@ final class SessionManager {
         elevatorPitchSession = nil
         analyseMyTextSession = nil
         fixThisMessSession = nil
+        buildThePyramidSession = nil
         decodeAndRebuildSession = nil
         spotTheGapSession = SpotTheGapSession(practiceText: practiceText)
 
@@ -651,6 +661,99 @@ final class SessionManager {
         just the structural concept.
         - Hints teach the NARROWING methodology: area → element → specific. \
         This narrowing process IS the skill being taught.
+        """
+    }
+
+    // MARK: - Build the Pyramid
+
+    /// Start a "Build the Pyramid" session with a selected exercise.
+    func startBuildThePyramidSession(exercise: PyramidExercise, profile: LearnerProfile, language: String) async {
+        messages = []
+        sessionMetadata = []
+        activeSessionType = .buildThePyramid
+        sayItClearlySession = nil
+        findThePointSession = nil
+        elevatorPitchSession = nil
+        analyseMyTextSession = nil
+        fixThisMessSession = nil
+        spotTheGapSession = nil
+        decodeAndRebuildSession = nil
+        buildThePyramidSession = BuildThePyramidSession(exercise: exercise)
+
+        lastEvaluationResult = nil
+        sessionState = .active
+
+        let basePrompt = systemPromptAssembler.assemble(
+            level: profile.currentLevel,
+            sessionType: SessionType.buildThePyramid.rawValue,
+            language: language,
+            profileJSON: profile.toPromptJSON()
+        )
+
+        let directive = pyramidDirectiveBlock(exercise: exercise, language: language)
+        systemPrompt = basePrompt + "\n\n" + directive
+
+        await structuralEvaluator.prepareSession(
+            level: profile.currentLevel,
+            sessionType: SessionType.buildThePyramid.rawValue,
+            language: language,
+            profile: profile
+        )
+    }
+
+    /// Send Barbara's evaluation of the user's pyramid arrangement.
+    func evaluatePyramidArrangement(description: String) async {
+        guard sessionState == .active else { return }
+
+        let learnerMessage = ChatMessage(role: .learner, text: description)
+        messages.append(learnerMessage)
+
+        await streamBarbaraResponse()
+    }
+
+    /// Record an attempt on the current pyramid session.
+    func recordPyramidAttempt(score: Double) {
+        buildThePyramidSession?.recordAttempt(score: score)
+    }
+
+    /// Reveal the answer for the current pyramid session.
+    func revealPyramidAnswer() {
+        buildThePyramidSession?.revealAnswer()
+    }
+
+    /// Build the directive block for pyramid exercises.
+    private func pyramidDirectiveBlock(exercise: PyramidExercise, language: String) -> String {
+        let blockList = exercise.blocks.map { "- [\($0.id)] \($0.text) (\($0.type.rawValue))" }.joined(separator: "\n")
+        let answerKey = exercise.answerKey
+        let groupsDesc = answerKey.validGroupings.first.map { grouping in
+            grouping.groups.map { group in
+                "Parent: \(group.parentBlockID) → Children: \(group.memberBlockIDs.sorted().joined(separator: ", "))"
+            }.joined(separator: "\n")
+        } ?? "No groupings defined"
+
+        return """
+        # Build the Pyramid Session
+
+        The learner is arranging blocks into a pyramid structure using drag-and-drop. \
+        You can see the exercise structure below.
+
+        **Governing Thought (fixed at top):** \(exercise.governingThought.text)
+
+        **Available Blocks:**
+        \(blockList)
+
+        **Answer Key (HIDDEN — do not reveal directly):**
+        Governing Thought ID: \(answerKey.governingThoughtID)
+        Valid Grouping:
+        \(groupsDesc)
+
+        When the learner submits their arrangement for evaluation:
+        - Explain WHY groupings are right or wrong, not just that they are
+        - Use structural vocabulary: "These two points overlap — they are not MECE" \
+        or "This evidence does not support this claim"
+        - First attempt: give hints. Second attempt: more specific guidance. \
+        Third attempt: reveal the answer with full explanation.
+        - Praise correct groupings even if the order within a group differs from the answer key.
         """
     }
 
@@ -844,6 +947,7 @@ final class SessionManager {
         analyseMyTextSession = nil
         fixThisMessSession = nil
         spotTheGapSession = nil
+        buildThePyramidSession = nil
         decodeAndRebuildSession = nil
 
         lastEvaluationResult = nil

--- a/app/SayItRight/Intelligence/ConversationManager/SessionType.swift
+++ b/app/SayItRight/Intelligence/ConversationManager/SessionType.swift
@@ -11,6 +11,7 @@ enum SessionType: String, CaseIterable, Identifiable, Sendable {
     case analyseMyText = "analyse-my-text"
     case fixThisMess = "fix-this-mess"
     case spotTheGap = "spot-the-gap"
+    case buildThePyramid = "build-the-pyramid"
     case decodeAndRebuild = "decode-and-rebuild"
 
     var id: String { rawValue }
@@ -30,6 +31,8 @@ enum SessionType: String, CaseIterable, Identifiable, Sendable {
             language == "de" ? "Räum das auf" : "Fix this mess"
         case .spotTheGap:
             language == "de" ? "Finde die Lücke" : "Spot the gap"
+        case .buildThePyramid:
+            language == "de" ? "Bau die Pyramide" : "Build the pyramid"
         case .decodeAndRebuild:
             language == "de" ? "Entschlüsseln und Neubauen" : "Decode and rebuild"
         }
@@ -54,6 +57,10 @@ enum SessionType: String, CaseIterable, Identifiable, Sendable {
             language == "de"
                 ? "F\u{00FC}g deinen eigenen Text ein. Barbara bewertet die Struktur."
                 : "Paste your own text. Barbara evaluates the structure."
+        case .buildThePyramid:
+            language == "de"
+                ? "Ordne Bausteine in eine Pyramide. Barbara pr\u{00FC}ft ob sie MECE ist."
+                : "Arrange blocks into a pyramid. Barbara checks if it is MECE."
         case .fixThisMess:
             language == "de"
                 ? "Bringe Ordnung in ein schlecht strukturiertes Argument."
@@ -76,6 +83,7 @@ enum SessionType: String, CaseIterable, Identifiable, Sendable {
         case .findThePoint: "magnifyingglass"
         case .elevatorPitch: "timer"
         case .analyseMyText: "doc.text"
+        case .buildThePyramid: "rectangle.3.group"
         case .fixThisMess: "arrow.up.and.down.text.horizontal"
         case .spotTheGap: "eye.trianglebadge.exclamationmark"
         case .decodeAndRebuild: "arrow.triangle.2.circlepath"

--- a/app/SayItRight/Presentation/PyramidBuilder/PyramidTreeState.swift
+++ b/app/SayItRight/Presentation/PyramidBuilder/PyramidTreeState.swift
@@ -72,6 +72,11 @@ final class PyramidTreeState {
         self.unplacedBlocks = blocks
     }
 
+    /// Add a block to the unplaced pool.
+    func addToUnplacedPool(_ block: PyramidBlock) {
+        unplacedBlocks.append(block)
+    }
+
     // MARK: - Tree Construction
 
     /// Build a TreeNode hierarchy from placed blocks, starting at the given root.

--- a/app/SayItRight/Presentation/Session/BuildThePyramidView.swift
+++ b/app/SayItRight/Presentation/Session/BuildThePyramidView.swift
@@ -1,0 +1,384 @@
+import SwiftUI
+
+/// Full session view for "Build the Pyramid" exercises.
+///
+/// Displays the governing thought at top, an unplaced block pool, and the
+/// pyramid canvas where users drag blocks into position. Barbara evaluates
+/// via a sidebar chat after the user taps "Check".
+struct BuildThePyramidView: View {
+    let sessionManager: SessionManager
+    let coordinator: BuildThePyramidCoordinator
+    let profile: LearnerProfile
+    let language: String
+    var onDismiss: (() -> Void)?
+
+    @State private var viewModel: ChatViewModel
+    @State private var treeState = PyramidTreeState()
+    @State private var sessionStarted = false
+    @State private var noExercisesAvailable = false
+    @State private var exercise: PyramidExercise?
+    @State private var validationResult: PyramidValidationResult?
+    @State private var blockFeedbackStates: [String: BlockFeedbackState] = [:]
+    @State private var gapPlacements: [GapPlacement] = []
+    @State private var isPyramidComplete = false
+    @State private var feedbackConfig = FeedbackConfiguration()
+    @State private var attempts = 0
+
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+
+    init(
+        sessionManager: SessionManager,
+        coordinator: BuildThePyramidCoordinator,
+        profile: LearnerProfile,
+        language: String,
+        onDismiss: (() -> Void)? = nil
+    ) {
+        self.sessionManager = sessionManager
+        self.coordinator = coordinator
+        self.profile = profile
+        self.language = language
+        self.onDismiss = onDismiss
+        self._viewModel = State(initialValue: ChatViewModel(sessionManager: sessionManager))
+    }
+
+    var body: some View {
+        Group {
+            if noExercisesAvailable {
+                noExercisesView
+            } else if exercise != nil {
+                sessionContent
+            } else {
+                ProgressView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+        }
+        .navigationTitle(SessionType.buildThePyramid.displayName(language: language))
+        #if !os(macOS)
+        .navigationBarTitleDisplayMode(.inline)
+        #endif
+        .toolbar {
+            ToolbarItem(placement: .automatic) {
+                Button(action: endSessionAndDismiss) {
+                    Label(
+                        language == "de" ? "Beenden" : "End Session",
+                        systemImage: "xmark.circle"
+                    )
+                }
+            }
+        }
+        .task {
+            guard !sessionStarted else { return }
+            sessionStarted = true
+            let ex = await coordinator.startSession(
+                sessionManager: sessionManager,
+                profile: profile,
+                language: language
+            )
+            if let ex {
+                exercise = ex
+                setupExercise(ex)
+            } else {
+                noExercisesAvailable = true
+            }
+        }
+    }
+
+    // MARK: - Session Content
+
+    @ViewBuilder
+    private var sessionContent: some View {
+        #if os(macOS)
+        splitLayout
+        #else
+        if horizontalSizeClass == .regular {
+            splitLayout
+        } else {
+            compactLayout
+        }
+        #endif
+    }
+
+    /// iPad/Mac: pyramid left, chat right.
+    private var splitLayout: some View {
+        HStack(spacing: 0) {
+            pyramidCanvas
+                .frame(maxWidth: .infinity)
+
+            Divider()
+
+            VStack(spacing: 0) {
+                ChatView(viewModel: viewModel)
+                    .frame(maxWidth: .infinity)
+            }
+            .frame(width: 320)
+        }
+    }
+
+    /// iPhone: pyramid above, feedback below.
+    private var compactLayout: some View {
+        VStack(spacing: 0) {
+            pyramidCanvas
+
+            Divider()
+
+            ChatView(viewModel: viewModel)
+                .frame(maxHeight: 200)
+        }
+    }
+
+    // MARK: - Pyramid Canvas
+
+    private var pyramidCanvas: some View {
+        VStack(spacing: 12) {
+            // Governing thought (fixed at top)
+            if let ex = exercise {
+                Text(ex.governingThought.text)
+                    .font(.headline)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 10)
+                    .background(BlockType.governingThought.color.opacity(0.15))
+                    .clipShape(RoundedRectangle(cornerRadius: 10))
+                    .padding(.top, 12)
+            }
+
+            // Pyramid tree area
+            GeometryReader { geo in
+                ZStack {
+                    // Connection lines
+                    if let rootID = treeState.rootBlockID,
+                       let rootNode = treeState.buildTreeNode(from: rootID) {
+                        ConnectionLinesView(
+                            nodeLayouts: treeState.nodeLayouts,
+                            connections: rootNode.extractConnections(),
+                            dragOverrides: [:]
+                        )
+                    }
+
+                    // Drop zones
+                    DropZoneOverlay(
+                        zones: treeState.dropZones,
+                        highlightedZoneID: treeState.highlightedZoneID
+                    )
+
+                    // Placed blocks
+                    ForEach(Array(treeState.placedBlocks.values), id: \.id) { placed in
+                        if let layout = treeState.nodeLayouts[placed.id.uuidString] {
+                            DraggableBlockView(
+                                block: placed.block,
+                                visualState: .placed,
+                                onDragChanged: { value in
+                                    treeState.beginDrag(blockID: placed.id)
+                                    treeState.updateDrag(position: value.location)
+                                },
+                                onDragEnded: { value in
+                                    if let zone = treeState.endDrag(position: value.location) {
+                                        treeState.reparentBlock(placed.id, toParent: UUID(uuidString: zone.parentID)!, atIndex: zone.childIndex)
+                                    }
+                                }
+                            )
+                            .validationFeedback(blockFeedbackStates[placed.id.uuidString] ?? .none)
+                            .position(layout.center)
+                        }
+                    }
+
+                    // Feedback overlays
+                    if feedbackConfig.isEnabled {
+                        PyramidFeedbackOverlay(
+                            blockFeedbackStates: blockFeedbackStates,
+                            gaps: gapPlacements,
+                            nodeLayouts: treeState.nodeLayouts,
+                            layoutEngine: treeState.layoutEngine,
+                            isPyramidComplete: isPyramidComplete,
+                            configuration: $feedbackConfig
+                        )
+                    }
+                }
+            }
+
+            // Unplaced blocks pool
+            UnplacedBlocksPool(
+                blocks: treeState.unplacedBlocks,
+                onDragChanged: { block, value in
+                    treeState.beginDrag(blockID: block.id)
+                    treeState.updateDrag(position: value.location)
+                },
+                onDragEnded: { block, value in
+                    // endDrag handles placement from unplaced pool internally
+                    let zone = treeState.endDrag(position: value.location)
+                    if zone == nil {
+                        // Dropped outside any zone — place under root as fallback
+                        placeBlockInTree(block)
+                    }
+                }
+            )
+            .padding(.horizontal, 12)
+            .padding(.bottom, 8)
+
+            // Action buttons
+            HStack(spacing: 16) {
+                Button(action: checkArrangement) {
+                    Label(
+                        language == "de" ? "Prüfen" : "Check",
+                        systemImage: "checkmark.circle"
+                    )
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(treeState.unplacedBlocks.count > 0)
+
+                if sessionManager.buildThePyramidSession?.canShowAnswer == true {
+                    Button(action: showAnswer) {
+                        Label(
+                            language == "de" ? "Lösung zeigen" : "Show Answer",
+                            systemImage: "eye"
+                        )
+                    }
+                    .buttonStyle(.bordered)
+                }
+            }
+            .padding(.bottom, 12)
+        }
+    }
+
+    // MARK: - Exercise Setup
+
+    private func setupExercise(_ exercise: PyramidExercise) {
+        // Place governing thought as root
+        let rootBlock = PyramidBlock(
+            text: exercise.governingThought.text,
+            type: exercise.governingThought.type.blockType,
+            level: 0
+        )
+        treeState.placeAsRoot(rootBlock)
+
+        // Add remaining blocks to unplaced pool
+        for block in exercise.blocks {
+            let pyramidBlock = PyramidBlock(
+                text: block.text,
+                type: block.type.blockType,
+                level: nil
+            )
+            treeState.addToUnplacedPool(pyramidBlock)
+        }
+    }
+
+    private func placeBlockInTree(_ block: PyramidBlock) {
+        // Place under root if no children yet, or find first available parent
+        guard let rootID = treeState.rootBlockID else { return }
+        let childCount = treeState.placedBlocks[rootID]?.childIDs.count ?? 0
+        treeState.placeBlock(block, underParent: rootID, atIndex: childCount)
+    }
+
+    // MARK: - Validation
+
+    private func checkArrangement() {
+        guard let exercise else { return }
+
+        let userTree = UserPyramidTree.from(treeState)
+        let result = coordinator.validateArrangement(
+            userTree: userTree,
+            answerKey: exercise.answerKey
+        )
+        validationResult = result
+        attempts += 1
+        sessionManager.recordPyramidAttempt(score: result.score)
+
+        // Map validation result to visual feedback
+        blockFeedbackStates = ValidationFeedbackMapper.blockFeedbackStates(from: result)
+        gapPlacements = ValidationFeedbackMapper.gapPlacements(from: result)
+        isPyramidComplete = ValidationFeedbackMapper.isPyramidComplete(result)
+        feedbackConfig.isEnabled = true
+
+        // Send description to Barbara for textual feedback
+        let description = buildArrangementDescription(result: result)
+        Task {
+            await sessionManager.evaluatePyramidArrangement(description: description)
+        }
+    }
+
+    private func buildArrangementDescription(result: PyramidValidationResult) -> String {
+        let score = Int(result.score * 100)
+        let correct = result.blockStatuses.values.filter { if case .correct = $0 { return true } else { return false } }.count
+        let total = result.blockStatuses.count
+        let govCorrect = result.governingThoughtCorrect ? "yes" : "no"
+
+        var desc = "[PYRAMID CHECK — Attempt \(attempts)]\n"
+        desc += "Score: \(score)%, Correct blocks: \(correct)/\(total), Governing thought correct: \(govCorrect)\n"
+
+        for assessment in result.groupAssessments {
+            if !assessment.overlappingMembers.isEmpty {
+                desc += "MECE violation: group under \(assessment.userParentBlockID) has overlapping members\n"
+            }
+            if !assessment.missingMembers.isEmpty {
+                desc += "Missing members in group under \(assessment.userParentBlockID)\n"
+            }
+        }
+
+        if result.score >= 1.0 {
+            desc += "PYRAMID COMPLETE — all blocks correctly placed."
+        }
+
+        return desc
+    }
+
+    private func showAnswer() {
+        sessionManager.revealPyramidAnswer()
+        Task {
+            await sessionManager.evaluatePyramidArrangement(
+                description: "[SHOW ANSWER REQUESTED — reveal the correct arrangement and explain why]"
+            )
+        }
+    }
+
+    // MARK: - No Exercises
+
+    private var noExercisesView: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "rectangle.3.group")
+                .font(.system(size: 48))
+                .foregroundStyle(.secondary)
+
+            Text(language == "de"
+                 ? "Keine \u{00DC}bungen verf\u{00FC}gbar"
+                 : "No exercises available")
+                .font(.title3)
+                .fontWeight(.semibold)
+
+            Text(language == "de"
+                 ? "Es gibt aktuell keine passenden \u{00DC}bungen f\u{00FC}r dein Level."
+                 : "There are no matching exercises for your current level.")
+                .font(.body)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+
+            if let onDismiss {
+                Button(language == "de" ? "Zur\u{00FC}ck" : "Go Back") {
+                    onDismiss()
+                }
+                .buttonStyle(.borderedProminent)
+                .padding(.top, 8)
+            }
+        }
+        .padding(32)
+    }
+
+    // MARK: - Actions
+
+    private func endSessionAndDismiss() {
+        sessionManager.endSession()
+        onDismiss?()
+    }
+}
+
+// MARK: - Previews
+
+#Preview("Build the Pyramid") {
+    NavigationStack {
+        BuildThePyramidView(
+            sessionManager: SessionManager(),
+            coordinator: BuildThePyramidCoordinator(exercises: []),
+            profile: .createDefault(displayName: "Alex"),
+            language: "en"
+        )
+    }
+}

--- a/app/SayItRight/Tests/BuildThePyramidTests.swift
+++ b/app/SayItRight/Tests/BuildThePyramidTests.swift
@@ -1,0 +1,156 @@
+import Foundation
+import Testing
+@testable import SayItRight
+
+@Suite("Build the Pyramid")
+struct BuildThePyramidTests {
+
+    // MARK: - Session Type
+
+    @Test("SessionType includes buildThePyramid")
+    func sessionTypeExists() {
+        let type = SessionType.buildThePyramid
+        #expect(type.rawValue == "build-the-pyramid")
+    }
+
+    @Test("buildThePyramid has display names")
+    func displayNames() {
+        let en = SessionType.buildThePyramid.displayName(language: "en")
+        let de = SessionType.buildThePyramid.displayName(language: "de")
+        #expect(en == "Build the pyramid")
+        #expect(de == "Bau die Pyramide")
+    }
+
+    @Test("buildThePyramid has icon")
+    func icon() {
+        #expect(SessionType.buildThePyramid.iconName == "rectangle.3.group")
+    }
+
+    // MARK: - Exercise Data Model
+
+    @Test("PyramidExercise is decodable from JSON")
+    func exerciseDecodable() throws {
+        let json = """
+        {
+            "id": "test-001",
+            "titleEN": "Test",
+            "titleDE": "Test",
+            "level": 1,
+            "language": "en",
+            "governingThought": {
+                "id": "gt-1",
+                "text": "Main claim",
+                "type": "governing_thought"
+            },
+            "blocks": [
+                {"id": "sp-1", "text": "Support 1", "type": "support_point"},
+                {"id": "ev-1", "text": "Evidence 1", "type": "evidence"}
+            ],
+            "answerKey": {
+                "governingThoughtID": "gt-1",
+                "validGroupings": [{
+                    "groups": [{
+                        "parentBlockID": "sp-1",
+                        "memberBlockIDs": ["ev-1"]
+                    }]
+                }]
+            }
+        }
+        """.data(using: .utf8)!
+
+        let exercise = try JSONDecoder().decode(PyramidExercise.self, from: json)
+        #expect(exercise.id == "test-001")
+        #expect(exercise.blocks.count == 2)
+        #expect(exercise.governingThought.type == .governingThought)
+        #expect(exercise.answerKey.governingThoughtID == "gt-1")
+    }
+
+    // MARK: - Session State
+
+    @Test("BuildThePyramidSession tracks attempts")
+    func sessionTracksAttempts() {
+        var session = BuildThePyramidSession(
+            exercise: makeTestExercise(),
+            maxAttempts: 3
+        )
+        #expect(session.attempts == 0)
+        #expect(!session.isComplete)
+        #expect(!session.canShowAnswer)
+
+        session.recordAttempt(score: 0.5)
+        #expect(session.attempts == 1)
+        #expect(!session.isComplete)
+        #expect(!session.canShowAnswer)
+
+        session.recordAttempt(score: 0.7)
+        session.recordAttempt(score: 0.8)
+        #expect(session.attempts == 3)
+        #expect(session.canShowAnswer)
+    }
+
+    @Test("Session completes on perfect score")
+    func sessionCompletesOnPerfect() {
+        var session = BuildThePyramidSession(exercise: makeTestExercise())
+        session.recordAttempt(score: 1.0)
+        #expect(session.isComplete)
+    }
+
+    @Test("Session can reveal answer")
+    func sessionRevealsAnswer() {
+        var session = BuildThePyramidSession(exercise: makeTestExercise())
+        session.revealAnswer()
+        #expect(session.isComplete)
+        #expect(session.showedAnswer)
+    }
+
+    // MARK: - Exercise Block Type
+
+    @Test("ExerciseBlockType converts to BlockType")
+    func blockTypeConversion() {
+        #expect(ExerciseBlockType.governingThought.blockType == .governingThought)
+        #expect(ExerciseBlockType.supportPoint.blockType == .supportPoint)
+        #expect(ExerciseBlockType.evidence.blockType == .evidence)
+    }
+
+    // MARK: - Library
+
+    @Test("PyramidExerciseLibrary filters by level and language")
+    func libraryFilters() {
+        let ex1 = makeTestExercise(id: "l1-en", level: 1, language: "en")
+        let ex2 = makeTestExercise(id: "l2-en", level: 2, language: "en")
+        let ex3 = makeTestExercise(id: "l1-de", level: 1, language: "de")
+        let library = PyramidExerciseLibrary(exercises: [ex1, ex2, ex3])
+
+        let l1en = library.exercises(for: 1, language: "en")
+        #expect(l1en.count == 1)
+        #expect(l1en[0].id == "l1-en")
+
+        let l2en = library.exercises(for: 2, language: "en")
+        #expect(l2en.count == 2) // level <= 2 returns both l1 and l2
+    }
+
+    // MARK: - Helpers
+
+    private func makeTestExercise(id: String = "test", level: Int = 1, language: String = "en") -> PyramidExercise {
+        PyramidExercise(
+            id: id,
+            titleEN: "Test",
+            titleDE: "Test",
+            level: level,
+            language: language,
+            governingThought: ExerciseBlock(id: "gt", text: "Claim", type: .governingThought),
+            blocks: [
+                ExerciseBlock(id: "sp", text: "Support", type: .supportPoint),
+                ExerciseBlock(id: "ev", text: "Evidence", type: .evidence),
+            ],
+            answerKey: PyramidAnswerKey(
+                governingThoughtID: "gt",
+                validGroupings: [
+                    ValidGrouping(groups: [
+                        ValidGroup(parentBlockID: "sp", memberBlockIDs: ["ev"])
+                    ])
+                ]
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `PyramidExercise` data model, JSON exercise library (3 exercises: 2 EN, 1 DE), and `PyramidExerciseLibrary` with level/language filtering
- Adds `BuildThePyramidSession` for attempt tracking, score recording, and answer reveal
- Adds `BuildThePyramidCoordinator` for exercise selection and MECE validation orchestration
- Adds `BuildThePyramidView` with split (iPad/Mac) and compact (iPhone) layouts, drag-drop from unplaced pool, validation feedback overlays, and Barbara chat sidebar
- Extends `SessionManager` with pyramid session lifecycle methods
- Adds `buildThePyramid` to `SessionType` with display names, subtitle, and icon
- 9 tests covering data model decoding, session state, block type conversion, and library filtering

Closes #70

## Test plan
- [x] `swift build` passes
- [x] All 9 BuildThePyramidTests pass
- [ ] Manual: launch app, select Build the Pyramid, verify exercise loads
- [ ] Manual: drag blocks into tree, tap Check, verify feedback overlays
- [ ] Manual: exhaust attempts, verify Show Answer button appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)