### PR TITLE
feat: haptic feedback and animation polish (#75)

### DIFF
--- a/app/SayItRight/Presentation/PyramidBuilder/CelebrationEffectView.swift
+++ b/app/SayItRight/Presentation/PyramidBuilder/CelebrationEffectView.swift
@@ -13,6 +13,7 @@ struct CelebrationEffectView: View {
     @State private var scale: CGFloat = 0.5
     @State private var opacity: Double = 0.0
     @State private var innerOpacity: Double = 0.0
+    @State private var hapticTrigger: PyramidHaptic?
 
     var body: some View {
         ZStack {
@@ -41,6 +42,7 @@ struct CelebrationEffectView: View {
                 .opacity(innerOpacity)
         }
         .allowsHitTesting(false)
+        .pyramidHaptic(hapticTrigger)
         .onChange(of: isActive) { _, newValue in
             if newValue {
                 playCelebration()
@@ -50,6 +52,28 @@ struct CelebrationEffectView: View {
     }
 
     private func playCelebration() {
+        hapticTrigger = .pyramidComplete
+
+        if shouldReduceMotion {
+            // Simplified: just fade in and out, no spring/bounce.
+            withAnimation(.linear(duration: 0.2)) {
+                scale = 1.0
+                opacity = 1.0
+                innerOpacity = 1.0
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.2) {
+                withAnimation(.linear(duration: 0.3)) {
+                    opacity = 0.0
+                    innerOpacity = 0.0
+                }
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+                scale = 0.5
+                isActive = false
+            }
+            return
+        }
+
         // Phase 1: Scale up and fade in.
         withAnimation(.spring(response: 0.4, dampingFraction: 0.6)) {
             scale = 1.2

--- a/app/SayItRight/Presentation/PyramidBuilder/ConnectionLinesView.swift
+++ b/app/SayItRight/Presentation/PyramidBuilder/ConnectionLinesView.swift
@@ -127,43 +127,75 @@ struct ConnectionLinesView: View {
 /// Wraps ``ConnectionLinesView`` with appear/disappear animations
 /// for individual connections.
 ///
-/// When connections are added, they fade and scale in.
-/// When connections are removed, they fade out before removal.
+/// New connections animate in using a `trim(from:to:)` grow effect
+/// (or simple fade when reduce motion is enabled).
+/// Removed connections fade out before removal.
 struct AnimatedConnectionLinesView: View {
     let nodeLayouts: [String: NodeLayout]
     let connections: [PyramidConnection]
     var dragOverrides: [String: CGPoint] = [:]
 
     @State private var visibleConnectionIDs: Set<String> = []
+    @State private var trimProgress: [String: CGFloat] = [:]
 
     var body: some View {
-        ConnectionLinesView(
-            nodeLayouts: nodeLayouts,
-            connections: connections,
-            dragOverrides: dragOverrides
-        )
-        .opacity(visibleConnectionIDs.isEmpty && !connections.isEmpty ? 0 : 1)
-        .animation(.easeInOut(duration: 0.3), value: visibleConnectionIDs)
+        ZStack {
+            // Draw each connection individually for per-line trim animation.
+            ForEach(connections) { connection in
+                if let parentLayout = nodeLayouts[connection.parentID],
+                   let childLayout = nodeLayouts[connection.childID] {
+                    let parentCenter = dragOverrides[connection.parentID] ?? parentLayout.center
+                    let childCenter = dragOverrides[connection.childID] ?? childLayout.center
+
+                    let startPoint = CGPoint(
+                        x: parentCenter.x,
+                        y: parentCenter.y + parentLayout.size.height / 2
+                    )
+                    let endPoint = CGPoint(
+                        x: childCenter.x,
+                        y: childCenter.y - childLayout.size.height / 2
+                    )
+
+                    ConnectionLinesView.bezierPath(from: startPoint, to: endPoint)
+                        .trim(from: 0, to: trimProgress[connection.id] ?? 1.0)
+                        .stroke(
+                            ConnectionLineStyle.normal.color,
+                            lineWidth: ConnectionLineStyle.normal.lineWidth
+                        )
+                }
+            }
+        }
+        .allowsHitTesting(false)
         .onChange(of: connections) { oldValue, newValue in
             let newIDs = Set(newValue.map(\.id))
             let oldIDs = Set(oldValue.map(\.id))
             let added = newIDs.subtracting(oldIDs)
 
-            if !added.isEmpty {
-                withAnimation(.easeInOut(duration: 0.3)) {
-                    visibleConnectionIDs.formUnion(added)
+            for id in added {
+                if shouldReduceMotion {
+                    trimProgress[id] = 1.0
+                } else {
+                    trimProgress[id] = 0.0
+                    withAnimation(.easeOut(duration: 0.3)) {
+                        trimProgress[id] = 1.0
+                    }
                 }
             }
 
             let removed = oldIDs.subtracting(newIDs)
-            if !removed.isEmpty {
-                withAnimation(.easeOut(duration: 0.25)) {
-                    visibleConnectionIDs.subtract(removed)
+            for id in removed {
+                withAnimation(.easeOut(duration: 0.2)) {
+                    trimProgress[id] = 0.0
+                }
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+                    trimProgress.removeValue(forKey: id)
                 }
             }
         }
         .onAppear {
-            visibleConnectionIDs = Set(connections.map(\.id))
+            for connection in connections {
+                trimProgress[connection.id] = 1.0
+            }
         }
     }
 }

--- a/app/SayItRight/Presentation/PyramidBuilder/DraggableBlockView.swift
+++ b/app/SayItRight/Presentation/PyramidBuilder/DraggableBlockView.swift
@@ -22,6 +22,7 @@ struct DraggableBlockView: View {
     @State private var dragOffset: CGSize = .zero
     @State private var isDragging: Bool = false
     @State private var isHovering: Bool = false
+    @State private var currentHaptic: PyramidHaptic?
 
     // MARK: - Body
 
@@ -37,8 +38,19 @@ struct DraggableBlockView: View {
             )
             .zIndex(isDragging ? 1000 : 0)
             .gesture(dragGesture)
-            .animation(.spring(response: 0.3, dampingFraction: 0.7), value: isDragging)
-            .animation(.spring(response: 0.3, dampingFraction: 0.7), value: dragOffset)
+            .pyramidHaptic(currentHaptic)
+            .animation(
+                shouldReduceMotion
+                    ? .linear(duration: 0.15)
+                    : .spring(response: 0.3, dampingFraction: 0.7),
+                value: isDragging
+            )
+            .animation(
+                shouldReduceMotion
+                    ? .linear(duration: 0.15)
+                    : .spring(response: 0.3, dampingFraction: 0.7),
+                value: dragOffset
+            )
             .onHover { hovering in
                 isHovering = hovering
             }
@@ -85,6 +97,9 @@ struct DraggableBlockView: View {
     private var dragGesture: some Gesture {
         DragGesture(coordinateSpace: .global)
             .onChanged { value in
+                if !isDragging {
+                    currentHaptic = .blockPickup
+                }
                 isDragging = true
                 dragOffset = value.translation
                 onDragChanged?(value)
@@ -93,7 +108,13 @@ struct DraggableBlockView: View {
                 isDragging = false
                 onDragEnded?(value)
                 // Snap back — parent can override position if dropped in valid zone.
-                dragOffset = .zero
+                withAnimation(
+                    shouldReduceMotion
+                        ? .linear(duration: 0.15)
+                        : .spring(response: 0.3, dampingFraction: 0.6)
+                ) {
+                    dragOffset = .zero
+                }
             }
     }
 

--- a/app/SayItRight/Presentation/PyramidBuilder/GapPlaceholderView.swift
+++ b/app/SayItRight/Presentation/PyramidBuilder/GapPlaceholderView.swift
@@ -31,13 +31,17 @@ struct GapPlaceholderView: View {
                 width: BlockDimensions.minWidth + 20,
                 height: BlockDimensions.minHeight
             )
-            .opacity(isPulsing ? 0.5 : 1.0)
+            .opacity(shouldReduceMotion ? 0.8 : (isPulsing ? 0.5 : 1.0))
             .animation(
-                .easeInOut(duration: 1.2).repeatForever(autoreverses: true),
+                shouldReduceMotion
+                    ? nil
+                    : .easeInOut(duration: 1.2).repeatForever(autoreverses: true),
                 value: isPulsing
             )
             .onAppear {
-                isPulsing = true
+                if !shouldReduceMotion {
+                    isPulsing = true
+                }
             }
             .accessibilityLabel("Missing block")
             .accessibilityHint("A block is needed here to complete the group")

--- a/app/SayItRight/Presentation/PyramidBuilder/HapticFeedbackManager.swift
+++ b/app/SayItRight/Presentation/PyramidBuilder/HapticFeedbackManager.swift
@@ -1,0 +1,81 @@
+import SwiftUI
+
+// MARK: - Haptic Feedback Manager
+
+/// Centralized haptic feedback for pyramid builder interactions.
+///
+/// Provides platform-aware haptic feedback using `sensoryFeedback()` modifiers
+/// on iOS 17+ and guards against Mac (no haptic hardware).
+/// All haptics are silenced when `UIAccessibility.isReduceMotionEnabled` is true.
+enum PyramidHaptic: Sendable {
+    /// Light tap when picking up a block.
+    case blockPickup
+    /// Medium impact when a block snaps into a valid drop zone.
+    case validDrop
+    /// Error notification when a block is returned to pool.
+    case invalidDrop
+    /// Success notification when the entire pyramid is correct.
+    case pyramidComplete
+}
+
+// MARK: - Haptic Modifier
+
+/// View modifier that triggers sensory feedback for pyramid interactions.
+///
+/// Uses the iOS 17+ `sensoryFeedback()` API. On macOS this is a no-op.
+struct PyramidHapticModifier: ViewModifier {
+    let trigger: PyramidHaptic?
+    @State private var hapticTrigger: Int = 0
+
+    func body(content: Content) -> some View {
+        content
+            #if os(iOS)
+            .sensoryFeedback(feedback, trigger: hapticTrigger)
+            #endif
+            .onChange(of: trigger) { _, newValue in
+                guard newValue != nil else { return }
+                #if os(iOS)
+                if !UIAccessibility.isReduceMotionEnabled {
+                    hapticTrigger += 1
+                }
+                #endif
+            }
+    }
+
+    #if os(iOS)
+    private var feedback: SensoryFeedback {
+        switch trigger {
+        case .blockPickup: .impact(flexibility: .soft, intensity: 0.5)
+        case .validDrop: .impact(flexibility: .rigid, intensity: 0.7)
+        case .invalidDrop: .error
+        case .pyramidComplete: .success
+        case .none: .impact(flexibility: .soft, intensity: 0.0)
+        }
+    }
+    #endif
+}
+
+// MARK: - Reduce Motion Helper
+
+/// Whether animations should be simplified for accessibility.
+///
+/// Checks `UIAccessibility.isReduceMotionEnabled` on iOS,
+/// `NSWorkspace.shared.accessibilityDisplayShouldReduceMotion` on macOS.
+var shouldReduceMotion: Bool {
+    #if os(iOS)
+    UIAccessibility.isReduceMotionEnabled
+    #elseif os(macOS)
+    NSWorkspace.shared.accessibilityDisplayShouldReduceMotion
+    #else
+    false
+    #endif
+}
+
+// MARK: - View Extension
+
+extension View {
+    /// Attach a pyramid haptic trigger to this view.
+    func pyramidHaptic(_ haptic: PyramidHaptic?) -> some View {
+        modifier(PyramidHapticModifier(trigger: haptic))
+    }
+}

--- a/app/SayItRight/Presentation/PyramidBuilder/ValidationFeedbackModifier.swift
+++ b/app/SayItRight/Presentation/PyramidBuilder/ValidationFeedbackModifier.swift
@@ -41,9 +41,11 @@ struct FeedbackGlowModifier: ViewModifier {
         case .meceOverlap:
             RoundedRectangle(cornerRadius: BlockDimensions.cornerRadius)
                 .strokeBorder(FeedbackPalette.overlap, lineWidth: 3)
-                .opacity(isPulsing ? 0.6 : 1.0)
+                .opacity(shouldReduceMotion ? 1.0 : (isPulsing ? 0.6 : 1.0))
                 .animation(
-                    .easeInOut(duration: 0.8).repeatForever(autoreverses: true),
+                    shouldReduceMotion
+                        ? nil
+                        : .easeInOut(duration: 0.8).repeatForever(autoreverses: true),
                     value: isPulsing
                 )
         case .none:
@@ -92,7 +94,7 @@ struct ShakeModifier: ViewModifier {
         content
             .offset(x: shakeOffset)
             .onChange(of: feedbackState) { _, newValue in
-                if newValue == .misplaced {
+                if newValue == .misplaced && !shouldReduceMotion {
                     triggerShake()
                 }
             }

--- a/app/SayItRight/Presentation/Session/BuildThePyramidView.swift
+++ b/app/SayItRight/Presentation/Session/BuildThePyramidView.swift
@@ -27,6 +27,7 @@ struct BuildThePyramidView: View {
     @State private var isDiscardHighlighted = false
     @State private var canvasScale: CGFloat = 1.0
     @State private var shouldAutoFit = false
+    @State private var sessionHaptic: PyramidHaptic?
 
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
@@ -181,9 +182,12 @@ struct BuildThePyramidView: View {
                 onDragEnded: { block, value in
                     // endDrag handles placement from unplaced pool internally
                     let zone = treeState.endDrag(position: value.location)
-                    if zone == nil {
+                    if zone != nil {
+                        sessionHaptic = .validDrop
+                    } else {
                         // Dropped outside any zone — place under root as fallback
                         placeBlockInTree(block)
+                        sessionHaptic = .validDrop
                     }
                 }
             )
@@ -227,6 +231,7 @@ struct BuildThePyramidView: View {
             }
             .padding(.bottom, 12)
         }
+        .pyramidHaptic(sessionHaptic)
     }
 
     /// Whether the current exercise has red herring blocks.
@@ -290,6 +295,13 @@ struct BuildThePyramidView: View {
         isPyramidComplete = ValidationFeedbackMapper.isPyramidComplete(result)
         feedbackConfig.isEnabled = true
         shouldAutoFit = true
+
+        // Haptic feedback based on result
+        if isPyramidComplete {
+            sessionHaptic = .pyramidComplete
+        } else {
+            sessionHaptic = .invalidDrop
+        }
 
         // Send description to Barbara for textual feedback
         let description = buildArrangementDescription(result: result)

--- a/app/SayItRight/Presentation/Session/FixThisMessVisualView.swift
+++ b/app/SayItRight/Presentation/Session/FixThisMessVisualView.swift
@@ -27,6 +27,7 @@ struct FixThisMessVisualView: View {
     @State private var movedBlockIDs: Set<String> = []
     /// Original wrong positions for change tracking.
     @State private var originalParentMap: [String: String] = [:]
+    @State private var sessionHaptic: PyramidHaptic?
 
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
@@ -156,6 +157,7 @@ struct FixThisMessVisualView: View {
                                     if let zone = treeState.endDrag(position: value.location) {
                                         treeState.reparentBlock(placed.id, toParent: UUID(uuidString: zone.parentID)!, atIndex: zone.childIndex)
                                         trackMove(blockID: placed.id.uuidString)
+                                        sessionHaptic = .validDrop
                                     }
                                 }
                             )
@@ -200,6 +202,7 @@ struct FixThisMessVisualView: View {
                             placeBlockInTree(block)
                         }
                         trackMove(blockID: block.id.uuidString)
+                        sessionHaptic = .validDrop
                     }
                 )
                 .padding(.horizontal, 12)
@@ -239,6 +242,7 @@ struct FixThisMessVisualView: View {
                     .padding(.bottom, 8)
             }
         }
+        .pyramidHaptic(sessionHaptic)
     }
 
     // MARK: - Exercise Setup
@@ -323,6 +327,12 @@ struct FixThisMessVisualView: View {
         gapPlacements = ValidationFeedbackMapper.gapPlacements(from: result)
         isPyramidComplete = ValidationFeedbackMapper.isPyramidComplete(result)
         feedbackConfig.isEnabled = true
+
+        if isPyramidComplete {
+            sessionHaptic = .pyramidComplete
+        } else {
+            sessionHaptic = .invalidDrop
+        }
 
         // Build description including change tracking for Barbara
         let description = buildArrangementDescription(result: result)

--- a/app/SayItRight/SayItRight.xcodeproj/project.pbxproj
+++ b/app/SayItRight/SayItRight.xcodeproj/project.pbxproj
@@ -18,12 +18,14 @@
 		033B5DE1A4166D33D74334B9 /* ResponseParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 192E20839A759A3AF4CC7D51 /* ResponseParser.swift */; };
 		0346190953B25D320839884F /* Config.template.plist in Resources */ = {isa = PBXBuildFile; fileRef = E040537D24996C58EBA537D8 /* Config.template.plist */; };
 		042513332D5A484B14A5DE76 /* ChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A6659848CFB393F442C3B61 /* ChatView.swift */; };
+		04D246575340FDB8D0A466AC /* FixThisMessExerciseLibrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF7C54B8489C89FCA6ED3EDE /* FixThisMessExerciseLibrary.swift */; };
 		05B170645F777D60BA83A7CA /* FirstLaunchUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F059CE021493035199DE590 /* FirstLaunchUITests.swift */; };
 		070DB0DAB08A4A6479129643 /* LevelTransitionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 413063A3E8C728FA167973FC /* LevelTransitionTests.swift */; };
 		08B73D82C6BB007D6B4AFE15 /* AppLanguage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1607A6E887C79A834F460459 /* AppLanguage.swift */; };
 		09099979FE939EB2AF863CF9 /* SpeechRecognitionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD87491EB57716C7181C506 /* SpeechRecognitionService.swift */; };
 		0993F28FAFD79202B101068F /* MacChatInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C051275C85D1D1ED1778AC59 /* MacChatInputView.swift */; };
 		0A34DEDADFDCDA5E7ADE5A1C /* AnthropicService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C28CC98EB4FCDC9137D15433 /* AnthropicService.swift */; };
+		0D8BCE6EC8CFA4639CB8F081 /* iPadPyramidLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B237CADEB85F975D748385B3 /* iPadPyramidLayoutTests.swift */; };
 		0D91C125ACD8254D27757AFF /* ProgressionCriteria.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1848454FCBCACB1CC310E3F8 /* ProgressionCriteria.swift */; };
 		0DDC5480C5521B99A77E02A0 /* ComparisonResponseParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC11499E66D1CCC6F0EDB5EE /* ComparisonResponseParser.swift */; };
 		0EB7A9CA948A196FA81EBD88 /* TTSPlaybackService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4F296F432E8A069994E5167 /* TTSPlaybackService.swift */; };
@@ -33,16 +35,19 @@
 		109845A5BD28BDC5307C4A51 /* KeychainService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BCBA23B5D640E11325097D0 /* KeychainService.swift */; };
 		112C860A4101D395FAA0F637 /* TreeLayoutEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8D4F615BD301FC609D050A /* TreeLayoutEngineTests.swift */; };
 		11F8D4B4ACCE017B7DA2CEC3 /* PracticeTextGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400403CA410CF7A0E750127F /* PracticeTextGenerator.swift */; };
