### PR TITLE
feat: Red herring blocks in pyramid exercises

### DIFF
--- a/app/SayItRight/Content/PyramidExercises/PyramidExercise.swift
+++ b/app/SayItRight/Content/PyramidExercises/PyramidExercise.swift
@@ -37,6 +37,7 @@ enum ExerciseBlockType: String, Codable, Sendable {
     case governingThought = "governing_thought"
     case supportPoint = "support_point"
     case evidence = "evidence"
+    case redHerring = "red_herring"
 
     /// Convert to the presentation-layer BlockType.
     var blockType: BlockType {
@@ -44,6 +45,7 @@ enum ExerciseBlockType: String, Codable, Sendable {
         case .governingThought: .governingThought
         case .supportPoint: .supportPoint
         case .evidence: .evidence
+        case .redHerring: .redHerring
         }
     }
 }

--- a/app/SayItRight/Content/PyramidExercises/pyramid-exercises.json
+++ b/app/SayItRight/Content/PyramidExercises/pyramid-exercises.json
@@ -181,5 +181,72 @@
         }
       ]
     }
+  },
+  {
+    "id": "pe-003-en",
+    "titleEN": "Remote Work (with Red Herrings)",
+    "titleDE": "Homeoffice (mit Ablenkern)",
+    "level": 2,
+    "language": "en",
+    "governingThought": {
+      "id": "gt-003",
+      "text": "Companies should offer remote work options because they increase productivity and reduce costs.",
+      "type": "governing_thought"
+    },
+    "blocks": [
+      {
+        "id": "sp-005",
+        "text": "Remote workers report higher productivity",
+        "type": "support_point"
+      },
+      {
+        "id": "sp-006",
+        "text": "Companies save on office costs",
+        "type": "support_point"
+      },
+      {
+        "id": "ev-009",
+        "text": "Stanford study: 13% productivity increase in remote workers",
+        "type": "evidence"
+      },
+      {
+        "id": "ev-010",
+        "text": "Fewer interruptions from colleagues during focus work",
+        "type": "evidence"
+      },
+      {
+        "id": "ev-011",
+        "text": "Average company saves $11,000 per remote worker annually",
+        "type": "evidence"
+      },
+      {
+        "id": "ev-012",
+        "text": "Reduced need for large office space in expensive city centres",
+        "type": "evidence"
+      },
+      {
+        "id": "rh-001",
+        "text": "Many employees prefer working in their pyjamas",
+        "type": "red_herring"
+      }
+    ],
+    "answerKey": {
+      "governingThoughtID": "gt-003",
+      "validGroupings": [
+        {
+          "groups": [
+            {
+              "parentBlockID": "sp-005",
+              "memberBlockIDs": ["ev-009", "ev-010"]
+            },
+            {
+              "parentBlockID": "sp-006",
+              "memberBlockIDs": ["ev-011", "ev-012"]
+            }
+          ]
+        }
+      ],
+      "redHerringBlockIDs": ["rh-001"]
+    }
   }
 ]

--- a/app/SayItRight/Intelligence/StructuralEvaluator/MECEValidationEngine.swift
+++ b/app/SayItRight/Intelligence/StructuralEvaluator/MECEValidationEngine.swift
@@ -12,6 +12,9 @@ struct PyramidAnswerKey: Sendable, Equatable, Codable {
     /// to its expected evidence children. Multiple alternative groupings can
     /// be provided — the engine picks the best match.
     let validGroupings: [ValidGrouping]
+    /// Block IDs that are red herrings — they should NOT be placed in the pyramid.
+    /// Empty for exercises without red herrings.
+    var redHerringBlockIDs: Set<String> = []
 }
 
 /// One complete valid arrangement of the pyramid.
@@ -58,6 +61,10 @@ enum BlockValidationStatus: Sendable, Equatable {
     case ungrouped
     /// Block is not placed at all but should be.
     case missing
+    /// Block is a red herring that was incorrectly placed in the tree.
+    case redHerringPlaced
+    /// Block is a red herring that was correctly discarded.
+    case redHerringDiscarded
 }
 
 /// MECE assessment for a single group in the user's pyramid.
