### PR TITLE
feat: Fix This Mess visual variant

### DIFF
--- a/app/SayItRight/App/SayItRightApp.swift
+++ b/app/SayItRight/App/SayItRightApp.swift
@@ -53,6 +53,7 @@ struct ContentView: View {
     @State private var spotTheGapCoordinator = SpotTheGapCoordinator()
     @State private var buildThePyramidCoordinator = BuildThePyramidCoordinator()
     @State private var decodeAndRebuildCoordinator = DecodeAndRebuildCoordinator()
+    @State private var fixThisMessVisualCoordinator = FixThisMessVisualCoordinator()
     @State private var showSayItClearly = false
     @State private var showVoiceSayItClearly = false
     @State private var showFindThePoint = false
@@ -62,6 +63,7 @@ struct ContentView: View {
     @State private var showBuildThePyramid = false
     @State private var showAnalyseMyText = false
     @State private var showFixThisMess = false
+    @State private var showFixThisMessVisual = false
     @State private var showSpotTheGap = false
     @State private var showDecodeAndRebuild = false
     @State private var showDashboard = false
@@ -121,7 +123,15 @@ struct ContentView: View {
                 case .analyseMyText:
                     showAnalyseMyText = true
                 case .fixThisMess:
-                    showFixThisMess = true
+                    #if os(iOS)
+                    if horizontalSizeClass == .regular {
+                        showFixThisMessVisual = true
+                    } else {
+                        showFixThisMess = true
+                    }
+                    #else
+                    showFixThisMessVisual = true
+                    #endif
                 case .spotTheGap:
                     showSpotTheGap = true
                 case .decodeAndRebuild:
@@ -215,6 +225,16 @@ struct ContentView: View {
                     language: language
                 ) {
                     showFixThisMess = false
+                }
+            }
+            .navigationDestination(isPresented: $showFixThisMessVisual) {
+                FixThisMessVisualView(
+                    sessionManager: sessionManager,
+                    coordinator: fixThisMessVisualCoordinator,
+                    profile: profile,
+                    language: language
+                ) {
+                    showFixThisMessVisual = false
                 }
             }
             .navigationDestination(isPresented: $showSpotTheGap) {

--- a/app/SayItRight/Content/PyramidExercises/FixThisMessExercise.swift
+++ b/app/SayItRight/Content/PyramidExercises/FixThisMessExercise.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// An exercise for "Fix this mess" visual mode.
+///
+/// Contains a pyramid exercise with an intentionally wrong initial arrangement.
+/// The user must diagnose and fix the structural problems.
+struct FixThisMessExercise: Codable, Sendable, Identifiable {
+    let id: String
+    let titleEN: String
+    let titleDE: String
+    let level: Int
+    let language: String
+
+    /// The correct governing thought block.
+    let governingThought: ExerciseBlock
+
+    /// All blocks (support points and evidence) in the exercise.
+    let blocks: [ExerciseBlock]
+
+    /// The correct answer key.
+    let answerKey: PyramidAnswerKey
+
+    /// The wrong initial arrangement: maps parent block IDs to child block IDs.
+    /// The governing thought is always placed as root.
+    let wrongArrangement: WrongArrangement
+
+    /// Description of what is structurally wrong (for Barbara's reference).
+    let structuralFlawDescription: String
+
+    func title(language: String) -> String {
+        language == "de" ? titleDE : titleEN
+    }
+}
+
+/// Describes a wrong initial arrangement of blocks in the pyramid.
+struct WrongArrangement: Codable, Sendable, Equatable {
+    /// Parent-to-children mapping. Keys are block IDs from the exercise.
+    let groups: [WrongGroup]
+}
+
+/// A single wrong grouping in the initial arrangement.
+struct WrongGroup: Codable, Sendable, Equatable {
+    /// The parent block ID.
+    let parentBlockID: String
+    /// The child block IDs placed under this parent (in wrong order/grouping).
+    let childBlockIDs: [String]
+}

--- a/app/SayItRight/Content/PyramidExercises/FixThisMessExerciseLibrary.swift
+++ b/app/SayItRight/Content/PyramidExercises/FixThisMessExerciseLibrary.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// Manages the library of "Fix this mess" visual exercises.
+struct FixThisMessExerciseLibrary: Sendable {
+    let exercises: [FixThisMessExercise]
+
+    /// Load exercises from the bundled JSON file.
+    static func loadFromBundle() -> FixThisMessExerciseLibrary {
+        guard let url = Bundle.main.url(
+            forResource: "fix-this-mess-exercises",
+            withExtension: "json"
+        ) else {
+            return FixThisMessExerciseLibrary(exercises: [])
+        }
+
+        do {
+            let data = try Data(contentsOf: url)
+            let exercises = try JSONDecoder().decode([FixThisMessExercise].self, from: data)
+            return FixThisMessExerciseLibrary(exercises: exercises)
+        } catch {
+            return FixThisMessExerciseLibrary(exercises: [])
+        }
+    }
+
+    /// Filter exercises by level and language.
+    func exercises(for level: Int, language: String) -> [FixThisMessExercise] {
+        exercises.filter { $0.level <= level && $0.language == language }
+    }
+
+    /// Pick a random exercise, excluding recently seen IDs.
+    func randomExercise(
+        for level: Int,
+        language: String,
+        excluding recentIDs: Set<String> = []
+    ) -> FixThisMessExercise? {
+        var candidates = exercises(for: level, language: language)
+        let unseen = candidates.filter { !recentIDs.contains($0.id) }
+        if !unseen.isEmpty { candidates = unseen }
+        return candidates.randomElement()
+    }
+}

--- a/app/SayItRight/Content/PyramidExercises/fix-this-mess-exercises.json
+++ b/app/SayItRight/Content/PyramidExercises/fix-this-mess-exercises.json
@@ -1,0 +1,224 @@
+[
+  {
+    "id": "ftm-001-en",
+    "titleEN": "School Uniforms (Broken)",
+    "titleDE": "Schuluniformen (Kaputt)",
+    "level": 1,
+    "language": "en",
+    "governingThought": {
+      "id": "gt-001",
+      "text": "Schools should adopt uniforms because they reduce social pressure and improve focus.",
+      "type": "governing_thought"
+    },
+    "blocks": [
+      {
+        "id": "sp-001",
+        "text": "Uniforms reduce visible economic differences",
+        "type": "support_point"
+      },
+      {
+        "id": "sp-002",
+        "text": "Students focus more on learning",
+        "type": "support_point"
+      },
+      {
+        "id": "ev-001",
+        "text": "23% reduction in bullying incidents in pilot schools",
+        "type": "evidence"
+      },
+      {
+        "id": "ev-002",
+        "text": "Students no longer compete over brand-name clothing",
+        "type": "evidence"
+      },
+      {
+        "id": "ev-003",
+        "text": "Teacher surveys report fewer distractions in class",
+        "type": "evidence"
+      },
+      {
+        "id": "ev-004",
+        "text": "Homework completion rates rose 15% after uniform adoption",
+        "type": "evidence"
+      }
+    ],
+    "answerKey": {
+      "governingThoughtID": "gt-001",
+      "validGroupings": [
+        {
+          "groups": [
+            {
+              "parentBlockID": "sp-001",
+              "memberBlockIDs": ["ev-001", "ev-002"]
+            },
+            {
+              "parentBlockID": "sp-002",
+              "memberBlockIDs": ["ev-003", "ev-004"]
+            }
+          ]
+        }
+      ]
+    },
+    "wrongArrangement": {
+      "groups": [
+        {
+          "parentBlockID": "sp-001",
+          "childBlockIDs": ["ev-001", "ev-003"]
+        },
+        {
+          "parentBlockID": "sp-002",
+          "childBlockIDs": ["ev-002", "ev-004"]
+        }
+      ]
+    },
+    "structuralFlawDescription": "Evidence is assigned to the wrong support points. 'Teacher surveys report fewer distractions' supports 'focus on learning', not 'economic differences'. Similarly, 'competing over brand-name clothing' supports 'economic differences', not 'focus'."
+  },
+  {
+    "id": "ftm-002-en",
+    "titleEN": "Homework Debate (Broken)",
+    "titleDE": "Hausaufgaben-Debatte (Kaputt)",
+    "level": 1,
+    "language": "en",
+    "governingThought": {
+      "id": "gt-002",
+      "text": "Homework should be reduced because it causes stress without improving learning outcomes.",
+      "type": "governing_thought"
+    },
+    "blocks": [
+      {
+        "id": "sp-003",
+        "text": "Excessive homework causes student burnout",
+        "type": "support_point"
+      },
+      {
+        "id": "sp-004",
+        "text": "Research shows diminishing returns beyond 1 hour",
+        "type": "support_point"
+      },
+      {
+        "id": "ev-005",
+        "text": "40% of students report homework-related anxiety",
+        "type": "evidence"
+      },
+      {
+        "id": "ev-006",
+        "text": "Sleep deprivation linked to heavy homework loads",
+        "type": "evidence"
+      },
+      {
+        "id": "ev-007",
+        "text": "Stanford study: no correlation between homework volume and test scores after 90 minutes",
+        "type": "evidence"
+      },
+      {
+        "id": "ev-008",
+        "text": "Finland assigns minimal homework and ranks top in PISA",
+        "type": "evidence"
+      }
+    ],
+    "answerKey": {
+      "governingThoughtID": "gt-002",
+      "validGroupings": [
+        {
+          "groups": [
+            {
+              "parentBlockID": "sp-003",
+              "memberBlockIDs": ["ev-005", "ev-006"]
+            },
+            {
+              "parentBlockID": "sp-004",
+              "memberBlockIDs": ["ev-007", "ev-008"]
+            }
+          ]
+        }
+      ]
+    },
+    "wrongArrangement": {
+      "groups": [
+        {
+          "parentBlockID": "sp-003",
+          "childBlockIDs": ["ev-005", "ev-007"]
+        },
+        {
+          "parentBlockID": "sp-004",
+          "childBlockIDs": ["ev-006", "ev-008"]
+        }
+      ]
+    },
+    "structuralFlawDescription": "Evidence is swapped between groups. The Stanford study about homework volume and test scores supports 'diminishing returns', not 'burnout'. Sleep deprivation supports 'burnout', not 'research results'."
+  },
+  {
+    "id": "ftm-001-de",
+    "titleEN": "School Uniforms (Broken)",
+    "titleDE": "Schuluniformen (Kaputt)",
+    "level": 1,
+    "language": "de",
+    "governingThought": {
+      "id": "gt-de-001",
+      "text": "Schulen sollten Uniformen einf\u00fchren, weil sie sozialen Druck reduzieren und die Konzentration verbessern.",
+      "type": "governing_thought"
+    },
+    "blocks": [
+      {
+        "id": "sp-de-001",
+        "text": "Uniformen reduzieren sichtbare wirtschaftliche Unterschiede",
+        "type": "support_point"
+      },
+      {
+        "id": "sp-de-002",
+        "text": "Sch\u00fcler konzentrieren sich mehr aufs Lernen",
+        "type": "support_point"
+      },
+      {
+        "id": "ev-de-001",
+        "text": "23% weniger Mobbing-Vorf\u00e4lle in Pilotschulen",
+        "type": "evidence"
+      },
+      {
+        "id": "ev-de-002",
+        "text": "Sch\u00fcler konkurrieren nicht mehr um Markenkleidung",
+        "type": "evidence"
+      },
+      {
+        "id": "ev-de-003",
+        "text": "Lehrer berichten von weniger Ablenkungen im Unterricht",
+        "type": "evidence"
+      },
+      {
+        "id": "ev-de-004",
+        "text": "Hausaufgaben-Abschlussrate stieg um 15% nach Uniform-Einf\u00fchrung",
+        "type": "evidence"
+      }
+    ],
+    "answerKey": {
+      "governingThoughtID": "gt-de-001",
+      "validGroupings": [
+        {
+          "groups": [
+            {
+              "parentBlockID": "sp-de-001",
+              "memberBlockIDs": ["ev-de-001", "ev-de-002"]
+            },
+            {
+              "parentBlockID": "sp-de-002",
+              "memberBlockIDs": ["ev-de-003", "ev-de-004"]
+            }
+          ]
+        }
+      ]
+    },
+    "wrongArrangement": {
+      "groups": [
+        {
+          "parentBlockID": "sp-de-001",
+          "childBlockIDs": ["ev-de-001", "ev-de-003"]
+        },
+        {
+          "parentBlockID": "sp-de-002",
+          "childBlockIDs": ["ev-de-002", "ev-de-004"]
+        }
+      ]
+    },
+    "structuralFlawDescription": "Belege sind den falschen St\u00fctzpunkten zugeordnet. 'Lehrer berichten von weniger Ablenkungen' geh\u00f6rt zu 'Konzentration aufs Lernen', nicht zu 'wirtschaftliche Unterschiede'."
+  }
+]

--- a/app/SayItRight/Intelligence/ConversationManager/FixThisMessVisualCoordinator.swift
+++ b/app/SayItRight/Intelligence/ConversationManager/FixThisMessVisualCoordinator.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+/// Orchestrates the visual "Fix this mess" session flow.
+///
+/// Similar to BuildThePyramidCoordinator but starts from a wrong arrangement
+/// rather than an empty pyramid.
+@MainActor
+@Observable
+final class FixThisMessVisualCoordinator {
+
+    var recentExerciseIDs: Set<String> = []
+
+    private let library: FixThisMessExerciseLibrary
+    private let validationEngine = MECEValidationEngine()
+    private let maxRecentExercises = 10
+
+    init(library: FixThisMessExerciseLibrary = .loadFromBundle()) {
+        self.library = library
+    }
+
+    /// Convenience initialiser for testing.
+    init(exercises: [FixThisMessExercise]) {
+        self.library = FixThisMessExerciseLibrary(exercises: exercises)
+    }
+
+    /// Start a visual fix-this-mess session.
+    ///
+    /// - Returns: The selected exercise, or `nil` if none available.
+    @discardableResult
+    func startSession(
+        sessionManager: SessionManager,
+        profile: LearnerProfile,
+        language: String
+    ) async -> FixThisMessExercise? {
+        guard let exercise = library.randomExercise(
+            for: profile.currentLevel,
+            language: language,
+            excluding: recentExerciseIDs
+        ) else {
+            return nil
+        }
+
+        trackSeen(exercise)
+        await sessionManager.startFixThisMessVisualSession(
+            exercise: exercise,
+            profile: profile,
+            language: language
+        )
+        return exercise
+    }
+
+    /// Validate the user's fixed arrangement.
+    func validateArrangement(
+        userTree: UserPyramidTree,
+        answerKey: PyramidAnswerKey
+    ) -> PyramidValidationResult {
+        validationEngine.validate(userTree: userTree, answerKey: answerKey)
+    }
+
+    private func trackSeen(_ exercise: FixThisMessExercise) {
+        recentExerciseIDs.insert(exercise.id)
+        if recentExerciseIDs.count > maxRecentExercises {
+            recentExerciseIDs.removeAll()
+            recentExerciseIDs.insert(exercise.id)
+        }
+    }
+}

--- a/app/SayItRight/Intelligence/ConversationManager/SessionManager.swift
+++ b/app/SayItRight/Intelligence/ConversationManager/SessionManager.swift
@@ -757,6 +757,85 @@ final class SessionManager {
         """
     }
 
+    // MARK: - Fix This Mess (Visual)
+
+    /// Start a visual "Fix this mess" session with a broken pyramid arrangement.
+    func startFixThisMessVisualSession(exercise: FixThisMessExercise, profile: LearnerProfile, language: String) async {
+        messages = []
+        sessionMetadata = []
+        activeSessionType = .fixThisMess
+        sayItClearlySession = nil
+        findThePointSession = nil
+        elevatorPitchSession = nil
+        analyseMyTextSession = nil
+        fixThisMessSession = nil
+        spotTheGapSession = nil
+        buildThePyramidSession = nil
+        decodeAndRebuildSession = nil
+
+        lastEvaluationResult = nil
+        sessionState = .active
+
+        let basePrompt = systemPromptAssembler.assemble(
+            level: profile.currentLevel,
+            sessionType: SessionType.fixThisMess.rawValue,
+            language: language,
+            profileJSON: profile.toPromptJSON()
+        )
+
+        let directive = fixThisMessVisualDirectiveBlock(exercise: exercise, language: language)
+        systemPrompt = basePrompt + "\n\n" + directive
+
+        await structuralEvaluator.prepareSession(
+            level: profile.currentLevel,
+            sessionType: SessionType.fixThisMess.rawValue,
+            language: language,
+            profile: profile
+        )
+    }
+
+    /// Build the directive block for visual fix-this-mess exercises.
+    private func fixThisMessVisualDirectiveBlock(exercise: FixThisMessExercise, language: String) -> String {
+        let blockList = exercise.blocks.map { "- [\($0.id)] \($0.text) (\($0.type.rawValue))" }.joined(separator: "\n")
+        let answerKey = exercise.answerKey
+        let groupsDesc = answerKey.validGroupings.first.map { grouping in
+            grouping.groups.map { group in
+                "Parent: \(group.parentBlockID) → Children: \(group.memberBlockIDs.sorted().joined(separator: ", "))"
+            }.joined(separator: "\n")
+        } ?? "No groupings defined"
+
+        let wrongDesc = exercise.wrongArrangement.groups.map { group in
+            "Parent: \(group.parentBlockID) → Children: \(group.childBlockIDs.joined(separator: ", "))"
+        }.joined(separator: "\n")
+
+        return """
+        # Fix This Mess — Visual Session
+
+        The learner sees a BROKEN pyramid arrangement and must fix it by \
+        dragging blocks to the correct positions. This is a diagnosis + correction exercise.
+
+        **Governing Thought (fixed at top):** \(exercise.governingThought.text)
+
+        **All Blocks:**
+        \(blockList)
+
+        **Wrong Initial Arrangement (what the learner sees):**
+        \(wrongDesc)
+
+        **What is wrong:** \(exercise.structuralFlawDescription)
+
+        **Correct Answer Key (HIDDEN — do not reveal directly):**
+        \(groupsDesc)
+
+        When the learner checks their arrangement:
+        - First distinguish between DIAGNOSIS and CORRECTION: "You found the problem" vs "You fixed it"
+        - Credit partial fixes: "You fixed the grouping but moved the wrong block"
+        - Explain the original structural flaw in your feedback
+        - Use structural vocabulary: MECE violations, misplaced evidence, wrong grouping
+        - First attempt: hints about what is wrong. Second: more specific. Third: reveal.
+        """
+    }
+
     // MARK: - Decode and Rebuild
 
     /// Start a "Decode and rebuild" session.

--- a/app/SayItRight/Presentation/Session/FixThisMessVisualView.swift
+++ b/app/SayItRight/Presentation/Session/FixThisMessVisualView.swift
@@ -1,0 +1,451 @@
+import SwiftUI
+
+/// Visual variant of "Fix this mess" — starts with a broken pyramid arrangement.
+///
+/// The user must diagnose what is wrong and drag blocks to fix the structure.
+/// Similar to BuildThePyramidView but initializes with a wrong arrangement
+/// and tracks which blocks the user has moved.
+struct FixThisMessVisualView: View {
+    let sessionManager: SessionManager
+    let coordinator: FixThisMessVisualCoordinator
+    let profile: LearnerProfile
+    let language: String
+    var onDismiss: (() -> Void)?
+
+    @State private var viewModel: ChatViewModel
+    @State private var treeState = PyramidTreeState()
+    @State private var sessionStarted = false
+    @State private var noExercisesAvailable = false
+    @State private var exercise: FixThisMessExercise?
+    @State private var validationResult: PyramidValidationResult?
+    @State private var blockFeedbackStates: [String: BlockFeedbackState] = [:]
+    @State private var gapPlacements: [GapPlacement] = []
+    @State private var isPyramidComplete = false
+    @State private var feedbackConfig = FeedbackConfiguration()
+    @State private var attempts = 0
+    /// Track which blocks the user has moved from their original wrong position.
+    @State private var movedBlockIDs: Set<String> = []
+    /// Original wrong positions for change tracking.
+    @State private var originalParentMap: [String: String] = [:]
+
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+
+    init(
+        sessionManager: SessionManager,
+        coordinator: FixThisMessVisualCoordinator,
+        profile: LearnerProfile,
+        language: String,
+        onDismiss: (() -> Void)? = nil
+    ) {
+        self.sessionManager = sessionManager
+        self.coordinator = coordinator
+        self.profile = profile
+        self.language = language
+        self.onDismiss = onDismiss
+        self._viewModel = State(initialValue: ChatViewModel(sessionManager: sessionManager))
+    }
+
+    var body: some View {
+        Group {
+            if noExercisesAvailable {
+                noExercisesView
+            } else if exercise != nil {
+                sessionContent
+            } else {
+                ProgressView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+        }
+        .navigationTitle(language == "de" ? "Räum das auf (visuell)" : "Fix this mess (visual)")
+        #if !os(macOS)
+        .navigationBarTitleDisplayMode(.inline)
+        #endif
+        .toolbar {
+            ToolbarItem(placement: .automatic) {
+                Button(action: endSessionAndDismiss) {
+                    Label(
+                        language == "de" ? "Beenden" : "End Session",
+                        systemImage: "xmark.circle"
+                    )
+                }
+            }
+        }
+        .task {
+            guard !sessionStarted else { return }
+            sessionStarted = true
+            let ex = await coordinator.startSession(
+                sessionManager: sessionManager,
+                profile: profile,
+                language: language
+            )
+            if let ex {
+                exercise = ex
+                setupWrongArrangement(ex)
+            } else {
+                noExercisesAvailable = true
+            }
+        }
+    }
+
+    // MARK: - Session Content
+
+    @ViewBuilder
+    private var sessionContent: some View {
+        #if os(macOS)
+        splitLayout
+        #else
+        if horizontalSizeClass == .regular {
+            splitLayout
+        } else {
+            compactLayout
+        }
+        #endif
+    }
+
+    private var splitLayout: some View {
+        HStack(spacing: 0) {
+            pyramidCanvas
+                .frame(maxWidth: .infinity)
+
+            Divider()
+
+            VStack(spacing: 0) {
+                ChatView(viewModel: viewModel)
+                    .frame(maxWidth: .infinity)
+            }
+            .frame(width: 320)
+        }
+    }
+
+    private var compactLayout: some View {
+        VStack(spacing: 0) {
+            pyramidCanvas
+
+            Divider()
+
+            ChatView(viewModel: viewModel)
+                .frame(maxHeight: 200)
+        }
+    }
+
+    // MARK: - Pyramid Canvas
+
+    private var pyramidCanvas: some View {
+        VStack(spacing: 12) {
+            // Governing thought (fixed at top)
+            if let ex = exercise {
+                VStack(spacing: 4) {
+                    Text(ex.governingThought.text)
+                        .font(.headline)
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 10)
+                        .background(BlockType.governingThought.color.opacity(0.15))
+                        .clipShape(RoundedRectangle(cornerRadius: 10))
+
+                    Text(language == "de"
+                         ? "Diese Pyramide ist kaputt. Repariere sie!"
+                         : "This pyramid is broken. Fix it!")
+                        .font(.caption)
+                        .foregroundStyle(.orange)
+                        .fontWeight(.medium)
+                }
+                .padding(.top, 12)
+            }
+
+            // Pyramid tree area
+            GeometryReader { geo in
+                ZStack {
+                    // Connection lines
+                    if let rootID = treeState.rootBlockID,
+                       let rootNode = treeState.buildTreeNode(from: rootID) {
+                        ConnectionLinesView(
+                            nodeLayouts: treeState.nodeLayouts,
+                            connections: rootNode.extractConnections(),
+                            dragOverrides: [:]
+                        )
+                    }
+
+                    // Drop zones
+                    DropZoneOverlay(
+                        zones: treeState.dropZones,
+                        highlightedZoneID: treeState.highlightedZoneID
+                    )
+
+                    // Placed blocks
+                    ForEach(Array(treeState.placedBlocks.values), id: \.id) { placed in
+                        if let layout = treeState.nodeLayouts[placed.id.uuidString] {
+                            DraggableBlockView(
+                                block: placed.block,
+                                visualState: .placed,
+                                onDragChanged: { value in
+                                    treeState.beginDrag(blockID: placed.id)
+                                    treeState.updateDrag(position: value.location)
+                                },
+                                onDragEnded: { value in
+                                    if let zone = treeState.endDrag(position: value.location) {
+                                        treeState.reparentBlock(placed.id, toParent: UUID(uuidString: zone.parentID)!, atIndex: zone.childIndex)
+                                        trackMove(blockID: placed.id.uuidString)
+                                    }
+                                }
+                            )
+                            .validationFeedback(blockFeedbackStates[placed.id.uuidString] ?? .none)
+                            .overlay(alignment: .topLeading) {
+                                if movedBlockIDs.contains(placed.id.uuidString) {
+                                    Image(systemName: "arrow.turn.up.right")
+                                        .font(.caption2)
+                                        .foregroundStyle(.blue)
+                                        .padding(3)
+                                }
+                            }
+                            .position(layout.center)
+                        }
+                    }
+
+                    // Feedback overlays
+                    if feedbackConfig.isEnabled {
+                        PyramidFeedbackOverlay(
+                            blockFeedbackStates: blockFeedbackStates,
+                            gaps: gapPlacements,
+                            nodeLayouts: treeState.nodeLayouts,
+                            layoutEngine: treeState.layoutEngine,
+                            isPyramidComplete: isPyramidComplete,
+                            configuration: $feedbackConfig
+                        )
+                    }
+                }
+            }
+
+            // Unplaced blocks pool (blocks removed from tree go here)
+            if !treeState.unplacedBlocks.isEmpty {
+                UnplacedBlocksPool(
+                    blocks: treeState.unplacedBlocks,
+                    onDragChanged: { block, value in
+                        treeState.beginDrag(blockID: block.id)
+                        treeState.updateDrag(position: value.location)
+                    },
+                    onDragEnded: { block, value in
+                        let zone = treeState.endDrag(position: value.location)
+                        if zone == nil {
+                            placeBlockInTree(block)
+                        }
+                        trackMove(blockID: block.id.uuidString)
+                    }
+                )
+                .padding(.horizontal, 12)
+                .padding(.bottom, 8)
+            }
+
+            // Action buttons
+            HStack(spacing: 16) {
+                Button(action: checkArrangement) {
+                    Label(
+                        language == "de" ? "Prüfen" : "Check",
+                        systemImage: "checkmark.circle"
+                    )
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(!treeState.unplacedBlocks.isEmpty)
+
+                if attempts >= 3 {
+                    Button(action: showAnswer) {
+                        Label(
+                            language == "de" ? "Lösung zeigen" : "Show Answer",
+                            systemImage: "eye"
+                        )
+                    }
+                    .buttonStyle(.bordered)
+                }
+            }
+            .padding(.bottom, 12)
+
+            // Change tracking indicator
+            if !movedBlockIDs.isEmpty {
+                Text(language == "de"
+                     ? "\(movedBlockIDs.count) Block(s) verschoben"
+                     : "\(movedBlockIDs.count) block(s) moved")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .padding(.bottom, 8)
+            }
+        }
+    }
+
+    // MARK: - Exercise Setup
+
+    private func setupWrongArrangement(_ exercise: FixThisMessExercise) {
+        // Build a mapping from exercise block IDs to PyramidBlock instances
+        var blockMap: [String: PyramidBlock] = [:]
+
+        // Create governing thought as root
+        let rootBlock = PyramidBlock(
+            text: exercise.governingThought.text,
+            type: exercise.governingThought.type.blockType,
+            level: 0
+        )
+        blockMap[exercise.governingThought.id] = rootBlock
+        treeState.placeAsRoot(rootBlock)
+
+        // Create all blocks
+        for block in exercise.blocks {
+            let pyramidBlock = PyramidBlock(
+                text: block.text,
+                type: block.type.blockType,
+                level: nil
+            )
+            blockMap[block.id] = pyramidBlock
+        }
+
+        // Place support points under root according to wrong arrangement
+        for wrongGroup in exercise.wrongArrangement.groups {
+            guard let parentBlock = blockMap[wrongGroup.parentBlockID],
+                  let rootID = treeState.rootBlockID else { continue }
+
+            // Place the support point under root
+            let parentChildIndex = treeState.placedBlocks[rootID]?.childIDs.count ?? 0
+            treeState.placeBlock(parentBlock, underParent: rootID, atIndex: parentChildIndex)
+
+            // Record original parent for change tracking
+            originalParentMap[wrongGroup.parentBlockID] = rootID.uuidString
+
+            // Place children under this support point
+            for (index, childID) in wrongGroup.childBlockIDs.enumerated() {
+                guard let childBlock = blockMap[childID] else { continue }
+                treeState.placeBlock(childBlock, underParent: parentBlock.id, atIndex: index)
+                originalParentMap[childID] = parentBlock.id.uuidString
+            }
+        }
+
+        // Any blocks not in the wrong arrangement go to unplaced pool
+        let placedIDs = Set(treeState.placedBlocks.keys.map { $0.uuidString })
+        for block in exercise.blocks {
+            if blockMap[block.id] != nil && !placedIDs.contains(blockMap[block.id]!.id.uuidString) {
+                treeState.addToUnplacedPool(blockMap[block.id]!)
+            }
+        }
+    }
+
+    private func placeBlockInTree(_ block: PyramidBlock) {
+        guard let rootID = treeState.rootBlockID else { return }
+        let childCount = treeState.placedBlocks[rootID]?.childIDs.count ?? 0
+        treeState.placeBlock(block, underParent: rootID, atIndex: childCount)
+    }
+
+    private func trackMove(blockID: String) {
+        movedBlockIDs.insert(blockID)
+    }
+
+    // MARK: - Validation
+
+    private func checkArrangement() {
+        guard let exercise else { return }
+
+        let userTree = UserPyramidTree.from(treeState)
+        let result = coordinator.validateArrangement(
+            userTree: userTree,
+            answerKey: exercise.answerKey
+        )
+        validationResult = result
+        attempts += 1
+
+        // Map validation result to visual feedback
+        blockFeedbackStates = ValidationFeedbackMapper.blockFeedbackStates(from: result)
+        gapPlacements = ValidationFeedbackMapper.gapPlacements(from: result)
+        isPyramidComplete = ValidationFeedbackMapper.isPyramidComplete(result)
+        feedbackConfig.isEnabled = true
+
+        // Build description including change tracking for Barbara
+        let description = buildArrangementDescription(result: result)
+        Task {
+            await sessionManager.evaluatePyramidArrangement(description: description)
+        }
+    }
+
+    private func buildArrangementDescription(result: PyramidValidationResult) -> String {
+        let score = Int(result.score * 100)
+        let correct = result.blockStatuses.values.filter { if case .correct = $0 { return true } else { return false } }.count
+        let total = result.blockStatuses.count
+        let govCorrect = result.governingThoughtCorrect ? "yes" : "no"
+
+        var desc = "[FIX THIS MESS — Attempt \(attempts)]\n"
+        desc += "Score: \(score)%, Correct blocks: \(correct)/\(total), Governing thought correct: \(govCorrect)\n"
+        desc += "Blocks moved by learner: \(movedBlockIDs.count)\n"
+
+        for assessment in result.groupAssessments {
+            if !assessment.overlappingMembers.isEmpty {
+                desc += "MECE violation: group under \(assessment.userParentBlockID) has overlapping members\n"
+            }
+            if !assessment.missingMembers.isEmpty {
+                desc += "Missing members in group under \(assessment.userParentBlockID)\n"
+            }
+        }
+
+        if result.score >= 1.0 {
+            desc += "PYRAMID FIXED — all blocks correctly placed."
+        } else if movedBlockIDs.isEmpty {
+            desc += "DIAGNOSIS ONLY — learner checked without making changes."
+        }
+
+        return desc
+    }
+
+    private func showAnswer() {
+        Task {
+            await sessionManager.evaluatePyramidArrangement(
+                description: "[SHOW ANSWER REQUESTED — reveal the correct arrangement and explain what was broken in the original]"
+            )
+        }
+    }
+
+    // MARK: - No Exercises
+
+    private var noExercisesView: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "rectangle.3.group")
+                .font(.system(size: 48))
+                .foregroundStyle(.secondary)
+
+            Text(language == "de"
+                 ? "Keine \u{00DC}bungen verf\u{00FC}gbar"
+                 : "No exercises available")
+                .font(.title3)
+                .fontWeight(.semibold)
+
+            Text(language == "de"
+                 ? "Es gibt aktuell keine passenden \u{00DC}bungen f\u{00FC}r dein Level."
+                 : "There are no matching exercises for your current level.")
+                .font(.body)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+
+            if let onDismiss {
+                Button(language == "de" ? "Zur\u{00FC}ck" : "Go Back") {
+                    onDismiss()
+                }
+                .buttonStyle(.borderedProminent)
+                .padding(.top, 8)
+            }
+        }
+        .padding(32)
+    }
+
+    // MARK: - Actions
+
+    private func endSessionAndDismiss() {
+        sessionManager.endSession()
+        onDismiss?()
+    }
+}
+
+// MARK: - Previews
+
+#Preview("Fix This Mess Visual") {
+    NavigationStack {
+        FixThisMessVisualView(
+            sessionManager: SessionManager(),
+            coordinator: FixThisMessVisualCoordinator(exercises: []),
+            profile: .createDefault(displayName: "Alex"),
+            language: "en"
+        )
+    }
+}

--- a/app/SayItRight/Tests/FixThisMessVisualTests.swift
+++ b/app/SayItRight/Tests/FixThisMessVisualTests.swift
@@ -1,0 +1,136 @@
+import Foundation
+import Testing
+@testable import SayItRight
+
+@Suite("Fix This Mess Visual")
+struct FixThisMessVisualTests {
+
+    // MARK: - Data Model
+
+    @Test("FixThisMessExercise is decodable from JSON")
+    func exerciseDecodable() throws {
+        let json = """
+        {
+            "id": "ftm-test",
+            "titleEN": "Test",
+            "titleDE": "Test",
+            "level": 1,
+            "language": "en",
+            "governingThought": {
+                "id": "gt-1",
+                "text": "Main claim",
+                "type": "governing_thought"
+            },
+            "blocks": [
+                {"id": "sp-1", "text": "Support 1", "type": "support_point"},
+                {"id": "ev-1", "text": "Evidence 1", "type": "evidence"},
+                {"id": "ev-2", "text": "Evidence 2", "type": "evidence"}
+            ],
+            "answerKey": {
+                "governingThoughtID": "gt-1",
+                "validGroupings": [{
+                    "groups": [{
+                        "parentBlockID": "sp-1",
+                        "memberBlockIDs": ["ev-1", "ev-2"]
+                    }]
+                }]
+            },
+            "wrongArrangement": {
+                "groups": [{
+                    "parentBlockID": "sp-1",
+                    "childBlockIDs": ["ev-2"]
+                }]
+            },
+            "structuralFlawDescription": "Evidence 1 is missing from the group"
+        }
+        """.data(using: .utf8)!
+
+        let exercise = try JSONDecoder().decode(FixThisMessExercise.self, from: json)
+        #expect(exercise.id == "ftm-test")
+        #expect(exercise.blocks.count == 3)
+        #expect(exercise.wrongArrangement.groups.count == 1)
+        #expect(exercise.wrongArrangement.groups[0].childBlockIDs == ["ev-2"])
+        #expect(exercise.structuralFlawDescription.contains("Evidence 1"))
+    }
+
+    // MARK: - Library
+
+    @Test("FixThisMessExerciseLibrary filters by level and language")
+    func libraryFilters() {
+        let ex1 = makeTestExercise(id: "l1-en", level: 1, language: "en")
+        let ex2 = makeTestExercise(id: "l2-en", level: 2, language: "en")
+        let ex3 = makeTestExercise(id: "l1-de", level: 1, language: "de")
+        let library = FixThisMessExerciseLibrary(exercises: [ex1, ex2, ex3])
+
+        let l1en = library.exercises(for: 1, language: "en")
+        #expect(l1en.count == 1)
+        #expect(l1en[0].id == "l1-en")
+
+        let l2en = library.exercises(for: 2, language: "en")
+        #expect(l2en.count == 2)
+    }
+
+    @Test("Library excludes recent exercises")
+    func libraryExcludesRecent() {
+        let ex1 = makeTestExercise(id: "a", level: 1, language: "en")
+        let ex2 = makeTestExercise(id: "b", level: 1, language: "en")
+        let library = FixThisMessExerciseLibrary(exercises: [ex1, ex2])
+
+        let result = library.randomExercise(for: 1, language: "en", excluding: ["a"])
+        #expect(result?.id == "b")
+    }
+
+    // MARK: - Wrong Arrangement
+
+    @Test("WrongArrangement describes incorrect block placement")
+    func wrongArrangementStructure() {
+        let arrangement = WrongArrangement(groups: [
+            WrongGroup(parentBlockID: "sp-1", childBlockIDs: ["ev-1", "ev-3"]),
+            WrongGroup(parentBlockID: "sp-2", childBlockIDs: ["ev-2", "ev-4"]),
+        ])
+
+        #expect(arrangement.groups.count == 2)
+        #expect(arrangement.groups[0].childBlockIDs.contains("ev-3"))
+        #expect(arrangement.groups[1].parentBlockID == "sp-2")
+    }
+
+    @Test("Exercise title respects language")
+    func titleLanguage() {
+        let exercise = makeTestExercise(id: "test", level: 1, language: "en")
+        #expect(exercise.title(language: "en") == "Test EN")
+        #expect(exercise.title(language: "de") == "Test DE")
+    }
+
+    // MARK: - Helpers
+
+    private func makeTestExercise(
+        id: String = "test",
+        level: Int = 1,
+        language: String = "en"
+    ) -> FixThisMessExercise {
+        FixThisMessExercise(
+            id: id,
+            titleEN: "Test EN",
+            titleDE: "Test DE",
+            level: level,
+            language: language,
+            governingThought: ExerciseBlock(id: "gt", text: "Claim", type: .governingThought),
+            blocks: [
+                ExerciseBlock(id: "sp", text: "Support", type: .supportPoint),
+                ExerciseBlock(id: "ev", text: "Evidence", type: .evidence),
+            ],
+            answerKey: PyramidAnswerKey(
+                governingThoughtID: "gt",
+                validGroupings: [
+                    ValidGrouping(groups: [
+                        ValidGroup(parentBlockID: "sp", memberBlockIDs: ["ev"])
+                    ])
+                ]
+            ),
+            wrongArrangement: WrongArrangement(groups: [
+                WrongGroup(parentBlockID: "sp", childBlockIDs: ["ev"])
+            ]),
+            structuralFlawDescription: "Test flaw"
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Visual "Fix this mess" variant: starts with blocks in wrong pyramid arrangement
- `FixThisMessExercise` model with `WrongArrangement` describing incorrect initial placement
- 3 exercises (swapped evidence between support points) in EN and DE
- `FixThisMessVisualView` with change tracking — shows which blocks user moved
- iPad/Mac routes to visual variant; iPhone stays text-based
- Barbara's prompt distinguishes diagnosis ("you found the problem") from correction ("you fixed it")
- 5 tests for data model, library filtering, and arrangement structure

Closes #71

## Test plan
- [x] `swift build` passes
- [x] All 5 FixThisMessVisualTests pass
- [ ] Manual: iPad/Mac opens visual variant with blocks pre-arranged wrongly
- [ ] Manual: iPhone opens text-based variant
- [ ] Manual: drag blocks to rearrange, verify change indicators appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)