+		12096C0E28E2320DE65946E1 /* BuildThePyramidCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3156D3670B3AC3EE91BDD423 /* BuildThePyramidCoordinator.swift */; };
 		1307449DE0CB3798F0EA6C91 /* ParentSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B08B6C7C928249161C6C0AC /* ParentSettingsView.swift */; };
 		135CB2AD458844ACF2E1688D /* SpotTheGapSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D6E766B91AF9A75C1FBD2F7 /* SpotTheGapSessionTests.swift */; };
 		1460EBA977EDC2340452180C /* SayItClearlyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47BCCF7B7169BFF3B4722C58 /* SayItClearlyView.swift */; };
 		14CE5BE581E0C8BD9D97C4CF /* SessionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8EF7D134A239EF29A060F8C /* SessionType.swift */; };
 		15B5147ED1BA715EC959B464 /* OnboardingUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 103ABAFD57131CF246BE99AC /* OnboardingUITests.swift */; };
 		15C2944B9C7F642A1F1CE5E0 /* TreeLayoutEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8D4F615BD301FC609D050A /* TreeLayoutEngineTests.swift */; };
+		1617BEA120790071FB69172C /* pyramid-exercises.json in Resources */ = {isa = PBXBuildFile; fileRef = 8175192283ED8224716BB935 /* pyramid-exercises.json */; };
 		16755F914DD22F021F0C1E04 /* FindThePointSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DF3448F79F9C75AEEF2A73E /* FindThePointSessionTests.swift */; };
 		16AEE1E1B60B3EF1CBACC319 /* FixThisMessView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A9E8EB9C1E2B0BA8B04848D /* FixThisMessView.swift */; };
 		17805A9B8E4E6A4F93F3D8A5 /* SeenTextsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC1974647876CBDFA39B8A71 /* SeenTextsStore.swift */; };
 		180A80A7954F7CD067B7C8DB /* ThinkingIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF9D188FA8779E14011857FD /* ThinkingIndicatorView.swift */; };
+		183B504D74DDAD2D59703D77 /* RedHerringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 793A8B950E0FD6822E2346F2 /* RedHerringTests.swift */; };
 		1851700C174060BC3AC3208C /* SayItClearlySessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9512DE8E01F6C1AB4E4B8C /* SayItClearlySessionTests.swift */; };
 		1A0A534D8D6C7F327BD1F572 /* StreamingSentenceDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F1615A68359E9BF1E15F1C0 /* StreamingSentenceDetector.swift */; };
 		1CDA6E9592B48813ECDFA8D7 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DD215422DC5781D0AFDAAEE /* OnboardingView.swift */; };
@@ -56,26 +61,33 @@
 		25C8BCA79939B0F44945A97F /* SidebarViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1161CE00FACCF6715D7034A1 /* SidebarViewTests.swift */; };
 		26EF845803D483A39BCEA37B /* StreamingSentenceDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E4E18B61DA2D4BD3AB29AD9 /* StreamingSentenceDetectorTests.swift */; };
 		26F70AF1E1BDF322EBFDC2B8 /* ChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A6659848CFB393F442C3B61 /* ChatView.swift */; };
+		271B69A42DF1CE011056D109 /* FixThisMessExerciseLibrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF7C54B8489C89FCA6ED3EDE /* FixThisMessExerciseLibrary.swift */; };
 		272E62E1088D208085F245B5 /* TextDifficultyCalibratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60AF6BBA9B0AF6383B674F02 /* TextDifficultyCalibratorTests.swift */; };
+		276888BF58A22A31763A50CD /* VoiceTextToggleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E52A3B192714E4372A8B24A /* VoiceTextToggleTests.swift */; };
 		28CABE726983AF0A238983DE /* NetworkErrorHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F95CF0998D962402B03233 /* NetworkErrorHandlerTests.swift */; };
 		2979108A06095D07DB94AC91 /* StreamingSentenceDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E4E18B61DA2D4BD3AB29AD9 /* StreamingSentenceDetectorTests.swift */; };
 		2A460E01C69253703F197DFA /* StreamingSentenceDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F1615A68359E9BF1E15F1C0 /* StreamingSentenceDetector.swift */; };
 		2A465A472C7B43AE1FCFDECE /* ChatViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23B4EEBCB3D583F917C7B25 /* ChatViewModel.swift */; };
+		2AF2DE11A7FF74C304397F6E /* FixThisMessVisualView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E1B20E8DFB3372D627CEB28 /* FixThisMessVisualView.swift */; };
 		2B14BDEB8225AE1C3D457F15 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DD215422DC5781D0AFDAAEE /* OnboardingView.swift */; };
 		2B62856D49AD9FB989384F80 /* AnthropicModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10F6CAB4EBA45B17A293C4C0 /* AnthropicModel.swift */; };
 		2B6D34E742035859B43FF43E /* MessageBubbleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A0D6917A3C05487B814E35 /* MessageBubbleView.swift */; };
 		2BA09208E878385E27A82A73 /* DecodeAndRebuildTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F311FDA056466909DBBC103C /* DecodeAndRebuildTests.swift */; };
 		2C1D8AB58512AA4B4605815E /* AnthropicService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C28CC98EB4FCDC9137D15433 /* AnthropicService.swift */; };
 		2C83ABF0241F42C8239A5DB3 /* SessionHistoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D693A9655797CEF326A8BA1C /* SessionHistoryTests.swift */; };
+		2CC52BCAEFD6CF1ACB67DFFF /* iPadPyramidLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B237CADEB85F975D748385B3 /* iPadPyramidLayoutTests.swift */; };
 		2D4D59D45FD3FDC4D737C08B /* PracticeTextLibraryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C70ADBF790944D3353F4FA32 /* PracticeTextLibraryTests.swift */; };
 		2D80A3F94A0B23AF02D04401 /* EvaluationResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 238EF463FFDCF9B00EC4123A /* EvaluationResult.swift */; };
 		2DDE080F3029A0750773ED22 /* BarbaraVoiceProfileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A6B15AE1ED645EEDFCA7DF5 /* BarbaraVoiceProfileTests.swift */; };
+		2F436DDC4A51CD9C42561E74 /* ZoomablePyramidCanvas.swift in Sources */ = {isa = PBXBuildFile; fileRef = F04D28D3D25E27B90D61F453 /* ZoomablePyramidCanvas.swift */; };
 		2F52829C24DE0D1E7D980EB2 /* FirstLaunchSetupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E493E1B347AC7D15C639949F /* FirstLaunchSetupView.swift */; };
 		2F84726B57E3AFF495436EF3 /* FixThisMessSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1023A980330BA11476479AC6 /* FixThisMessSessionTests.swift */; };
+		305AC34522F185D22A07231D /* PyramidKeyboardShortcuts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C98932E1C66B27BA28CA1E1 /* PyramidKeyboardShortcuts.swift */; };
 		322C09D5891901217A964082 /* VoiceSayItClearlyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 705DD7DFE2CA7A3BA37785EA /* VoiceSayItClearlyTests.swift */; };
 		32A7C946EE1DBD9A38776B96 /* SentenceDiff.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6F5A6679EC9EA0FDF699347 /* SentenceDiff.swift */; };
 		32D5314255E68AE513C355B9 /* StreamingTTSCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DF0427FCB8E6843FA1E136B /* StreamingTTSCoordinatorTests.swift */; };
 		33274CD62BE5B41D80760AC0 /* SystemPromptAssemblerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65A78B634A6D6F9D4CD57BC7 /* SystemPromptAssemblerTests.swift */; };
+		332FF8BDFA4A13A575E7A187 /* BuildThePyramidView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76026FDE2955161A78FADB69 /* BuildThePyramidView.swift */; };
 		33D64B1F80E3DC6DAB7F372D /* AnswerKeyComparison.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1910976EBE55B2D0A2B347CA /* AnswerKeyComparison.swift */; };
 		33D97DD448F0E5566052D4BC /* SpeechRecognitionServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D57221714F45B9C00201617 /* SpeechRecognitionServiceTests.swift */; };
 		3663C29466AF276F1C5289C7 /* SystemPromptAssembler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4096FB5122C41B3F25CCFB2 /* SystemPromptAssembler.swift */; };