@@ -256,10 +263,21 @@ struct MECEValidationEngine: Sendable {
             .subtracting(userTree.rootBlockID.map { Set([$0]) } ?? [])
 
         for blockID in ungroupedBlockIDs {
-            if let correctGroup = findCorrectGroup(for: blockID, in: grouping) {
+            if answerKey.redHerringBlockIDs.contains(blockID) {
+                blockStatuses[blockID] = .redHerringPlaced
+            } else if let correctGroup = findCorrectGroup(for: blockID, in: grouping) {
                 blockStatuses[blockID] = .wrongGroup(expectedGroupParentID: correctGroup.parentBlockID)
             } else {
                 blockStatuses[blockID] = .ungrouped
+            }
+        }
+
+        // Flag red herrings placed in valid groups (they shouldn't be there).
+        for redHerringID in answerKey.redHerringBlockIDs {
+            if userTree.allPlacedBlockIDs.contains(redHerringID) {
+                blockStatuses[redHerringID] = .redHerringPlaced
+            } else {
+                blockStatuses[redHerringID] = .redHerringDiscarded
             }
         }
 

--- a/app/SayItRight/Presentation/PyramidBuilder/BlockFeedbackState.swift
+++ b/app/SayItRight/Presentation/PyramidBuilder/BlockFeedbackState.swift
@@ -101,6 +101,11 @@ struct ValidationFeedbackMapper: Sendable {
             case .missing:
                 // Missing blocks are shown as gap placeholders, not block feedback.
                 break
+            case .redHerringPlaced:
+                states[blockID] = .misplaced
+            case .redHerringDiscarded:
+                // Correctly discarded — no visual feedback on the canvas.
+                break
             }
         }
 

--- a/app/SayItRight/Presentation/PyramidBuilder/DiscardZoneView.swift
+++ b/app/SayItRight/Presentation/PyramidBuilder/DiscardZoneView.swift
@@ -1,0 +1,94 @@
+import SwiftUI
+
+/// A drop target for discarding red herring blocks from the pyramid.
+///
+/// Appears at the bottom of the pyramid canvas. Blocks dragged here are
+/// removed from play (but can be retrieved from the discarded pile).
+struct DiscardZoneView: View {
+    /// Whether a block is currently being dragged near the zone.
+    var isHighlighted: Bool = false
+    /// Blocks that have been discarded.
+    let discardedBlocks: [PyramidBlock]
+    /// Called when the user taps a discarded block to retrieve it.
+    var onRetrieve: ((PyramidBlock) -> Void)?
+
+    var body: some View {
+        VStack(spacing: 8) {
+            // Drop target area
+            HStack(spacing: 8) {
+                Image(systemName: "xmark.bin")
+                    .font(.title3)
+                Text("Discard")
+                    .font(.subheadline.weight(.medium))
+            }
+            .foregroundStyle(isHighlighted ? .red : .secondary)
+            .padding(.horizontal, 20)
+            .padding(.vertical, 10)
+            .background(
+                RoundedRectangle(cornerRadius: 12)
+                    .strokeBorder(
+                        style: StrokeStyle(lineWidth: 2, dash: isHighlighted ? [] : [8, 4])
+                    )
+                    .foregroundStyle(isHighlighted ? .red : .secondary.opacity(0.5))
+                    .background(
+                        RoundedRectangle(cornerRadius: 12)
+                            .fill(isHighlighted ? Color.red.opacity(0.1) : Color.clear)
+                    )
+            )
+            .scaleEffect(isHighlighted ? 1.05 : 1.0)
+            .animation(.easeInOut(duration: 0.2), value: isHighlighted)
+            .accessibilityLabel("Discard zone")
+            .accessibilityHint("Drag blocks here to discard them")
+
+            // Discarded blocks (retrievable)
+            if !discardedBlocks.isEmpty {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 8) {
+                        ForEach(discardedBlocks) { block in
+                            Button {
+                                onRetrieve?(block)
+                            } label: {
+                                Text(block.text)
+                                    .font(.caption)
+                                    .lineLimit(1)
+                                    .padding(.horizontal, 8)
+                                    .padding(.vertical, 4)
+                                    .background(
+                                        Capsule()
+                                            .fill(.secondary.opacity(0.15))
+                                    )
+                                    .foregroundStyle(.secondary)
+                            }
+                            .buttonStyle(.plain)
+                            .accessibilityLabel("Retrieve: \(block.text)")
+                            .accessibilityHint("Tap to return this block to the unplaced pool")
+                        }
+                    }
+                    .padding(.horizontal, 12)
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Previews
+
+#Preview("Discard Zone — Empty") {
+    DiscardZoneView(discardedBlocks: [])
+        .padding()
+}
+
+#Preview("Discard Zone — Highlighted") {
+    DiscardZoneView(isHighlighted: true, discardedBlocks: [])
+        .padding()
+}
+
+#Preview("Discard Zone — With Discarded Blocks") {
+    DiscardZoneView(
+        discardedBlocks: [
+            PyramidBlock(text: "Irrelevant fact about weather", type: .redHerring),
+            PyramidBlock(text: "Unrelated statistic", type: .redHerring),
+        ]
+    )
+    .padding()
+}

--- a/app/SayItRight/Presentation/PyramidBuilder/PyramidBlock.swift
+++ b/app/SayItRight/Presentation/PyramidBuilder/PyramidBlock.swift
@@ -8,13 +8,15 @@ enum BlockType: String, Sendable, CaseIterable, Codable {
     case governingThought
     case supportPoint
     case evidence
+    case redHerring
 
     /// Display colour for each block type.
+    /// Red herrings look identical to evidence blocks — no visual cheating.
     var color: Color {
         switch self {
         case .governingThought: Color(red: 0.20, green: 0.45, blue: 0.75) // deep blue
         case .supportPoint: Color(red: 0.30, green: 0.65, blue: 0.50)     // teal green
-        case .evidence: Color(red: 0.55, green: 0.55, blue: 0.65)         // slate grey
+        case .evidence, .redHerring: Color(red: 0.55, green: 0.55, blue: 0.65) // slate grey
         }
     }
 
@@ -24,6 +26,7 @@ enum BlockType: String, Sendable, CaseIterable, Codable {
         case .governingThought: "Governing Thought"
         case .supportPoint: "Support Point"
         case .evidence: "Evidence"
+        case .redHerring: "Evidence" // Appears as evidence to the user
         }
     }
 }