@@ -105,6 +117,7 @@
 		496007D2A4A26B62F5B29D3D /* SayItRight.xcodeproj in Resources */ = {isa = PBXBuildFile; fileRef = 3FAF495135EB918BBBE3A021 /* SayItRight.xcodeproj */; };
 		49828FC1CE9DAC9540F13C29 /* AdaptiveChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0756AEBC135E6923ED87C8A0 /* AdaptiveChatView.swift */; };
 		4A474E230C0D5315C1A62ABC /* FixThisMessCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0F94F29CC51A4E01478BE88 /* FixThisMessCoordinator.swift */; };
+		4AA8887DDA05E2D04B8FDDDD /* pyramid-exercises.json in Resources */ = {isa = PBXBuildFile; fileRef = 8175192283ED8224716BB935 /* pyramid-exercises.json */; };
 		4ADCA36A5D1E8FE321C0FB22 /* SpotTheGapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99F23A39D61653C0FB1CBB47 /* SpotTheGapView.swift */; };
 		4AEE63E3C80544718B5058DA /* VoiceSayItClearlyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8565117528BB06983545B8A /* VoiceSayItClearlyView.swift */; };
 		4B2A43D61DD2CE7ADE73132C /* PracticeTextLibrary_de.json in Resources */ = {isa = PBXBuildFile; fileRef = BEE1CAA3817E82AA6D53AF15 /* PracticeTextLibrary_de.json */; };
@@ -114,6 +127,7 @@
 		531F7C8788BD0D599A7E8D04 /* PyramidFeedbackOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 147D1E1AF8B5697A25D1EFFB /* PyramidFeedbackOverlay.swift */; };
 		537119E6E50C56A7FBE6CF59 /* AudioSessionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED72B2F78895FD96D69C5698 /* AudioSessionManager.swift */; };
 		551B5D55D83D830E1E13748E /* AdaptiveDifficultyEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35D136B15681796D9B441FCE /* AdaptiveDifficultyEngine.swift */; };
+		562FAF04B0C6756D1406823A /* PyramidExercise.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEFAA436BA86F6308DC9335A /* PyramidExercise.swift */; };
 		5673D8240DB6073E30B4EAF5 /* LearnerProfileStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7340051027E1031862796AD /* LearnerProfileStore.swift */; };
 		56E59D06B02418F6D1057A03 /* ChatViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40319D5211156AC1671570F5 /* ChatViewTests.swift */; };
 		57BFD8048F458724D5220EE4 /* SidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F227EDAC8833CE0EA075111 /* SidebarView.swift */; };
@@ -127,18 +141,22 @@
 		5DA2F76EA751F3EF0CB55386 /* StreamingTTSCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DF0427FCB8E6843FA1E136B /* StreamingTTSCoordinatorTests.swift */; };
 		5DBDDDE558A97B0071AA74AE /* TextDifficultyCalibrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4CF3E7C70F0FAB82378322A /* TextDifficultyCalibrator.swift */; };
 		5E86220B69F94E1D80BE6E21 /* PracticeTextLibrary_en.json in Resources */ = {isa = PBXBuildFile; fileRef = E021EB6D73273983DB9E14F6 /* PracticeTextLibrary_en.json */; };
+		5EA73D157455010E5D04CB2B /* FixThisMessVisualView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E1B20E8DFB3372D627CEB28 /* FixThisMessVisualView.swift */; };
 		5EC9E9835C8E009CDF6CAEC4 /* FeedbackBubbleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A92CDDC30DF529F4F6E693B /* FeedbackBubbleTests.swift */; };
 		5F51449B08403989803DD749 /* ResponseParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 192E20839A759A3AF4CC7D51 /* ResponseParser.swift */; };
 		5F73FE131A1DB6BA939A2C5A /* AdaptiveChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0756AEBC135E6923ED87C8A0 /* AdaptiveChatView.swift */; };
 		60E3C43BE15EA0EBE21C942A /* ThinkingIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF9D188FA8779E14011857FD /* ThinkingIndicatorView.swift */; };
 		60E3DD654D41C484DFD3281E /* AudioSessionManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D5A7EA09817CE62F1FE9796 /* AudioSessionManagerTests.swift */; };
+		61977A1FD3316A0966C942F8 /* FixThisMessVisualCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13F7A3F7847EA1DF564E3C8E /* FixThisMessVisualCoordinator.swift */; };
 		61D91FAFDD31B3B2654460EC /* GapPlaceholderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E067F208DB8387CEC7A738A /* GapPlaceholderView.swift */; };
 		62641799AE854D5ED7B337B1 /* PracticeTextLibraryContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F58ED745199D9D446AC8FC6 /* PracticeTextLibraryContainer.swift */; };
 		63252351666063E76D3075C4 /* FixThisMessView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A9E8EB9C1E2B0BA8B04848D /* FixThisMessView.swift */; };
 		64A04AB12BD9FD132B0D9F8A /* TreeLayoutEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4AEE9C322510B2451BC0B6B /* TreeLayoutEngine.swift */; };
+		64A49F30B3A3F3CFE488E79B /* BuildThePyramidTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7324F8468E4DE52E9E5B114F /* BuildThePyramidTests.swift */; };
 		64C0FEE13C0BFAE2B0D6FE37 /* GapPlaceholderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E067F208DB8387CEC7A738A /* GapPlaceholderView.swift */; };
 		64E2CA4EDF1673C44CE2300E /* LearnerProfileStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7340051027E1031862796AD /* LearnerProfileStore.swift */; };
 		66DD685F81C1CDA61F82D0A3 /* FirstLaunchSetupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E493E1B347AC7D15C639949F /* FirstLaunchSetupView.swift */; };
+		66E23C17FC6D5ECFD14F6DAE /* RedHerringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 793A8B950E0FD6822E2346F2 /* RedHerringTests.swift */; };
 		673457079BE69921EBC15164 /* SessionSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABF4D8A07EE48301BBF12A0C /* SessionSummary.swift */; };
 		68324B657FD362B1C2BDBE57 /* CelebrationEffectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D24253A3138E22C5ED601F03 /* CelebrationEffectView.swift */; };
 		6862FA1CB7124F4D08390F6B /* PracticeTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C347D7912E827154F7F23208 /* PracticeTextView.swift */; };
@@ -147,6 +165,7 @@
 		691C23DCCF2C5FE4EB2B14CB /* ConnectionLinesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2ED4B98BAC3EA13F5C61CBCD /* ConnectionLinesTests.swift */; };
 		694D7A17D77BC80EF7C0DFE6 /* AppSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81A63E61EA4ABC850E93CB2E /* AppSettings.swift */; };
 		69648C78907876EC6BDB6892 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB92388718B19A2E45FBDC1 /* SettingsView.swift */; };
+		696E6FAE8B98220F58290FBA /* BuildThePyramidCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3156D3670B3AC3EE91BDD423 /* BuildThePyramidCoordinator.swift */; };
 		69AE8809D5B4FD31A2EFC38F /* DecodeAndRebuildView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B0CFE1578A9BD9153E4098D /* DecodeAndRebuildView.swift */; };
 		6C681A520B587FCEBFAE81B9 /* ChatMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D08BE80207F27A8208D3CCB2 /* ChatMessage.swift */; };
 		6C7096189A52A789768C7042 /* EvaluationResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 238EF463FFDCF9B00EC4123A /* EvaluationResult.swift */; };
@@ -155,8 +174,10 @@
 		7043BFA9D8C90767E45A2FD5 /* BarbaraMood.swift in Sources */ = {isa = PBXBuildFile; fileRef = 942B7D62D7DC6CDF6EE5C3AD /* BarbaraMood.swift */; };
 		723A20280CAAEEC0A61BF110 /* LevelUpCelebrationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B180A246925AD77C2C5D73C6 /* LevelUpCelebrationView.swift */; };
 		731B7002E3DBB7D9CDE10685 /* PracticeTextGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 761B9E06D45D03688B09D463 /* PracticeTextGeneratorTests.swift */; };
+		745051943B43B27A1E5C8726 /* ZoomablePyramidCanvas.swift in Sources */ = {isa = PBXBuildFile; fileRef = F04D28D3D25E27B90D61F453 /* ZoomablePyramidCanvas.swift */; };
 		754A2E39AA8EC9847F7C5A3D /* SessionFlowUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D487766C5B3D61C6959CC33D /* SessionFlowUITests.swift */; };
 		75AE4B49A8AA6C07DFCFE084 /* SayItRightApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE9990EFFDBC213F3F1D0B19 /* SayItRightApp.swift */; };
+		76A260081D4A503681C080E6 /* PyramidExerciseLibrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C783EF760D21412AAD9C2B5 /* PyramidExerciseLibrary.swift */; };
 		76A480936638CCB778908423 /* FindThePointSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DF3448F79F9C75AEEF2A73E /* FindThePointSessionTests.swift */; };
 		779DEBCF437A97E109B3E8BC /* PyramidBlock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AC8B2C13C23B149624FD027 /* PyramidBlock.swift */; };
 		77F5CBF575FBEBD80D594350 /* FixThisMessSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBC646A72B8AF0F24AD4708A /* FixThisMessSession.swift */; };
@@ -167,29 +188,36 @@
 		7B05C7916E626A00EABE4E1E /* VoiceInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F66A4FE516B8A86073D9B3 /* VoiceInputView.swift */; };
 		7C4F19780556D70FC8120784 /* PracticeTextFileWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39FB9A6BB2DA0BC61384039F /* PracticeTextFileWriter.swift */; };
 		7DC18453FA528BB316169109 /* PracticeTextGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400403CA410CF7A0E750127F /* PracticeTextGenerator.swift */; };
+		7DC5C94227802D3A92CF5500 /* PyramidExerciseLibrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C783EF760D21412AAD9C2B5 /* PyramidExerciseLibrary.swift */; };
 		7E7667450C92F22C9B74E67F /* InteractiveFlowUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 429373D23F77790C6237EF3D /* InteractiveFlowUITests.swift */; };
 		803EEA750EBA59009E814F7C /* SayItClearlyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47BCCF7B7169BFF3B4722C58 /* SayItClearlyView.swift */; };
 		81160A48F23B0693F8B6BE38 /* VoiceInputViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FFAF667809AFED071F2163 /* VoiceInputViewModel.swift */; };
 		812AC213EB49FEC705555E09 /* ResponseParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8D179C236AD14B5C8076627 /* ResponseParserTests.swift */; };
 		81A961AB926731C065A38556 /* ComparisonPromptBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69C98EBC60AB392AA8868374 /* ComparisonPromptBuilder.swift */; };
 		81E23FA9C56B29B66E3ECD13 /* SeenTextsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC1974647876CBDFA39B8A71 /* SeenTextsStore.swift */; };
+		8236A6035390656DBE37A096 /* HapticFeedbackManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CA7F0DA129D49EFFBBF4AEE /* HapticFeedbackManager.swift */; };
 		8253B0ABF87DA1DEF424AB4E /* MicrophoneButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8309BF4EE774FABE588555F4 /* MicrophoneButton.swift */; };
+		845F69076C945181FAD59B15 /* VoiceFindThePointTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A17D6E2ACDC8F492B10A02E /* VoiceFindThePointTests.swift */; };
+		85A21C89854A7C68754D1370 /* VoiceFindThePointView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77DAD2008EC8FEA09E753E5D /* VoiceFindThePointView.swift */; };
 		865BFDEEB91EE758933181A6 /* DashboardUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB007B7D8056D3457AE80A5A /* DashboardUITests.swift */; };
 		868CC677F0EF47C03E66115E /* BarbaraAvatarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36C6BF2F47F0B8EFFC2DF98B /* BarbaraAvatarView.swift */; };
 		86AC04612F354912B3989863 /* AppVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = F70F04FAE54C5FB6BC13D7E5 /* AppVersion.swift */; };
 		8728021A5019601223697286 /* ElevatorPitchCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76F67E39596D4AD4CCEAE6BB /* ElevatorPitchCoordinator.swift */; };
 		89CED9375747E4D03FCB8E66 /* PracticeTextGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 761B9E06D45D03688B09D463 /* PracticeTextGeneratorTests.swift */; };
+		8A9859967A8F8FA32CEDFCA2 /* FixThisMessVisualTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E9108B9D961EB9E8254EA37 /* FixThisMessVisualTests.swift */; };
 		8B42E4659938F6B197D2BE6D /* VoiceSayItClearlyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 705DD7DFE2CA7A3BA37785EA /* VoiceSayItClearlyTests.swift */; };
 		8BCAE7135857113693FB95A1 /* SpotTheGapCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1E18573A8B8C49ABAA910FF /* SpotTheGapCoordinator.swift */; };
 		8BED3E20F4C909B14BE520AA /* DropZoneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C05DDD40848A9E59E713026 /* DropZoneView.swift */; };
 		8CE2454D0869BE2E74B38474 /* FindThePointCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19168BF6E4820E37458DAA57 /* FindThePointCoordinator.swift */; };
 		8D0594B48254C2F95AB7F9F3 /* LearnerAvatar.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE528A4BB6F7C58BD0CC3708 /* LearnerAvatar.swift */; };
 		8DE0054F17D7F85924AFAA02 /* SeenTextsTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C3D288AEDB1EF42A2CF3455 /* SeenTextsTracker.swift */; };
+		8E704B681025F187D88B0036 /* FixThisMessVisualCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13F7A3F7847EA1DF564E3C8E /* FixThisMessVisualCoordinator.swift */; };
 		8E8D202555A73B2756F2EBB0 /* TTSPlaybackService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4F296F432E8A069994E5167 /* TTSPlaybackService.swift */; };
 		8F2A3431111B3072FE14DE79 /* RevisionDiffView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92030535097EE61AEB0991D5 /* RevisionDiffView.swift */; };
 		901D104DC385EA8F6044D909 /* DraggableBlockView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4373E47CEF1B184CF62920CB /* DraggableBlockView.swift */; };
 		908ED70F336A90E3DBF4E198 /* AnthropicServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F77568CC779F6818DEF9ADCC /* AnthropicServiceTests.swift */; };
 		90D8CBC321E62326F073C06E /* ProgressionCriteria.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1848454FCBCACB1CC310E3F8 /* ProgressionCriteria.swift */; };
+		921B826F139020FE3B614574 /* VoiceFindThePointTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A17D6E2ACDC8F492B10A02E /* VoiceFindThePointTests.swift */; };
 		93FD1F354940149B9002ABA4 /* StreamingTTSCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B930A94D3E14C1EBF3EDBB7 /* StreamingTTSCoordinator.swift */; };
 		940C00B95F727301E44CC7BC /* MicrophoneButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8309BF4EE774FABE588555F4 /* MicrophoneButton.swift */; };
 		945C5AB0AE1C1A1164802CF7 /* PracticeText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48A1CF3D22441AE55554B302 /* PracticeText.swift */; };
@@ -200,6 +228,7 @@
 		9B75A691D0F56293D7AF2B2B /* ComparisonPromptBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69C98EBC60AB392AA8868374 /* ComparisonPromptBuilder.swift */; };
 		9C6C847EC9BCCD14AE067A8A /* TTSPlaybackServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1964D965458CCC6A3A747B0 /* TTSPlaybackServiceTests.swift */; };
 		9C781F5BC09396E0F44BBFCB /* StructuralEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11A375822F278D205A1F9090 /* StructuralEvaluator.swift */; };
+		9CAED6F1658DB9BDA1BDC8BB /* BuildThePyramidView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76026FDE2955161A78FADB69 /* BuildThePyramidView.swift */; };
 		9D25E26FB942070B61F6E54D /* ElevatorPitchCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76F67E39596D4AD4CCEAE6BB /* ElevatorPitchCoordinator.swift */; };
 		9D641BA106661D4AD460D3A1 /* AnswerKeyComparison.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1910976EBE55B2D0A2B347CA /* AnswerKeyComparison.swift */; };
 		9E229F94708A12673A30600F /* PINEntryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0B8EDE7E53601DCAC1DB42 /* PINEntryView.swift */; };
@@ -207,8 +236,10 @@
 		9F4591B7ECA4FB6CA5E1F133 /* SpotTheGapSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = D017723020F6F34961708FA5 /* SpotTheGapSession.swift */; };
 		9FF735052B95F66DE636AF76 /* FindThePointSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5FB097A1FAE84E286F0F1F6 /* FindThePointSession.swift */; };
 		A04684C5FA38C05AE7ADD9AB /* BreakModeProfileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72E114135776783B6B39A5FC /* BreakModeProfileTests.swift */; };
+		A0961872ED42AE2AD1EC05B5 /* PyramidKeyboardShortcuts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C98932E1C66B27BA28CA1E1 /* PyramidKeyboardShortcuts.swift */; };
 		A0BC2607510CD45A0EB77F83 /* DecodeAndRebuildSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C1C17B6886769CDF1D032C0 /* DecodeAndRebuildSession.swift */; };
 		A14921A5A09F6F75BE93E7DD /* DecodeAndRebuildCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7457AD0D49EDBFFC9A164161 /* DecodeAndRebuildCoordinator.swift */; };
+		A1C987C11E9C50B647D8B005 /* DiscardZoneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 322D29DD7BB1907EBD89A714 /* DiscardZoneView.swift */; };
 		A21F3D22008E858CE7D1DE45 /* PracticeTextLibrary_de.json in Resources */ = {isa = PBXBuildFile; fileRef = BEE1CAA3817E82AA6D53AF15 /* PracticeTextLibrary_de.json */; };
 		A4A0DD5041F5926F318A2BB6 /* AnalyseMyTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9386A4C1CF530878ECC12755 /* AnalyseMyTextView.swift */; };
 		A4A5E4A6E927A6FF4AE200B1 /* AnswerKeyComparer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AEAE8216CAB132332EE8012 /* AnswerKeyComparer.swift */; };
@@ -224,7 +255,10 @@
 		A9B7342D214CE45653F5BAB3 /* LearnerAvatar.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE528A4BB6F7C58BD0CC3708 /* LearnerAvatar.swift */; };
 		A9BA44DA0F1F2B687C7EB602 /* AnthropicModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10F6CAB4EBA45B17A293C4C0 /* AnthropicModel.swift */; };
 		A9C54D9E4FC609C3A85D553B /* DimensionBarChartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64F1F5B0738E60E8163A2FDB /* DimensionBarChartView.swift */; };
+		AA09CFCB0A0FFE69AB641706 /* BuildThePyramidSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96CDCE119B56BA8E0B338AF9 /* BuildThePyramidSession.swift */; };
 		AA84EBC9B2E3A2AEE4D24AEE /* VoiceElevatorPitchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBF554DE2E568F5716D89DD7 /* VoiceElevatorPitchView.swift */; };
+		AB8E0712827B692367EFA3F7 /* HapticAnimationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 854A70E536D055C3D8D8667F /* HapticAnimationTests.swift */; };
+		AC885E581926E54467460CCE /* HapticFeedbackManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CA7F0DA129D49EFFBBF4AEE /* HapticFeedbackManager.swift */; };
 		AD8F19056F59A9446FB10082 /* SpotTheGapHintTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBB5356B054475EC18A358C6 /* SpotTheGapHintTests.swift */; };
 		AD9D198E44358F88EF30E30B /* StructuralEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11A375822F278D205A1F9090 /* StructuralEvaluator.swift */; };
 		AE1A15A7E561DB90F19FF361 /* ElevatorPitchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCC9887FA1B8FA6F1AF29DAE /* ElevatorPitchView.swift */; };
@@ -232,13 +266,16 @@
 		AE5F4FDA4052322F82140791 /* ValidationFeedbackModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BCC3E8C4CBE011C33FC740B /* ValidationFeedbackModifier.swift */; };
 		AFEA82FE224E0347257B1DFC /* DropZoneTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFA22F5F2A41A4A96CFE4C47 /* DropZoneTests.swift */; };
 		B007E9CAE8E63D427DBBFF69 /* ParentGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B22653B114F07E9EA40C7C62 /* ParentGate.swift */; };
+		B0C445835A3A5011D6FB5A9C /* VoiceFindThePointView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77DAD2008EC8FEA09E753E5D /* VoiceFindThePointView.swift */; };
 		B13787CFCAB24657373BD223 /* MessageBubbleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A0D6917A3C05487B814E35 /* MessageBubbleView.swift */; };
 		B199E127AAF2B4EEFF4C02CC /* MacOSAdaptationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2648E59B50498C1D83FD795F /* MacOSAdaptationTests.swift */; };
 		B4128092EF246AE96A5BF1E0 /* DropZoneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C05DDD40848A9E59E713026 /* DropZoneView.swift */; };
 		B46B0F09B751DF672F082614 /* StreamingTTSCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B930A94D3E14C1EBF3EDBB7 /* StreamingTTSCoordinator.swift */; };
+		B558692A669A4B26EA03F5E1 /* VoicePlatformAdaptationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2B55123D70AEA12D645BFDD /* VoicePlatformAdaptationTests.swift */; };
 		B6403B3CA71AF12E11A38232 /* ConnectionLinesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2ED4B98BAC3EA13F5C61CBCD /* ConnectionLinesTests.swift */; };
 		B665C92DF1CD20E2C25E9DD8 /* ElevatorPitchSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E01132CC12B1CCE944CDE83F /* ElevatorPitchSessionTests.swift */; };
 		B69E88F9600BA196BDC08FCB /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB92388718B19A2E45FBDC1 /* SettingsView.swift */; };
+		B6DF5C6B33D9BE31C43483EA /* VoiceTextToggleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E52A3B192714E4372A8B24A /* VoiceTextToggleTests.swift */; };
 		B7C28920B91F304603968367 /* ProgressDashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC3572D84CA72E9A0723635D /* ProgressDashboardView.swift */; };
 		B9A3E55F2A478C2A379A875C /* SessionSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABF4D8A07EE48301BBF12A0C /* SessionSummary.swift */; };
 		B9A55A00D5E93D6AC049A85C /* ConfigProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2927967CBDF0913F5EDD0EC7 /* ConfigProvider.swift */; };
@@ -263,6 +300,7 @@
 		C372EDF597BB3E75358D1121 /* BarbaraVoiceProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F4D31053E77ACAC3D6E7D2 /* BarbaraVoiceProfile.swift */; };
 		C37CC4D67FE88C69E19D6FF4 /* PyramidBlockTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B70EF3120BD198913EAEE0A2 /* PyramidBlockTests.swift */; };
 		C3D6237CFE9553D6515E743A /* ElevatorPitchSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B7D104D20992358220CF516 /* ElevatorPitchSession.swift */; };
+		C415840C4B796BB9EBE9AA5E /* HapticAnimationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 854A70E536D055C3D8D8667F /* HapticAnimationTests.swift */; };
 		C4CE7E6FB0DA7A6B078EF083 /* AnalyseMyTextSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA73D30DCB7C56BAA6867CC2 /* AnalyseMyTextSession.swift */; };
 		C6707E67B7475B58554F2F92 /* BarbaraVoiceProfileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A6B15AE1ED645EEDFCA7DF5 /* BarbaraVoiceProfileTests.swift */; };
 		C68A1A0B560C01274838748E /* ErrorBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E27CEE853747DCC27BA168 /* ErrorBannerView.swift */; };
@@ -284,6 +322,7 @@
 		CDF1C5AF3C7F3606450C0F8A /* BlockFeedbackState.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA32E530E1641F627E7C5970 /* BlockFeedbackState.swift */; };
 		CE49D1EC9F14EE85575FA236 /* PyramidTreeState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72D83F01BEC457D843FA46B2 /* PyramidTreeState.swift */; };
 		CE5B36B251DCE97CBA0D847C /* SessionHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79103E672E97A7B33767ED30 /* SessionHistoryView.swift */; };
+		CE956B898080AFC0ADA1730A /* fix-this-mess-exercises.json in Resources */ = {isa = PBXBuildFile; fileRef = DAE6A8B9A9002747D1DD9425 /* fix-this-mess-exercises.json */; };
 		CFD488522376107A7697D0ED /* SessionHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79103E672E97A7B33767ED30 /* SessionHistoryView.swift */; };
 		D18F59F6E50DE4B10D1B6929 /* SayItClearlySessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9512DE8E01F6C1AB4E4B8C /* SayItClearlySessionTests.swift */; };
 		D3070A5C5100B0857F8ACA4B /* AdaptiveDifficultyEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35D136B15681796D9B441FCE /* AdaptiveDifficultyEngine.swift */; };
@@ -297,10 +336,13 @@
 		D6CD1F94E1C2E57A0888230E /* FirstLaunchSetupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C278322C149174D648ECF14 /* FirstLaunchSetupTests.swift */; };
 		D6E46973E64FECEFF0A906BD /* DecodeAndRebuildView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B0CFE1578A9BD9153E4098D /* DecodeAndRebuildView.swift */; };
 		D74B3E49DCE283F274B0FAE0 /* SentenceDiff.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6F5A6679EC9EA0FDF699347 /* SentenceDiff.swift */; };
+		D7E47290ACA62619DE4AA077 /* FixThisMessVisualTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E9108B9D961EB9E8254EA37 /* FixThisMessVisualTests.swift */; };
 		D895EB4DE625E96EF1AC8F4F /* RevisionDiffView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92030535097EE61AEB0991D5 /* RevisionDiffView.swift */; };
+		DA23A8FB8AF9AE1560E396D6 /* FixThisMessExercise.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17A5179DE93BEAFE6F829A3F /* FixThisMessExercise.swift */; };
 		DC8CB9656F62B3F2E9C313EE /* FeedbackBubbleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A92CDDC30DF529F4F6E693B /* FeedbackBubbleTests.swift */; };
 		DD46000474FB0168BB12A02E /* AnalyseMyTextSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 652143071B4E57A9035FE43B /* AnalyseMyTextSessionTests.swift */; };
 		DDD2F11F3AD9916F6E39F996 /* AppLanguage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1607A6E887C79A834F460459 /* AppLanguage.swift */; };
+		DE00EC52070DADD840C639DA /* DiscardZoneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 322D29DD7BB1907EBD89A714 /* DiscardZoneView.swift */; };
 		DE1CC7ECEADF4111754C15B0 /* VoiceInputViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FFAF667809AFED071F2163 /* VoiceInputViewModel.swift */; };
 		DE38095862958923B2416C42 /* BarbaraAvatarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A553A59D04C7ABFA86CF117E /* BarbaraAvatarTests.swift */; };
 		DE4B413678C1C56B351AAF07 /* SpeechRecognitionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD87491EB57716C7181C506 /* SpeechRecognitionService.swift */; };
@@ -308,14 +350,17 @@
 		E051DAB7CE1CB6C9AE6C2D79 /* DropZone.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28E6F9B9D6818D8BCF742BCC /* DropZone.swift */; };
 		E071B3F83FAD19AECA65C8A1 /* ParentSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B08B6C7C928249161C6C0AC /* ParentSettingsView.swift */; };
 		E1C178382A2262BB8A5C7E72 /* Topic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 188F1F9BBC0111EE4F4EB660 /* Topic.swift */; };