--- a/app/SayItRight/Presentation/PyramidBuilder/PyramidTreeState.swift
+++ b/app/SayItRight/Presentation/PyramidBuilder/PyramidTreeState.swift
@@ -77,6 +77,13 @@ final class PyramidTreeState {
         unplacedBlocks.append(block)
     }
 
+    /// Remove a block from the unplaced pool by ID.
+    @discardableResult
+    func removeFromUnplacedPool(_ blockID: UUID) -> PyramidBlock? {
+        guard let index = unplacedBlocks.firstIndex(where: { $0.id == blockID }) else { return nil }
+        return unplacedBlocks.remove(at: index)
+    }
+
     // MARK: - Tree Construction
 
     /// Build a TreeNode hierarchy from placed blocks, starting at the given root.

--- a/app/SayItRight/Presentation/Session/BuildThePyramidView.swift
+++ b/app/SayItRight/Presentation/Session/BuildThePyramidView.swift
@@ -23,6 +23,8 @@ struct BuildThePyramidView: View {
     @State private var isPyramidComplete = false
     @State private var feedbackConfig = FeedbackConfiguration()
     @State private var attempts = 0
+    @State private var discardedBlocks: [PyramidBlock] = []
+    @State private var isDiscardHighlighted = false
 
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
@@ -215,6 +217,20 @@ struct BuildThePyramidView: View {
             .padding(.horizontal, 12)
             .padding(.bottom, 8)
 
+            // Discard zone (only for exercises with red herrings)
+            if hasRedHerrings {
+                DiscardZoneView(
+                    isHighlighted: isDiscardHighlighted,
+                    discardedBlocks: discardedBlocks,
+                    onRetrieve: { block in
+                        discardedBlocks.removeAll { $0.id == block.id }
+                        treeState.addToUnplacedPool(block)
+                    }
+                )
+                .padding(.horizontal, 12)
+                .padding(.bottom, 4)
+            }
+
             // Action buttons
             HStack(spacing: 16) {
                 Button(action: checkArrangement) {
@@ -224,7 +240,7 @@ struct BuildThePyramidView: View {
                     )
                 }
                 .buttonStyle(.borderedProminent)
-                .disabled(treeState.unplacedBlocks.count > 0)
+                .disabled(!treeState.unplacedBlocks.isEmpty)
 
                 if sessionManager.buildThePyramidSession?.canShowAnswer == true {
                     Button(action: showAnswer) {
@@ -237,6 +253,18 @@ struct BuildThePyramidView: View {
                 }
             }
             .padding(.bottom, 12)
+        }
+    }
+
+    /// Whether the current exercise has red herring blocks.
+    private var hasRedHerrings: Bool {
+        exercise?.answerKey.redHerringBlockIDs.isEmpty == false
+    }
+
+    /// Discard a block from the unplaced pool.
+    private func discardBlock(_ block: PyramidBlock) {
+        if treeState.removeFromUnplacedPool(block.id) != nil {
+            discardedBlocks.append(block)
         }
     }
 
@@ -314,7 +342,17 @@ struct BuildThePyramidView: View {
             }
         }
 
-        if result.score >= 1.0 {
+        // Red herring tracking
+        let redHerringPlaced = result.blockStatuses.values.filter { if case .redHerringPlaced = $0 { return true } else { return false } }.count
+        let redHerringDiscarded = result.blockStatuses.values.filter { if case .redHerringDiscarded = $0 { return true } else { return false } }.count
+        if redHerringPlaced > 0 {
+            desc += "RED HERRINGS: \(redHerringPlaced) red herring(s) incorrectly placed in the pyramid\n"
+        }
+        if redHerringDiscarded > 0 {
+            desc += "GOOD: \(redHerringDiscarded) red herring(s) correctly discarded\n"
+        }
+
+        if result.score >= 1.0 && redHerringPlaced == 0 {
             desc += "PYRAMID COMPLETE — all blocks correctly placed."
         }
 

--- a/app/SayItRight/Tests/RedHerringTests.swift
+++ b/app/SayItRight/Tests/RedHerringTests.swift
@@ -1,0 +1,175 @@
+import Foundation
+import Testing
+@testable import SayItRight
+
+@Suite("Red Herring Blocks")
+struct RedHerringTests {
+
+    // MARK: - Block Type
+
+    @Test("RedHerring block type exists")
+    func redHerringBlockType() {
+        let block = PyramidBlock(text: "Irrelevant", type: .redHerring)
+        #expect(block.type == .redHerring)
+        // Red herrings look like evidence — same color
+        #expect(block.type.color == BlockType.evidence.color)
+        // Label says "Evidence" to not give away the trick
+        #expect(block.type.label == "Evidence")
+    }
+
+    @Test("ExerciseBlockType includes redHerring")
+    func exerciseBlockType() {
+        let type = ExerciseBlockType.redHerring
+        #expect(type.rawValue == "red_herring")
+        #expect(type.blockType == .redHerring)
+    }
+
+    // MARK: - Answer Key
+
+    @Test("PyramidAnswerKey supports redHerringBlockIDs")
+    func answerKeyWithRedHerrings() {
+        let key = PyramidAnswerKey(
+            governingThoughtID: "gt",
+            validGroupings: [],
+            redHerringBlockIDs: ["rh-1", "rh-2"]
+        )
+        #expect(key.redHerringBlockIDs.count == 2)
+        #expect(key.redHerringBlockIDs.contains("rh-1"))
+    }
+
+    @Test("PyramidAnswerKey defaults to empty red herrings")
+    func answerKeyDefaultEmpty() {
+        let key = PyramidAnswerKey(
+            governingThoughtID: "gt",
+            validGroupings: []
+        )
+        #expect(key.redHerringBlockIDs.isEmpty)
+    }
+
+    // MARK: - Validation
+
+    @Test("Red herring placed in tree is flagged")
+    func redHerringPlacedFlagged() {
+        let engine = MECEValidationEngine()
+        let answerKey = PyramidAnswerKey(
+            governingThoughtID: "gt",
+            validGroupings: [
+                ValidGrouping(groups: [
+                    ValidGroup(parentBlockID: "sp", memberBlockIDs: ["ev"])
+                ])
+            ],
+            redHerringBlockIDs: ["rh"]
+        )
+
+        let userTree = UserPyramidTree(
+            rootBlockID: "gt",
+            parentToChildren: [
+                "gt": ["sp"],
+                "sp": ["ev", "rh"]
+            ],
+            allPlacedBlockIDs: ["gt", "sp", "ev", "rh"]
+        )
+
+        let result = engine.validate(userTree: userTree, answerKey: answerKey)
+
+        if case .redHerringPlaced = result.blockStatuses["rh"] {
+            // Expected
+        } else {
+            Issue.record("Expected red herring to be flagged as redHerringPlaced, got \(String(describing: result.blockStatuses["rh"]))")
+        }
+    }
+
+    @Test("Red herring discarded is marked correct")
+    func redHerringDiscardedCorrect() {
+        let engine = MECEValidationEngine()
+        let answerKey = PyramidAnswerKey(
+            governingThoughtID: "gt",
+            validGroupings: [
+                ValidGrouping(groups: [
+                    ValidGroup(parentBlockID: "sp", memberBlockIDs: ["ev"])
+                ])
+            ],
+            redHerringBlockIDs: ["rh"]
+        )
+
+        // User correctly didn't place the red herring
+        let userTree = UserPyramidTree(
+            rootBlockID: "gt",
+            parentToChildren: [
+                "gt": ["sp"],
+                "sp": ["ev"]
+            ],
+            allPlacedBlockIDs: ["gt", "sp", "ev"]
+        )
+
+        let result = engine.validate(userTree: userTree, answerKey: answerKey)
+
+        if case .redHerringDiscarded = result.blockStatuses["rh"] {
+            // Expected
+        } else {
+            Issue.record("Expected red herring to be flagged as redHerringDiscarded, got \(String(describing: result.blockStatuses["rh"]))")
+        }
+    }
+
+    // MARK: - Feedback Mapping
+
+    @Test("Red herring placed maps to misplaced feedback")
+    func redHerringFeedbackMapping() {
+        let result = PyramidValidationResult(
+            blockStatuses: ["rh": .redHerringPlaced, "ev": .correct],
+            groupAssessments: [],
+            governingThoughtCorrect: true,
+            score: 0.5,
+            ungroupedBlockIDs: [],
+            matchedGroupingIndex: 0
+        )
+
+        let states = ValidationFeedbackMapper.blockFeedbackStates(from: result)
+        #expect(states["rh"] == .misplaced)
+        #expect(states["ev"] == .correct)
+    }
+
+    // MARK: - JSON Decoding
+
+    @Test("Exercise with red herring decodes from JSON")
+    func exerciseWithRedHerringDecodes() throws {
+        let json = """
+        {
+            "id": "rh-test",
+            "titleEN": "Test",
+            "titleDE": "Test",
+            "level": 2,
+            "language": "en",
+            "governingThought": {"id": "gt", "text": "Claim", "type": "governing_thought"},
+            "blocks": [
+                {"id": "sp", "text": "Support", "type": "support_point"},
+                {"id": "ev", "text": "Evidence", "type": "evidence"},
+                {"id": "rh", "text": "Red herring", "type": "red_herring"}
+            ],
+            "answerKey": {
+                "governingThoughtID": "gt",
+                "validGroupings": [{"groups": [{"parentBlockID": "sp", "memberBlockIDs": ["ev"]}]}],
+                "redHerringBlockIDs": ["rh"]
+            }
+        }
+        """.data(using: .utf8)!
+
+        let exercise = try JSONDecoder().decode(PyramidExercise.self, from: json)
+        #expect(exercise.answerKey.redHerringBlockIDs == ["rh"])
+        #expect(exercise.blocks[2].type == .redHerring)
+    }
+
+    // MARK: - Discard Zone
+
+    @Test("PyramidTreeState removeFromUnplacedPool works")
+    @MainActor
+    func removeFromUnplacedPool() {
+        let block = PyramidBlock(text: "Test", type: .evidence)
+        let state = PyramidTreeState(blocks: [block])
+        #expect(state.unplacedBlocks.count == 1)
+
+        let removed = state.removeFromUnplacedPool(block.id)
+        #expect(removed != nil)
+        #expect(state.unplacedBlocks.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary
- Red herring blocks that look like evidence but don't belong in any valid group
- `DiscardZoneView` for removing red herrings with retrieval option
- MECE validation engine flags placed red herrings and credits correct discards
- New Level 2 exercise (Remote Work) with one red herring
- 9 tests covering block types, validation, feedback mapping, and JSON decoding

Closes #72

## Test plan
- [x] `swift build` passes
- [x] All 9 RedHerringTests pass
- [ ] Manual: L2 exercise shows red herring block identical to evidence
- [ ] Manual: discard zone appears, blocks can be discarded and retrieved

🤖 Generated with [Claude Code](https://claude.com/claude-code)