+		E1CEDBC152C75F388292530D /* PyramidExercise.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEFAA436BA86F6308DC9335A /* PyramidExercise.swift */; };
 		E22384E3209373AA4D8B48C6 /* ElevatorPitchSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E01132CC12B1CCE944CDE83F /* ElevatorPitchSessionTests.swift */; };
 		E2A161E1F5258D6DBC5A3548 /* PracticeTextFileWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39FB9A6BB2DA0BC61384039F /* PracticeTextFileWriter.swift */; };
 		E2E771E2E6E4B969403D183A /* ResponseParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8D179C236AD14B5C8076627 /* ResponseParserTests.swift */; };
 		E30210DD8492DB766516661E /* SessionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70A1CB45AEA63A237D7499E4 /* SessionManager.swift */; };
 		E321C3B2AF55A2695E19A119 /* FixThisMessCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0F94F29CC51A4E01478BE88 /* FixThisMessCoordinator.swift */; };
+		E41D00F52DEDE6F675777555 /* BuildThePyramidSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96CDCE119B56BA8E0B338AF9 /* BuildThePyramidSession.swift */; };
 		E41E774FF248354E2088C965 /* SessionFlowUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D487766C5B3D61C6959CC33D /* SessionFlowUITests.swift */; };
 		E4C81D76331F3F76AE3D62DC /* SessionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70A1CB45AEA63A237D7499E4 /* SessionManager.swift */; };
 		E55D26181C652FF34FB5B162 /* PracticeText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48A1CF3D22441AE55554B302 /* PracticeText.swift */; };
+		E6028FF9CD99BFB2D71A1EE0 /* TTSToggleButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ADB7696408FCD1220CF6CE5 /* TTSToggleButton.swift */; };
 		E6C0CE28BD49508CA40E8454 /* ProgressDashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC3572D84CA72E9A0723635D /* ProgressDashboardView.swift */; };
 		E713D1C41E34D3F651E1AE5C /* SessionPickerUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92081423D0707BA3273390CC /* SessionPickerUITests.swift */; };
 		E82E1F599E93664105775B47 /* LearnerProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49EB5CEF2D12A478BB1EA7AF /* LearnerProfile.swift */; };
@@ -323,8 +368,10 @@
 		E85E8849F8661277DB8256F1 /* PracticeTextLibraryContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F58ED745199D9D446AC8FC6 /* PracticeTextLibraryContainer.swift */; };
 		E964ABEE2D1CD7095C2F2CFE /* BarbaraAvatarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36C6BF2F47F0B8EFFC2DF98B /* BarbaraAvatarView.swift */; };
 		E97996275531EAC63277B021 /* AnswerKeyComparisonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2A6B03C9A74B0140D2B2BE7 /* AnswerKeyComparisonTests.swift */; };
+		E97F77D39C4A13969FAF5DD9 /* FixThisMessExercise.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17A5179DE93BEAFE6F829A3F /* FixThisMessExercise.swift */; };
 		EA0D4B1C48E68CDED67FFA0F /* TextDifficultyCalibratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60AF6BBA9B0AF6383B674F02 /* TextDifficultyCalibratorTests.swift */; };
 		EA56A67113CF8CEB37FE4066 /* SessionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = C02627D1A73370A9B58BE9CC /* SessionState.swift */; };
+		EBC0F4FD745B185D9413416D /* fix-this-mess-exercises.json in Resources */ = {isa = PBXBuildFile; fileRef = DAE6A8B9A9002747D1DD9425 /* fix-this-mess-exercises.json */; };
 		EBCF2F671531CFA0053373BA /* AnalyseMyTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9386A4C1CF530878ECC12755 /* AnalyseMyTextView.swift */; };
 		EBE7E901F00FD8C24B464A7F /* LevelTransitionEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51DEEB5ED5568D25D1376852 /* LevelTransitionEngine.swift */; };
 		EBE97AEDAD50F2E4A8AF50A3 /* PracticeTextLibraryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C70ADBF790944D3353F4FA32 /* PracticeTextLibraryTests.swift */; };
@@ -333,8 +380,10 @@
 		EDBBC9474916AA15B1A66C30 /* AdaptiveDifficultyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 076FD5273952AC72498F002F /* AdaptiveDifficultyTests.swift */; };
 		EE7B786DFC8E07B8C334D925 /* SpeechRecognitionServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D57221714F45B9C00201617 /* SpeechRecognitionServiceTests.swift */; };
 		F00F932F2105F4C2E508109B /* AnswerKeyComparer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AEAE8216CAB132332EE8012 /* AnswerKeyComparer.swift */; };
+		F0CC621C5F889F0283C990CD /* VoicePlatformAdaptationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2B55123D70AEA12D645BFDD /* VoicePlatformAdaptationTests.swift */; };
 		F0CC71F3229103F04C025A33 /* PracticeTextLibrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BFD6B8D5C586B0C9ADEEBA5 /* PracticeTextLibrary.swift */; };
 		F138325B5D79C1F7D86FD19F /* ErrorBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E27CEE853747DCC27BA168 /* ErrorBannerView.swift */; };
+		F179332F2979B527404C9CDC /* TTSToggleButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ADB7696408FCD1220CF6CE5 /* TTSToggleButton.swift */; };
 		F1F057BADCA87A05AF322BC6 /* LearnerProfileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A1C0B31006940A2DBFE5E41 /* LearnerProfileTests.swift */; };
 		F346F9FB9821471D106B15A5 /* SpotTheGapSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = D017723020F6F34961708FA5 /* SpotTheGapSession.swift */; };
 		F3616A8DCCA1C03700E986ED /* Config.plist in Resources */ = {isa = PBXBuildFile; fileRef = 87C3E174CED5835D593C922D /* Config.plist */; };
@@ -342,6 +391,7 @@
 		F489AF2C43E8E5A051F6D164 /* NetworkErrorHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91ECF5F1EF7623373F5BBD2C /* NetworkErrorHandler.swift */; };
 		F5A28442A564B05F3EB1CFE0 /* MockSpeechRecognitionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A734FF80156849AAC5CD69 /* MockSpeechRecognitionService.swift */; };
 		F65C548B9D183E16669313BF /* ProfileUpdaterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98CBB6A6B6FD6628BB30BA6D /* ProfileUpdaterTests.swift */; };
+		F665752C28731342E3478BD4 /* BuildThePyramidTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7324F8468E4DE52E9E5B114F /* BuildThePyramidTests.swift */; };
 		F68A7E82CAC1C17DF3417D14 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2679A39DC09E233E6C5FB8DC /* Assets.xcassets */; };
 		F9F35AAB16261DE9156AFA81 /* DraggableBlockView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4373E47CEF1B184CF62920CB /* DraggableBlockView.swift */; };
 		FB4A6CAC2211C3CE1456B0C4 /* ChatViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40319D5211156AC1671570F5 /* ChatViewTests.swift */; };
@@ -394,15 +444,19 @@
 		076FD5273952AC72498F002F /* AdaptiveDifficultyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdaptiveDifficultyTests.swift; sourceTree = "<group>"; };
 		0A30E1A80DC1D1B71AF67390 /* FeedbackBubbleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackBubbleView.swift; sourceTree = "<group>"; };
 		0AEAE8216CAB132332EE8012 /* AnswerKeyComparer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnswerKeyComparer.swift; sourceTree = "<group>"; };
+		0C98932E1C66B27BA28CA1E1 /* PyramidKeyboardShortcuts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PyramidKeyboardShortcuts.swift; sourceTree = "<group>"; };
 		0D5A7EA09817CE62F1FE9796 /* AudioSessionManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioSessionManagerTests.swift; sourceTree = "<group>"; };
+		0E52A3B192714E4372A8B24A /* VoiceTextToggleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceTextToggleTests.swift; sourceTree = "<group>"; };
 		0F511DE18C0C20C43553C36D /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
 		1023A980330BA11476479AC6 /* FixThisMessSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FixThisMessSessionTests.swift; sourceTree = "<group>"; };
 		103ABAFD57131CF246BE99AC /* OnboardingUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingUITests.swift; sourceTree = "<group>"; };
 		10F6CAB4EBA45B17A293C4C0 /* AnthropicModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnthropicModel.swift; sourceTree = "<group>"; };
 		1161CE00FACCF6715D7034A1 /* SidebarViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarViewTests.swift; sourceTree = "<group>"; };
 		11A375822F278D205A1F9090 /* StructuralEvaluator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StructuralEvaluator.swift; sourceTree = "<group>"; };
+		13F7A3F7847EA1DF564E3C8E /* FixThisMessVisualCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FixThisMessVisualCoordinator.swift; sourceTree = "<group>"; };
 		147D1E1AF8B5697A25D1EFFB /* PyramidFeedbackOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PyramidFeedbackOverlay.swift; sourceTree = "<group>"; };
 		1607A6E887C79A834F460459 /* AppLanguage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLanguage.swift; sourceTree = "<group>"; };
+		17A5179DE93BEAFE6F829A3F /* FixThisMessExercise.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FixThisMessExercise.swift; sourceTree = "<group>"; };
 		1848454FCBCACB1CC310E3F8 /* ProgressionCriteria.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressionCriteria.swift; sourceTree = "<group>"; };
 		188F1F9BBC0111EE4F4EB660 /* Topic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Topic.swift; sourceTree = "<group>"; };
 		1910976EBE55B2D0A2B347CA /* AnswerKeyComparison.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnswerKeyComparison.swift; sourceTree = "<group>"; };
@@ -433,6 +487,8 @@
 		2ED4B98BAC3EA13F5C61CBCD /* ConnectionLinesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionLinesTests.swift; sourceTree = "<group>"; };
 		2F8727097172513F7D8AA109 /* SayItRight.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SayItRight.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		30EED07035F76FC2168D236A /* ProfileUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileUpdater.swift; sourceTree = "<group>"; };
+		3156D3670B3AC3EE91BDD423 /* BuildThePyramidCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildThePyramidCoordinator.swift; sourceTree = "<group>"; };
+		322D29DD7BB1907EBD89A714 /* DiscardZoneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscardZoneView.swift; sourceTree = "<group>"; };
 		35D136B15681796D9B441FCE /* AdaptiveDifficultyEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdaptiveDifficultyEngine.swift; sourceTree = "<group>"; };
 		36C6BF2F47F0B8EFFC2DF98B /* BarbaraAvatarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarbaraAvatarView.swift; sourceTree = "<group>"; };
 		39FB9A6BB2DA0BC61384039F /* PracticeTextFileWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticeTextFileWriter.swift; sourceTree = "<group>"; };
@@ -452,6 +508,7 @@
 		4A6B15AE1ED645EEDFCA7DF5 /* BarbaraVoiceProfileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarbaraVoiceProfileTests.swift; sourceTree = "<group>"; };
 		4B7D104D20992358220CF516 /* ElevatorPitchSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElevatorPitchSession.swift; sourceTree = "<group>"; };
 		4C7E28ABC6EA21CD4558AB69 /* TopicBank.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = TopicBank.json; sourceTree = "<group>"; };
+		4CA7F0DA129D49EFFBBF4AEE /* HapticFeedbackManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HapticFeedbackManager.swift; sourceTree = "<group>"; };
 		4F227EDAC8833CE0EA075111 /* SidebarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarView.swift; sourceTree = "<group>"; };
 		51DEEB5ED5568D25D1376852 /* LevelTransitionEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LevelTransitionEngine.swift; sourceTree = "<group>"; };
 		51E5916F947F218355F932A9 /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
@@ -460,6 +517,7 @@
 		5BCC3E8C4CBE011C33FC740B /* ValidationFeedbackModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidationFeedbackModifier.swift; sourceTree = "<group>"; };
 		5C05DDD40848A9E59E713026 /* DropZoneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DropZoneView.swift; sourceTree = "<group>"; };
 		5E067F208DB8387CEC7A738A /* GapPlaceholderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GapPlaceholderView.swift; sourceTree = "<group>"; };
+		5E1B20E8DFB3372D627CEB28 /* FixThisMessVisualView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FixThisMessVisualView.swift; sourceTree = "<group>"; };
 		5E4E18B61DA2D4BD3AB29AD9 /* StreamingSentenceDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamingSentenceDetectorTests.swift; sourceTree = "<group>"; };
 		60AF6BBA9B0AF6383B674F02 /* TextDifficultyCalibratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextDifficultyCalibratorTests.swift; sourceTree = "<group>"; };
 		61E27CEE853747DCC27BA168 /* ErrorBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorBannerView.swift; sourceTree = "<group>"; };
@@ -472,25 +530,34 @@
 		69C98EBC60AB392AA8868374 /* ComparisonPromptBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComparisonPromptBuilder.swift; sourceTree = "<group>"; };
 		6A92CDDC30DF529F4F6E693B /* FeedbackBubbleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackBubbleTests.swift; sourceTree = "<group>"; };
 		6BCBA23B5D640E11325097D0 /* KeychainService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainService.swift; sourceTree = "<group>"; };
+		6C783EF760D21412AAD9C2B5 /* PyramidExerciseLibrary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PyramidExerciseLibrary.swift; sourceTree = "<group>"; };
 		705DD7DFE2CA7A3BA37785EA /* VoiceSayItClearlyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceSayItClearlyTests.swift; sourceTree = "<group>"; };
 		70A1CB45AEA63A237D7499E4 /* SessionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionManager.swift; sourceTree = "<group>"; };
 		72D83F01BEC457D843FA46B2 /* PyramidTreeState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PyramidTreeState.swift; sourceTree = "<group>"; };
 		72E114135776783B6B39A5FC /* BreakModeProfileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BreakModeProfileTests.swift; sourceTree = "<group>"; };
+		7324F8468E4DE52E9E5B114F /* BuildThePyramidTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildThePyramidTests.swift; sourceTree = "<group>"; };
 		733BB20C0BD2FB42B93C9EB2 /* SayItRightUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SayItRightUITests.swift; sourceTree = "<group>"; };
 		7457AD0D49EDBFFC9A164161 /* DecodeAndRebuildCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecodeAndRebuildCoordinator.swift; sourceTree = "<group>"; };
+		76026FDE2955161A78FADB69 /* BuildThePyramidView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildThePyramidView.swift; sourceTree = "<group>"; };
 		761B9E06D45D03688B09D463 /* PracticeTextGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticeTextGeneratorTests.swift; sourceTree = "<group>"; };
 		76F67E39596D4AD4CCEAE6BB /* ElevatorPitchCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElevatorPitchCoordinator.swift; sourceTree = "<group>"; };
+		77DAD2008EC8FEA09E753E5D /* VoiceFindThePointView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceFindThePointView.swift; sourceTree = "<group>"; };
 		79103E672E97A7B33767ED30 /* SessionHistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionHistoryView.swift; sourceTree = "<group>"; };
+		793A8B950E0FD6822E2346F2 /* RedHerringTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RedHerringTests.swift; sourceTree = "<group>"; };
 		7A6659848CFB393F442C3B61 /* ChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatView.swift; sourceTree = "<group>"; };
 		7B0CFE1578A9BD9153E4098D /* DecodeAndRebuildView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecodeAndRebuildView.swift; sourceTree = "<group>"; };
 		7D0E72ADDB393F0AF5439B40 /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
 		7D6E766B91AF9A75C1FBD2F7 /* SpotTheGapSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotTheGapSessionTests.swift; sourceTree = "<group>"; };
+		7E9108B9D961EB9E8254EA37 /* FixThisMessVisualTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FixThisMessVisualTests.swift; sourceTree = "<group>"; };
+		8175192283ED8224716BB935 /* pyramid-exercises.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "pyramid-exercises.json"; sourceTree = "<group>"; };
 		81A11E691EB3DEE60B339B16 /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
 		81A63E61EA4ABC850E93CB2E /* AppSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSettings.swift; sourceTree = "<group>"; };
 		8309BF4EE774FABE588555F4 /* MicrophoneButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicrophoneButton.swift; sourceTree = "<group>"; };
+		854A70E536D055C3D8D8667F /* HapticAnimationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HapticAnimationTests.swift; sourceTree = "<group>"; };
 		86E2D821520E6552AE4B65B7 /* SayItRightTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = SayItRightTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		87C3E174CED5835D593C922D /* Config.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Config.plist; sourceTree = "<group>"; };
 		897590D408780860448C0A3D /* SentenceDiffTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentenceDiffTests.swift; sourceTree = "<group>"; };
+		8A17D6E2ACDC8F492B10A02E /* VoiceFindThePointTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceFindThePointTests.swift; sourceTree = "<group>"; };
 		8AB92388718B19A2E45FBDC1 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		8D20FDE7D46349EC7346DA67 /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
 		91ECF5F1EF7623373F5BBD2C /* NetworkErrorHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkErrorHandler.swift; sourceTree = "<group>"; };
@@ -499,12 +566,14 @@
 		9386A4C1CF530878ECC12755 /* AnalyseMyTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyseMyTextView.swift; sourceTree = "<group>"; };
 		942B7D62D7DC6CDF6EE5C3AD /* BarbaraMood.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarbaraMood.swift; sourceTree = "<group>"; };
 		95D3FAF0967C63A54E2C6E51 /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
+		96CDCE119B56BA8E0B338AF9 /* BuildThePyramidSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildThePyramidSession.swift; sourceTree = "<group>"; };
 		98CBB6A6B6FD6628BB30BA6D /* ProfileUpdaterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileUpdaterTests.swift; sourceTree = "<group>"; };
 		99F23A39D61653C0FB1CBB47 /* SpotTheGapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotTheGapView.swift; sourceTree = "<group>"; };
 		9A0B8EDE7E53601DCAC1DB42 /* PINEntryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PINEntryView.swift; sourceTree = "<group>"; };
 		9A1C0B31006940A2DBFE5E41 /* LearnerProfileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearnerProfileTests.swift; sourceTree = "<group>"; };
 		9A466760C86E7CBA8E140814 /* SessionPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionPickerView.swift; sourceTree = "<group>"; };
 		9AC8B2C13C23B149624FD027 /* PyramidBlock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PyramidBlock.swift; sourceTree = "<group>"; };
+		9ADB7696408FCD1220CF6CE5 /* TTSToggleButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TTSToggleButton.swift; sourceTree = "<group>"; };
 		9B930A94D3E14C1EBF3EDBB7 /* StreamingTTSCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamingTTSCoordinator.swift; sourceTree = "<group>"; };
 		9D07B7B9E84CD6DF8BC6ACCF /* MECEValidationEngineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MECEValidationEngineTests.swift; sourceTree = "<group>"; };
 		A1964D965458CCC6A3A747B0 /* TTSPlaybackServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TTSPlaybackServiceTests.swift; sourceTree = "<group>"; };
@@ -519,6 +588,7 @@
 		B1355D670E0F227DE429EAB9 /* DebugLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugLogger.swift; sourceTree = "<group>"; };
 		B180A246925AD77C2C5D73C6 /* LevelUpCelebrationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LevelUpCelebrationView.swift; sourceTree = "<group>"; };
 		B22653B114F07E9EA40C7C62 /* ParentGate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentGate.swift; sourceTree = "<group>"; };
+		B237CADEB85F975D748385B3 /* iPadPyramidLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iPadPyramidLayoutTests.swift; sourceTree = "<group>"; };
 		B466AA033E6F289710EDCFC8 /* FindThePointView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindThePointView.swift; sourceTree = "<group>"; };
 		B4AEE9C322510B2451BC0B6B /* TreeLayoutEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TreeLayoutEngine.swift; sourceTree = "<group>"; };
 		B70EF3120BD198913EAEE0A2 /* PyramidBlockTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PyramidBlockTests.swift; sourceTree = "<group>"; };
@@ -556,13 +626,16 @@
 		D693A9655797CEF326A8BA1C /* SessionHistoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionHistoryTests.swift; sourceTree = "<group>"; };
 		D6C50086B3A681AE4B706D0B /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
 		D7340051027E1031862796AD /* LearnerProfileStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearnerProfileStore.swift; sourceTree = "<group>"; };
+		DAE6A8B9A9002747D1DD9425 /* fix-this-mess-exercises.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "fix-this-mess-exercises.json"; sourceTree = "<group>"; };
 		DBF554DE2E568F5716D89DD7 /* VoiceElevatorPitchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceElevatorPitchView.swift; sourceTree = "<group>"; };
 		DC11499E66D1CCC6F0EDB5EE /* ComparisonResponseParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComparisonResponseParser.swift; sourceTree = "<group>"; };
 		DC1974647876CBDFA39B8A71 /* SeenTextsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeenTextsStore.swift; sourceTree = "<group>"; };
 		DE9990EFFDBC213F3F1D0B19 /* SayItRightApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SayItRightApp.swift; sourceTree = "<group>"; };
+		DF7C54B8489C89FCA6ED3EDE /* FixThisMessExerciseLibrary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FixThisMessExerciseLibrary.swift; sourceTree = "<group>"; };
 		E01132CC12B1CCE944CDE83F /* ElevatorPitchSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElevatorPitchSessionTests.swift; sourceTree = "<group>"; };
 		E021EB6D73273983DB9E14F6 /* PracticeTextLibrary_en.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = PracticeTextLibrary_en.json; sourceTree = "<group>"; };
 		E040537D24996C58EBA537D8 /* Config.template.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Config.template.plist; sourceTree = "<group>"; };
+		E2B55123D70AEA12D645BFDD /* VoicePlatformAdaptationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoicePlatformAdaptationTests.swift; sourceTree = "<group>"; };
 		E399297963E1A59A4C958BFA /* SeenTextsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeenTextsTests.swift; sourceTree = "<group>"; };
 		E493E1B347AC7D15C639949F /* FirstLaunchSetupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstLaunchSetupView.swift; sourceTree = "<group>"; };
 		E4CF3E7C70F0FAB82378322A /* TextDifficultyCalibrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextDifficultyCalibrator.swift; sourceTree = "<group>"; };
@@ -572,7 +645,9 @@
 		EA32E530E1641F627E7C5970 /* BlockFeedbackState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockFeedbackState.swift; sourceTree = "<group>"; };
 		EBB5356B054475EC18A358C6 /* SpotTheGapHintTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotTheGapHintTests.swift; sourceTree = "<group>"; };
 		ED72B2F78895FD96D69C5698 /* AudioSessionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioSessionManager.swift; sourceTree = "<group>"; };
+		EEFAA436BA86F6308DC9335A /* PyramidExercise.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PyramidExercise.swift; sourceTree = "<group>"; };
 		EF9A6BF1241D474DACAAE762 /* VoiceElevatorPitchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceElevatorPitchTests.swift; sourceTree = "<group>"; };
+		F04D28D3D25E27B90D61F453 /* ZoomablePyramidCanvas.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZoomablePyramidCanvas.swift; sourceTree = "<group>"; };
 		F2A6B03C9A74B0140D2B2BE7 /* AnswerKeyComparisonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnswerKeyComparisonTests.swift; sourceTree = "<group>"; };
 		F311FDA056466909DBBC103C /* DecodeAndRebuildTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecodeAndRebuildTests.swift; sourceTree = "<group>"; };
 		F3E7290B780810CAE4428003 /* StructuralEvaluatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StructuralEvaluatorTests.swift; sourceTree = "<group>"; };
@@ -609,6 +684,7 @@
 				6CC2ABFC83DABF3884313EB9 /* ExerciseLibrary */,
 				642F2EA09D7FC0374BA0C644 /* PracticeTexts */,
 				AFD89869387E971A84CC9922 /* ProgressionCriteria */,
+				6000770C653E7A87277987BD /* PyramidExercises */,
 			);
 			path = Content;
 			sourceTree = "<group>";
@@ -620,15 +696,19 @@
 				EA32E530E1641F627E7C5970 /* BlockFeedbackState.swift */,
 				D24253A3138E22C5ED601F03 /* CelebrationEffectView.swift */,
 				C3915AE540EBA11321FA76BB /* ConnectionLinesView.swift */,
+				322D29DD7BB1907EBD89A714 /* DiscardZoneView.swift */,
 				4373E47CEF1B184CF62920CB /* DraggableBlockView.swift */,
 				28E6F9B9D6818D8BCF742BCC /* DropZone.swift */,
 				5C05DDD40848A9E59E713026 /* DropZoneView.swift */,
 				5E067F208DB8387CEC7A738A /* GapPlaceholderView.swift */,
+				4CA7F0DA129D49EFFBBF4AEE /* HapticFeedbackManager.swift */,
 				9AC8B2C13C23B149624FD027 /* PyramidBlock.swift */,
 				147D1E1AF8B5697A25D1EFFB /* PyramidFeedbackOverlay.swift */,
+				0C98932E1C66B27BA28CA1E1 /* PyramidKeyboardShortcuts.swift */,
 				72D83F01BEC457D843FA46B2 /* PyramidTreeState.swift */,
 				B4AEE9C322510B2451BC0B6B /* TreeLayoutEngine.swift */,
 				5BCC3E8C4CBE011C33FC740B /* ValidationFeedbackModifier.swift */,
+				F04D28D3D25E27B90D61F453 /* ZoomablePyramidCanvas.swift */,
 			);
 			path = PyramidBuilder;
 			sourceTree = "<group>";
@@ -664,6 +744,19 @@
 			path = Intelligence;
 			sourceTree = "<group>";
 		};
+		6000770C653E7A87277987BD /* PyramidExercises */ = {
+			isa = PBXGroup;
+			children = (
+				DAE6A8B9A9002747D1DD9425 /* fix-this-mess-exercises.json */,
+				17A5179DE93BEAFE6F829A3F /* FixThisMessExercise.swift */,
+				DF7C54B8489C89FCA6ED3EDE /* FixThisMessExerciseLibrary.swift */,
+				8175192283ED8224716BB935 /* pyramid-exercises.json */,
+				EEFAA436BA86F6308DC9335A /* PyramidExercise.swift */,
+				6C783EF760D21412AAD9C2B5 /* PyramidExerciseLibrary.swift */,
+			);
+			path = PyramidExercises;
+			sourceTree = "<group>";
+		};
 		61CD158B63FA63545C909D3C /* VoiceDrill */ = {
 			isa = PBXGroup;
 			children = (
@@ -672,7 +765,9 @@
 				8309BF4EE774FABE588555F4 /* MicrophoneButton.swift */,
 				FF9D188FA8779E14011857FD /* ThinkingIndicatorView.swift */,
 				E4F296F432E8A069994E5167 /* TTSPlaybackService.swift */,
+				9ADB7696408FCD1220CF6CE5 /* TTSToggleButton.swift */,
 				DBF554DE2E568F5716D89DD7 /* VoiceElevatorPitchView.swift */,
+				77DAD2008EC8FEA09E753E5D /* VoiceFindThePointView.swift */,
 				61F66A4FE516B8A86073D9B3 /* VoiceInputView.swift */,
 				26FFAF667809AFED071F2163 /* VoiceInputViewModel.swift */,
 				F8565117528BB06983545B8A /* VoiceSayItClearlyView.swift */,
@@ -732,6 +827,8 @@
 				CA73D30DCB7C56BAA6867CC2 /* AnalyseMyTextSession.swift */,
 				10F6CAB4EBA45B17A293C4C0 /* AnthropicModel.swift */,
 				C28CC98EB4FCDC9137D15433 /* AnthropicService.swift */,
+				3156D3670B3AC3EE91BDD423 /* BuildThePyramidCoordinator.swift */,
+				96CDCE119B56BA8E0B338AF9 /* BuildThePyramidSession.swift */,
 				7457AD0D49EDBFFC9A164161 /* DecodeAndRebuildCoordinator.swift */,
 				1C1C17B6886769CDF1D032C0 /* DecodeAndRebuildSession.swift */,
 				76F67E39596D4AD4CCEAE6BB /* ElevatorPitchCoordinator.swift */,
@@ -740,6 +837,7 @@
 				D5FB097A1FAE84E286F0F1F6 /* FindThePointSession.swift */,
 				C0F94F29CC51A4E01478BE88 /* FixThisMessCoordinator.swift */,
 				CBC646A72B8AF0F24AD4708A /* FixThisMessSession.swift */,
+				13F7A3F7847EA1DF564E3C8E /* FixThisMessVisualCoordinator.swift */,
 				91ECF5F1EF7623373F5BBD2C /* NetworkErrorHandler.swift */,
 				1F909A7D8C8D301AFFA580B6 /* SayItClearlyCoordinator.swift */,
 				BB7D3646F6A2ED3962F6EC0C /* SayItClearlySession.swift */,
@@ -778,6 +876,7 @@
 				A553A59D04C7ABFA86CF117E /* BarbaraAvatarTests.swift */,
 				4A6B15AE1ED645EEDFCA7DF5 /* BarbaraVoiceProfileTests.swift */,
 				72E114135776783B6B39A5FC /* BreakModeProfileTests.swift */,
+				7324F8468E4DE52E9E5B114F /* BuildThePyramidTests.swift */,
 				40319D5211156AC1671570F5 /* ChatViewTests.swift */,
 				2ED4B98BAC3EA13F5C61CBCD /* ConnectionLinesTests.swift */,
 				F311FDA056466909DBBC103C /* DecodeAndRebuildTests.swift */,
@@ -787,6 +886,9 @@
 				2DF3448F79F9C75AEEF2A73E /* FindThePointSessionTests.swift */,
 				1C278322C149174D648ECF14 /* FirstLaunchSetupTests.swift */,
 				1023A980330BA11476479AC6 /* FixThisMessSessionTests.swift */,
+				7E9108B9D961EB9E8254EA37 /* FixThisMessVisualTests.swift */,
+				854A70E536D055C3D8D8667F /* HapticAnimationTests.swift */,
+				B237CADEB85F975D748385B3 /* iPadPyramidLayoutTests.swift */,
 				9A1C0B31006940A2DBFE5E41 /* LearnerProfileTests.swift */,
 				413063A3E8C728FA167973FC /* LevelTransitionTests.swift */,
 				2648E59B50498C1D83FD795F /* MacOSAdaptationTests.swift */,
@@ -797,6 +899,7 @@
 				98CBB6A6B6FD6628BB30BA6D /* ProfileUpdaterTests.swift */,
 				A3C3798349D47FE3497CC587 /* ProgressDashboardTests.swift */,
 				B70EF3120BD198913EAEE0A2 /* PyramidBlockTests.swift */,
+				793A8B950E0FD6822E2346F2 /* RedHerringTests.swift */,
 				C8D179C236AD14B5C8076627 /* ResponseParserTests.swift */,
 				2C9512DE8E01F6C1AB4E4B8C /* SayItClearlySessionTests.swift */,
 				E399297963E1A59A4C958BFA /* SeenTextsTests.swift */,
@@ -816,7 +919,10 @@
 				A1964D965458CCC6A3A747B0 /* TTSPlaybackServiceTests.swift */,
 				AC256E9126646B1262512067 /* ValidationFeedbackTests.swift */,
 				EF9A6BF1241D474DACAAE762 /* VoiceElevatorPitchTests.swift */,
+				8A17D6E2ACDC8F492B10A02E /* VoiceFindThePointTests.swift */,
+				E2B55123D70AEA12D645BFDD /* VoicePlatformAdaptationTests.swift */,
 				705DD7DFE2CA7A3BA37785EA /* VoiceSayItClearlyTests.swift */,
+				0E52A3B192714E4372A8B24A /* VoiceTextToggleTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -1007,12 +1113,14 @@
 			children = (
 				2910D8E206E77E72AE6E8631 /* .gitkeep */,
 				9386A4C1CF530878ECC12755 /* AnalyseMyTextView.swift */,
+				76026FDE2955161A78FADB69 /* BuildThePyramidView.swift */,
 				2D7F67899A791B97B42902B0 /* DebugLogView.swift */,
 				7B0CFE1578A9BD9153E4098D /* DecodeAndRebuildView.swift */,
 				CCC9887FA1B8FA6F1AF29DAE /* ElevatorPitchView.swift */,
 				B466AA033E6F289710EDCFC8 /* FindThePointView.swift */,
 				E493E1B347AC7D15C639949F /* FirstLaunchSetupView.swift */,
 				1A9E8EB9C1E2B0BA8B04848D /* FixThisMessView.swift */,
+				5E1B20E8DFB3372D627CEB28 /* FixThisMessVisualView.swift */,
 				B180A246925AD77C2C5D73C6 /* LevelUpCelebrationView.swift */,
 				1DD215422DC5781D0AFDAAEE /* OnboardingView.swift */,
 				1B08B6C7C928249161C6C0AC /* ParentSettingsView.swift */,
@@ -1200,6 +1308,8 @@
 				5E86220B69F94E1D80BE6E21 /* PracticeTextLibrary_en.json in Resources */,
 				496007D2A4A26B62F5B29D3D /* SayItRight.xcodeproj in Resources */,
 				7917EA24942281486B8ACB77 /* TopicBank.json in Resources */,
+				EBC0F4FD745B185D9413416D /* fix-this-mess-exercises.json in Resources */,
+				4AA8887DDA05E2D04B8FDDDD /* pyramid-exercises.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1214,6 +1324,8 @@
 				C7E44A72C5785F58432FD35D /* PracticeTextLibrary_en.json in Resources */,
 				BDF08178D405ECC24953BC24 /* SayItRight.xcodeproj in Resources */,
 				CD51EBAE3FC9894B5D3F4501 /* TopicBank.json in Resources */,
+				CE956B898080AFC0ADA1730A /* fix-this-mess-exercises.json in Resources */,
+				1617BEA120790071FB69172C /* pyramid-exercises.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1232,6 +1344,7 @@
 				232A2240F8CDCBF5093977DA /* BarbaraAvatarTests.swift in Sources */,
 				2DDE080F3029A0750773ED22 /* BarbaraVoiceProfileTests.swift in Sources */,
 				BFB0F3572A32CDAB2C8100FD /* BreakModeProfileTests.swift in Sources */,
+				F665752C28731342E3478BD4 /* BuildThePyramidTests.swift in Sources */,
 				FB4A6CAC2211C3CE1456B0C4 /* ChatViewTests.swift in Sources */,
 				691C23DCCF2C5FE4EB2B14CB /* ConnectionLinesTests.swift in Sources */,
 				2BA09208E878385E27A82A73 /* DecodeAndRebuildTests.swift in Sources */,
@@ -1241,6 +1354,8 @@
 				76A480936638CCB778908423 /* FindThePointSessionTests.swift in Sources */,
 				B9F552778A5BD6CEEFB7FC21 /* FirstLaunchSetupTests.swift in Sources */,
 				2F84726B57E3AFF495436EF3 /* FixThisMessSessionTests.swift in Sources */,
+				8A9859967A8F8FA32CEDFCA2 /* FixThisMessVisualTests.swift in Sources */,
+				C415840C4B796BB9EBE9AA5E /* HapticAnimationTests.swift in Sources */,
 				CB5CCD79737A6748BDABC401 /* LearnerProfileTests.swift in Sources */,
 				070DB0DAB08A4A6479129643 /* LevelTransitionTests.swift in Sources */,
 				C70E6AC153240CF2D0DBCAB9 /* MECEValidationEngineTests.swift in Sources */,
@@ -1251,6 +1366,7 @@
 				F65C548B9D183E16669313BF /* ProfileUpdaterTests.swift in Sources */,
 				404C385E99618BE1F1977825 /* ProgressDashboardTests.swift in Sources */,
 				C89D58F492C55065E008013A /* PyramidBlockTests.swift in Sources */,
+				183B504D74DDAD2D59703D77 /* RedHerringTests.swift in Sources */,
 				812AC213EB49FEC705555E09 /* ResponseParserTests.swift in Sources */,
 				1851700C174060BC3AC3208C /* SayItClearlySessionTests.swift in Sources */,
 				EC8D5C128F51D0CCF602CE9D /* SeenTextsTests.swift in Sources */,
@@ -1270,7 +1386,11 @@
 				112C860A4101D395FAA0F637 /* TreeLayoutEngineTests.swift in Sources */,
 				21DAB04C88F950A1145C76C4 /* ValidationFeedbackTests.swift in Sources */,
 				96D63E6451B239809823E6EA /* VoiceElevatorPitchTests.swift in Sources */,
+				921B826F139020FE3B614574 /* VoiceFindThePointTests.swift in Sources */,
+				B558692A669A4B26EA03F5E1 /* VoicePlatformAdaptationTests.swift in Sources */,
 				8B42E4659938F6B197D2BE6D /* VoiceSayItClearlyTests.swift in Sources */,
+				276888BF58A22A31763A50CD /* VoiceTextToggleTests.swift in Sources */,
+				2CC52BCAEFD6CF1ACB67DFFF /* iPadPyramidLayoutTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1286,6 +1406,7 @@
 				DE38095862958923B2416C42 /* BarbaraAvatarTests.swift in Sources */,
 				C6707E67B7475B58554F2F92 /* BarbaraVoiceProfileTests.swift in Sources */,
 				A04684C5FA38C05AE7ADD9AB /* BreakModeProfileTests.swift in Sources */,
+				64A49F30B3A3F3CFE488E79B /* BuildThePyramidTests.swift in Sources */,
 				56E59D06B02418F6D1057A03 /* ChatViewTests.swift in Sources */,
 				B6403B3CA71AF12E11A38232 /* ConnectionLinesTests.swift in Sources */,
 				C6A4492196A222A1E25F65CB /* DecodeAndRebuildTests.swift in Sources */,
@@ -1295,6 +1416,8 @@
 				16755F914DD22F021F0C1E04 /* FindThePointSessionTests.swift in Sources */,
 				D6CD1F94E1C2E57A0888230E /* FirstLaunchSetupTests.swift in Sources */,
 				C04A2190D8A20EA7838C2282 /* FixThisMessSessionTests.swift in Sources */,
+				D7E47290ACA62619DE4AA077 /* FixThisMessVisualTests.swift in Sources */,
+				AB8E0712827B692367EFA3F7 /* HapticAnimationTests.swift in Sources */,
 				F1F057BADCA87A05AF322BC6 /* LearnerProfileTests.swift in Sources */,
 				3A4C9F15774CAF17D210FD6F /* LevelTransitionTests.swift in Sources */,
 				A6AC757407E2F30AB816970C /* MECEValidationEngineTests.swift in Sources */,
@@ -1305,6 +1428,7 @@
 				41A85E6A507F013D8D83DDA7 /* ProfileUpdaterTests.swift in Sources */,
 				01725E7CBADF98137BDC26AA /* ProgressDashboardTests.swift in Sources */,
 				C37CC4D67FE88C69E19D6FF4 /* PyramidBlockTests.swift in Sources */,
+				66E23C17FC6D5ECFD14F6DAE /* RedHerringTests.swift in Sources */,
 				E2E771E2E6E4B969403D183A /* ResponseParserTests.swift in Sources */,
 				D18F59F6E50DE4B10D1B6929 /* SayItClearlySessionTests.swift in Sources */,
 				3C3D496429C02F2A19997126 /* SeenTextsTests.swift in Sources */,
@@ -1324,7 +1448,11 @@
 				15C2944B9C7F642A1F1CE5E0 /* TreeLayoutEngineTests.swift in Sources */,
 				BBB3CACEC5AE458782FFD0D0 /* ValidationFeedbackTests.swift in Sources */,
 				DF0BFD0DC5FBFC8BC038693D /* VoiceElevatorPitchTests.swift in Sources */,
+				845F69076C945181FAD59B15 /* VoiceFindThePointTests.swift in Sources */,
+				F0CC621C5F889F0283C990CD /* VoicePlatformAdaptationTests.swift in Sources */,
 				322C09D5891901217A964082 /* VoiceSayItClearlyTests.swift in Sources */,
+				B6DF5C6B33D9BE31C43483EA /* VoiceTextToggleTests.swift in Sources */,
+				0D8BCE6EC8CFA4639CB8F081 /* iPadPyramidLayoutTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1348,6 +1476,9 @@
 				C15605E88266D05B8736AB18 /* BarbaraMood.swift in Sources */,
 				7A4E20F4593829C0C31A4AEC /* BarbaraVoiceProfile.swift in Sources */,
 				C00B6CA5143A309F86D4D506 /* BlockFeedbackState.swift in Sources */,
+				12096C0E28E2320DE65946E1 /* BuildThePyramidCoordinator.swift in Sources */,
+				AA09CFCB0A0FFE69AB641706 /* BuildThePyramidSession.swift in Sources */,
+				332FF8BDFA4A13A575E7A187 /* BuildThePyramidView.swift in Sources */,
 				68324B657FD362B1C2BDBE57 /* CelebrationEffectView.swift in Sources */,
 				CB11CF599D010F75FA77C233 /* ChatMessage.swift in Sources */,
 				042513332D5A484B14A5DE76 /* ChatView.swift in Sources */,
@@ -1362,6 +1493,7 @@
 				5A4BFD9F1E7358B998E599E9 /* DecodeAndRebuildSession.swift in Sources */,
 				69AE8809D5B4FD31A2EFC38F /* DecodeAndRebuildView.swift in Sources */,
 				A9C54D9E4FC609C3A85D553B /* DimensionBarChartView.swift in Sources */,
+				A1C987C11E9C50B647D8B005 /* DiscardZoneView.swift in Sources */,
 				901D104DC385EA8F6044D909 /* DraggableBlockView.swift in Sources */,
 				E051DAB7CE1CB6C9AE6C2D79 /* DropZone.swift in Sources */,
 				8BED3E20F4C909B14BE520AA /* DropZoneView.swift in Sources */,
@@ -1376,9 +1508,14 @@
 				5A025527375F657258C7BFD6 /* FindThePointView.swift in Sources */,
 				66DD685F81C1CDA61F82D0A3 /* FirstLaunchSetupView.swift in Sources */,
 				4A474E230C0D5315C1A62ABC /* FixThisMessCoordinator.swift in Sources */,
+				E97F77D39C4A13969FAF5DD9 /* FixThisMessExercise.swift in Sources */,
+				271B69A42DF1CE011056D109 /* FixThisMessExerciseLibrary.swift in Sources */,
 				CC905B20EEE1017CBFCB05FF /* FixThisMessSession.swift in Sources */,
 				16AEE1E1B60B3EF1CBACC319 /* FixThisMessView.swift in Sources */,
+				61977A1FD3316A0966C942F8 /* FixThisMessVisualCoordinator.swift in Sources */,
+				5EA73D157455010E5D04CB2B /* FixThisMessVisualView.swift in Sources */,
 				61D91FAFDD31B3B2654460EC /* GapPlaceholderView.swift in Sources */,
+				8236A6035390656DBE37A096 /* HapticFeedbackManager.swift in Sources */,
 				109845A5BD28BDC5307C4A51 /* KeychainService.swift in Sources */,
 				A9B7342D214CE45653F5BAB3 /* LearnerAvatar.swift in Sources */,
 				7A274863874522A22D93C22B /* LearnerProfile.swift in Sources */,
@@ -1405,7 +1542,10 @@
 				B7C28920B91F304603968367 /* ProgressDashboardView.swift in Sources */,
 				0D91C125ACD8254D27757AFF /* ProgressionCriteria.swift in Sources */,
 				779DEBCF437A97E109B3E8BC /* PyramidBlock.swift in Sources */,
+				562FAF04B0C6756D1406823A /* PyramidExercise.swift in Sources */,
+				76A260081D4A503681C080E6 /* PyramidExerciseLibrary.swift in Sources */,
 				531F7C8788BD0D599A7E8D04 /* PyramidFeedbackOverlay.swift in Sources */,
+				A0961872ED42AE2AD1EC05B5 /* PyramidKeyboardShortcuts.swift in Sources */,
 				CE49D1EC9F14EE85575FA236 /* PyramidTreeState.swift in Sources */,
 				033B5DE1A4166D33D74334B9 /* ResponseParser.swift in Sources */,
 				D895EB4DE625E96EF1AC8F4F /* RevisionDiffView.swift in Sources */,
@@ -1434,15 +1574,18 @@
 				9C781F5BC09396E0F44BBFCB /* StructuralEvaluator.swift in Sources */,
 				BFEC1C8AE1C77FC5D94AB5B6 /* SystemPromptAssembler.swift in Sources */,
 				0EB7A9CA948A196FA81EBD88 /* TTSPlaybackService.swift in Sources */,
+				F179332F2979B527404C9CDC /* TTSToggleButton.swift in Sources */,
 				5DBDDDE558A97B0071AA74AE /* TextDifficultyCalibrator.swift in Sources */,
 				60E3C43BE15EA0EBE21C942A /* ThinkingIndicatorView.swift in Sources */,
 				465D99D2F607EE3A29C71228 /* Topic.swift in Sources */,
 				64A04AB12BD9FD132B0D9F8A /* TreeLayoutEngine.swift in Sources */,
 				AE5F4FDA4052322F82140791 /* ValidationFeedbackModifier.swift in Sources */,
 				AE22A38235CA0C0C911A69EF /* VoiceElevatorPitchView.swift in Sources */,
+				B0C445835A3A5011D6FB5A9C /* VoiceFindThePointView.swift in Sources */,
 				00659B8342F2BACC70A60BFB /* VoiceInputView.swift in Sources */,
 				DE1CC7ECEADF4111754C15B0 /* VoiceInputViewModel.swift in Sources */,
 				6906E515B0FCA779B01818B5 /* VoiceSayItClearlyView.swift in Sources */,
+				745051943B43B27A1E5C8726 /* ZoomablePyramidCanvas.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1481,6 +1624,9 @@
 				7043BFA9D8C90767E45A2FD5 /* BarbaraMood.swift in Sources */,
 				C372EDF597BB3E75358D1121 /* BarbaraVoiceProfile.swift in Sources */,
 				CDF1C5AF3C7F3606450C0F8A /* BlockFeedbackState.swift in Sources */,
+				696E6FAE8B98220F58290FBA /* BuildThePyramidCoordinator.swift in Sources */,
+				E41D00F52DEDE6F675777555 /* BuildThePyramidSession.swift in Sources */,
+				9CAED6F1658DB9BDA1BDC8BB /* BuildThePyramidView.swift in Sources */,
 				CAC1EA1E8FF5890976DC2501 /* CelebrationEffectView.swift in Sources */,
 				6C681A520B587FCEBFAE81B9 /* ChatMessage.swift in Sources */,
 				26F70AF1E1BDF322EBFDC2B8 /* ChatView.swift in Sources */,
@@ -1495,6 +1641,7 @@
 				A0BC2607510CD45A0EB77F83 /* DecodeAndRebuildSession.swift in Sources */,
 				D6E46973E64FECEFF0A906BD /* DecodeAndRebuildView.swift in Sources */,
 				46A6335BD38DF3D1EEC54EE9 /* DimensionBarChartView.swift in Sources */,
+				DE00EC52070DADD840C639DA /* DiscardZoneView.swift in Sources */,
 				F9F35AAB16261DE9156AFA81 /* DraggableBlockView.swift in Sources */,
 				0F0F6EFEABD224BE50436E3C /* DropZone.swift in Sources */,
 				B4128092EF246AE96A5BF1E0 /* DropZoneView.swift in Sources */,
@@ -1509,9 +1656,14 @@
 				00BD16B95665CCD3B7B58AAE /* FindThePointView.swift in Sources */,
 				2F52829C24DE0D1E7D980EB2 /* FirstLaunchSetupView.swift in Sources */,
 				E321C3B2AF55A2695E19A119 /* FixThisMessCoordinator.swift in Sources */,
+				DA23A8FB8AF9AE1560E396D6 /* FixThisMessExercise.swift in Sources */,
+				04D246575340FDB8D0A466AC /* FixThisMessExerciseLibrary.swift in Sources */,
 				77F5CBF575FBEBD80D594350 /* FixThisMessSession.swift in Sources */,
 				63252351666063E76D3075C4 /* FixThisMessView.swift in Sources */,
+				8E704B681025F187D88B0036 /* FixThisMessVisualCoordinator.swift in Sources */,
+				2AF2DE11A7FF74C304397F6E /* FixThisMessVisualView.swift in Sources */,
 				64C0FEE13C0BFAE2B0D6FE37 /* GapPlaceholderView.swift in Sources */,
+				AC885E581926E54467460CCE /* HapticFeedbackManager.swift in Sources */,
 				4754932F6E5805C72ADB45E2 /* KeychainService.swift in Sources */,
 				8D0594B48254C2F95AB7F9F3 /* LearnerAvatar.swift in Sources */,
 				E82E1F599E93664105775B47 /* LearnerProfile.swift in Sources */,
@@ -1538,7 +1690,10 @@
 				E6C0CE28BD49508CA40E8454 /* ProgressDashboardView.swift in Sources */,
 				90D8CBC321E62326F073C06E /* ProgressionCriteria.swift in Sources */,
 				FCFA826700749EA41FCB4FDC /* PyramidBlock.swift in Sources */,
+				E1CEDBC152C75F388292530D /* PyramidExercise.swift in Sources */,
+				7DC5C94227802D3A92CF5500 /* PyramidExerciseLibrary.swift in Sources */,
 				C7AD8CE9CD5E3BC3C1568459 /* PyramidFeedbackOverlay.swift in Sources */,
+				305AC34522F185D22A07231D /* PyramidKeyboardShortcuts.swift in Sources */,
 				FC483FFC26C8467FF1807413 /* PyramidTreeState.swift in Sources */,
 				5F51449B08403989803DD749 /* ResponseParser.swift in Sources */,
 				8F2A3431111B3072FE14DE79 /* RevisionDiffView.swift in Sources */,
@@ -1567,15 +1722,18 @@
 				AD9D198E44358F88EF30E30B /* StructuralEvaluator.swift in Sources */,
 				3663C29466AF276F1C5289C7 /* SystemPromptAssembler.swift in Sources */,
 				8E8D202555A73B2756F2EBB0 /* TTSPlaybackService.swift in Sources */,
+				E6028FF9CD99BFB2D71A1EE0 /* TTSToggleButton.swift in Sources */,
 				D694E416EBC8627305D26DF2 /* TextDifficultyCalibrator.swift in Sources */,
 				180A80A7954F7CD067B7C8DB /* ThinkingIndicatorView.swift in Sources */,
 				E1C178382A2262BB8A5C7E72 /* Topic.swift in Sources */,
 				4DBA3C9AB5E598841BC408FA /* TreeLayoutEngine.swift in Sources */,
 				6D1844C5C88EF8B196CEE8A1 /* ValidationFeedbackModifier.swift in Sources */,
 				AA84EBC9B2E3A2AEE4D24AEE /* VoiceElevatorPitchView.swift in Sources */,
+				85A21C89854A7C68754D1370 /* VoiceFindThePointView.swift in Sources */,
 				7B05C7916E626A00EABE4E1E /* VoiceInputView.swift in Sources */,
 				81160A48F23B0693F8B6BE38 /* VoiceInputViewModel.swift in Sources */,
 				4AEE63E3C80544718B5058DA /* VoiceSayItClearlyView.swift in Sources */,
+				2F436DDC4A51CD9C42561E74 /* ZoomablePyramidCanvas.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/app/SayItRight/Tests/HapticAnimationTests.swift
+++ b/app/SayItRight/Tests/HapticAnimationTests.swift
@@ -1,0 +1,64 @@
+import CoreGraphics
+import Testing
+@testable import SayItRight
+
+@Suite("Haptic Feedback and Animation")
+struct HapticAnimationTests {
+
+    @Test("PyramidHaptic has all expected cases")
+    func hapticCases() {
+        let cases: [PyramidHaptic] = [
+            .blockPickup,
+            .validDrop,
+            .invalidDrop,
+            .pyramidComplete,
+        ]
+        #expect(cases.count == 4)
+    }
+
+    @Test("shouldReduceMotion returns a Bool")
+    func reduceMotionReturnsBool() {
+        // Just verify the function compiles and returns a Bool.
+        let result: Bool = shouldReduceMotion
+        #expect(result == true || result == false)
+    }
+
+    @Test("BlockFeedbackState has accessibility labels")
+    func feedbackStateAccessibility() {
+        #expect(!BlockFeedbackState.correct.accessibilityLabel.isEmpty)
+        #expect(!BlockFeedbackState.misplaced.accessibilityLabel.isEmpty)
+        #expect(!BlockFeedbackState.meceOverlap.accessibilityLabel.isEmpty)
+        #expect(BlockFeedbackState.none.accessibilityLabel.isEmpty)
+    }
+
+    @Test("FeedbackPalette defines all required colors")
+    func feedbackPaletteExists() {
+        // Verify all palette colors are accessible (compile-time + runtime).
+        let _ = FeedbackPalette.correct
+        let _ = FeedbackPalette.misplaced
+        let _ = FeedbackPalette.overlap
+        let _ = FeedbackPalette.gap
+        let _ = FeedbackPalette.celebration
+        #expect(true)
+    }
+
+    @Test("ConnectionLineStyle has normal and highlighted variants")
+    func connectionLineStyles() {
+        #expect(ConnectionLineStyle.normal.lineWidth > 0)
+        #expect(ConnectionLineStyle.highlighted.lineWidth > ConnectionLineStyle.normal.lineWidth)
+    }
+
+    @Test("PyramidConnection generates stable ID from parent and child")
+    func connectionID() {
+        let connection = PyramidConnection(parentID: "root", childID: "child-a")
+        #expect(connection.id == "root->child-a")
+    }
+
+    @Test("ConnectionLinesView.bezierPath creates a valid path")
+    func bezierPathCreation() {
+        let start = CGPoint(x: 100, y: 50)
+        let end = CGPoint(x: 200, y: 150)
+        let path = ConnectionLinesView.bezierPath(from: start, to: end)
+        #expect(!path.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds centralized `PyramidHaptic` enum with iOS `sensoryFeedback()` for block pickup (light), valid drop (medium), invalid drop (error), and pyramid complete (success)
- Connection lines now animate in with `trim(from:to:)` grow effect instead of simple fade
- All animations respect `UIAccessibility.isReduceMotionEnabled` / `NSWorkspace.accessibilityDisplayShouldReduceMotion` — simplified or disabled when reduce motion is on
- Shake, pulse, and celebration effects are conditionally applied based on accessibility settings

## Test plan
- [x] Build succeeds on macOS
- [x] 7 new tests pass (HapticAnimationTests suite)
- [ ] Manual: verify haptics on iPad (pickup, drop, check, complete)
- [ ] Manual: enable Reduce Motion in Settings, verify animations are simplified
- [ ] Manual: verify connection lines grow smoothly when blocks are placed

Closes #75

Generated with [Claude Code](https://claude.com/claude-code)